### PR TITLE
Brighten Internet blue: lighter paper, electric ink

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,13 +52,13 @@
 /* squig canvas theme — overwritten at runtime by lib/theme.ts.
    These defaults are Internet blue, so first paint matches. */
 :root {
-  --sq-bg: #edeae0;
-  --sq-paper: #faf8f2;
-  --sq-ink: #2338d4;
-  --sq-muted: #7a88e4;
-  --sq-faint: #bfc8f1;
-  --sq-grid: #d5cfc0;
-  --sq-select: #e8622f;
+  --sq-bg: #f6f3ea;
+  --sq-paper: #fffdf7;
+  --sq-ink: #2438ff;
+  --sq-muted: #6e7dff;
+  --sq-faint: #bfc6ff;
+  --sq-grid: #dfd9c7;
+  --sq-select: #ff5a24;
   --sq-font: var(--font-sketch);
 }
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -29,13 +29,13 @@ export interface Palette {
 export const THEMES = {
   "internet-blue": {
     label: "Internet blue",
-    bg: "#EDEAE0",
-    paper: "#FAF8F2",
-    ink: "#2338D4",
-    muted: "#7A88E4",
-    faint: "#BFC8F1",
-    grid: "#D5CFC0",
-    select: "#E8622F",
+    bg: "#F6F3EA",
+    paper: "#FFFDF7",
+    ink: "#2438FF",
+    muted: "#6E7DFF",
+    faint: "#BFC6FF",
+    grid: "#DFD9C7",
+    select: "#FF5A24",
   },
   "riso-red": {
     label: "Riso red",
@@ -45,7 +45,7 @@ export const THEMES = {
     muted: "#EE7B72",
     faint: "#F7B9B3",
     grid: "#DDD5C6",
-    select: "#2338D4",
+    select: "#2438FF",
   },
   "terminal-green": {
     label: "Terminal green",
@@ -75,7 +75,7 @@ export const THEMES = {
     muted: "#D69B4E",
     faint: "#EDCC96",
     grid: "#E2D8BE",
-    select: "#2338D4",
+    select: "#2438FF",
   },
   graphite: {
     label: "Graphite",


### PR DESCRIPTION
The default theme read too heavy — the background was a mid warm grey rather than paper, and the blue was a navy that lost the riso "one saturated pass" feel.

**Paper** `#EDEAE0` → `#F6F3EA`, surfaces `#FAF8F2` → `#FFFDF7` so floating panels occlude the canvas instead of blending into it. Grid lifts to match, preserving dot contrast.

**Ink** `#2338D4` → `#2438FF` — full-chroma electric blue, the hyperlink blue the theme is named after. Muted and faint follow it up the same hue. Selection accent brightens `#E8622F` → `#FF5A24` so it still cuts against the louder ink.

Riso red and Marigold use blue as their selection accent, so they take the new value too.

## Checks
- Contrast holds: muted-on-paper improves ~3.1:1 → ~3.4:1; ink on the faint button fill stays ~4.1:1.
- `pnpm lint` clean, `pnpm build` clean.
- Verified visually in the browser on `/` and `/kitchen-sink` — all 150 defs render, canvas dot grid still reads, selection handles still cut against the ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)