### PR TITLE
Make the scrollbar thin and floating

### DIFF
--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -44,14 +44,16 @@ function ScrollBar({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+        // Thin and floating — it overlays the content rather than taking a
+        // lane of its own, and only shows up while you're actually scrolling.
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-1.5 data-horizontal:flex-col data-horizontal:mb-1 data-vertical:h-full data-vertical:w-1.5 data-vertical:mr-1",
         className
       )}
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="relative flex-1 rounded-full bg-border"
+        className="relative flex-1 rounded-full bg-foreground/20"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )


### PR DESCRIPTION
Follow-up to #1. The scrollbar it added was Radix/shadcn's stock 10px track, which reads as a lane of chrome next to the list.

- Track halved to 6px and inset from the panel edge, so it floats over the content instead of sitting beside it.
- Thumb dropped to a low-contrast `bg-foreground/20`.
- It still only appears while you're actually scrolling (`type="scroll"` from #1), then fades.

Verified in the browser: the bar fades in during a wheel scroll over the components panel, sits inside the panel's right edge, and doesn't shift the grid. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)