### PR TITLE
Make the library panels scroll

### DIFF
--- a/components/chrome/library-panel.tsx
+++ b/components/chrome/library-panel.tsx
@@ -90,8 +90,10 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
         />
       </div>
 
-      {/* min-h-0 — without it the flex item won't shrink below its content. */}
-      <ScrollArea className="min-h-0 flex-1 overscroll-contain">
+      {/* min-h-0 — without it the flex item won't shrink below its content.
+          type="scroll" flashes the bar while scrolling, so a list this long
+          doesn't look like it ends at the fold. */}
+      <ScrollArea type="scroll" className="min-h-0 flex-1 overscroll-contain">
         <div className="p-2.5 pt-1">
           {sections.map((section) => (
             <div key={section.group} className="mb-2">

--- a/components/chrome/library-panel.tsx
+++ b/components/chrome/library-panel.tsx
@@ -74,7 +74,7 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
       className="absolute top-1/2 left-16 z-30 flex max-h-[82vh] w-[300px] -translate-y-1/2 flex-col overflow-hidden rounded-xl border bg-background shadow-lg"
       onPointerDown={(e) => e.stopPropagation()}
     >
-      <div className="relative border-b p-2.5">
+      <div className="relative shrink-0 border-b p-2.5">
         <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-5 size-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
           ref={inputRef}
@@ -90,7 +90,8 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
         />
       </div>
 
-      <ScrollArea className="flex-1">
+      {/* min-h-0 — without it the flex item won't shrink below its content. */}
+      <ScrollArea className="min-h-0 flex-1 overscroll-contain">
         <div className="p-2.5 pt-1">
           {sections.map((section) => (
             <div key={section.group} className="mb-2">
@@ -117,7 +118,7 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
         </div>
       </ScrollArea>
 
-      <div className="border-t px-3 py-2 text-xs text-muted-foreground">
+      <div className="shrink-0 border-t px-3 py-2 text-xs text-muted-foreground">
         {placing ? "now click the canvas to drop it" : `${total} to choose from — ⌘K searches everything`}
       </div>
     </div>

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -10,15 +10,20 @@ function ScrollArea({
   children,
   ...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  // The viewport stretches as a flex item rather than the stock `size-full`:
+  // a percentage height resolves to nothing when the root is itself a flex
+  // child, so the viewport grew to its content and the panel clipped it
+  // instead of scrolling. Stretching works whether the root's height is
+  // capped or content-sized.
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative flex flex-col", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        className="w-full min-h-0 flex-auto rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
The **components** and **blocks** panels clipped their lists instead of scrolling. Two separate things were wrong, and both had to be fixed:

1. **`library-panel.tsx`** — the `ScrollArea` was a flex child with `flex-1` but the default `min-height: auto`, so it never shrank below its content (~5300px) and the panel's `overflow-hidden` simply cut the list off. Added `min-h-0`, plus `shrink-0` on the search header and footer so they stay pinned.

2. **`ui/scroll-area.tsx`** — Radix's viewport uses `size-full`, but a percentage height resolves to nothing when the root is itself a flex child. So even with the root constrained to 656px, the viewport stayed content-height and still didn't scroll. The viewport now stretches as a flex item (`flex-auto min-h-0` inside a `flex flex-col` root), which works whether the root's height is capped or content-sized.

The second one was a latent bug for every `ScrollArea` in the app — the inspector would have hit it too once its content got tall enough.

## Verification

Ran the app and drove it in the browser:

- Components panel (83 items) scrolls with the wheel; search box and "83 to choose from" footer stay pinned.
- Blocks panel (67 items) scrolls the same way.
- Inspector with a Banner selected renders at its natural height, controls and Break apart / Delete buttons unchanged.
- `tsc --noEmit` clean, `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)