### PR TITLE
Float the file name at the top center, hidden while the mouse moves

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { LeftRail } from "@/components/chrome/left-rail"
 import { LibraryPanel } from "@/components/chrome/library-panel"
 import { Inspector } from "@/components/chrome/inspector"
 import { TopCorner, ZoomPill, CommandHint } from "@/components/chrome/top-corner"
+import { FileName } from "@/components/chrome/file-name"
 import { CommandPalette } from "@/components/chrome/command-palette"
 import { CanvasContextMenu } from "@/components/chrome/context-menu"
 
@@ -34,6 +35,7 @@ export default function Home() {
       <SketchDefs />
       <Canvas />
       <TopCorner />
+      <FileName />
       <LeftRail />
       <LibraryPanel />
       <Inspector />

--- a/components/chrome/file-name.tsx
+++ b/components/chrome/file-name.tsx
@@ -18,13 +18,23 @@ export function FileName() {
   const st = useSquig.getState
   const [resting, setResting] = useState(true)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // mirrors `resting` so a drag's worth of moves doesn't churn React state
+  const restingRef = useRef(true)
 
   // Hide on any pointer movement, reveal after the pointer has been still.
   useEffect(() => {
-    const onMove = () => {
+    const hide = () => {
+      restingRef.current = false
       setResting(false)
+    }
+    const show = () => {
+      restingRef.current = true
+      setResting(true)
+    }
+    const onMove = () => {
+      if (restingRef.current) hide()
       if (timer.current) clearTimeout(timer.current)
-      timer.current = setTimeout(() => setResting(true), REST_MS)
+      timer.current = setTimeout(show, REST_MS)
     }
     window.addEventListener("pointermove", onMove, { passive: true })
     return () => {
@@ -91,6 +101,7 @@ function NameInput({ initial }: { initial: string }) {
       </span>
       <input
         ref={input}
+        aria-label="file name"
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         // Tabbing away commits; the whole window losing focus should not —

--- a/components/chrome/file-name.tsx
+++ b/components/chrome/file-name.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// The file name floats at the top center of the canvas. It ducks out of the
+// way while the pointer is moving so it never sits between the user and what
+// they're drawing, and drifts back once the hand comes to rest.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useRef, useState } from "react"
+import { useSquig } from "@/lib/store"
+
+/** how long the pointer has to sit still before the name comes back */
+const REST_MS = 550
+
+export function FileName() {
+  const fileName = useSquig((s) => s.fileName)
+  const renaming = useSquig((s) => s.renamingFile)
+  const st = useSquig.getState
+  const [resting, setResting] = useState(true)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Hide on any pointer movement, reveal after the pointer has been still.
+  useEffect(() => {
+    const onMove = () => {
+      setResting(false)
+      if (timer.current) clearTimeout(timer.current)
+      timer.current = setTimeout(() => setResting(true), REST_MS)
+    }
+    window.addEventListener("pointermove", onMove, { passive: true })
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [])
+
+  const shown = resting || renaming
+
+  return (
+    <div
+      className="pointer-events-none absolute top-4 left-1/2 z-30 flex -translate-x-1/2 justify-center transition-opacity"
+      // out of the way quickly, back in gently
+      style={{ opacity: shown ? 1 : 0, transitionDuration: shown ? "260ms" : "110ms" }}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {renaming ? (
+        <NameInput initial={fileName} />
+      ) : (
+        <button
+          type="button"
+          className={`max-w-[60vw] truncate rounded-lg px-2.5 py-1 text-center text-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground ${shown ? "pointer-events-auto" : ""}`}
+          onClick={() => st().setRenamingFile(true)}
+          title="rename"
+        >
+          {fileName}
+        </button>
+      )}
+    </div>
+  )
+}
+
+/** Mounted only while renaming, so the draft starts from the current name. */
+function NameInput({ initial }: { initial: string }) {
+  const st = useSquig.getState
+  const [draft, setDraft] = useState(initial)
+  const input = useRef<HTMLInputElement>(null)
+
+  // The file menu may still be handing focus back as we mount, which beats
+  // React's autoFocus — claim it once that settles.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      input.current?.focus()
+      input.current?.select()
+    }, 60)
+    return () => clearTimeout(id)
+  }, [])
+
+  const commit = () => {
+    st().setFileName(draft.trim() || "untitled scribbles")
+    st().setRenamingFile(false)
+  }
+
+  return (
+    // Grid overlay: an invisible copy of the text sizes the cell, so the input
+    // grows with the name and stays centered on the same axis as the label.
+    <span className="pointer-events-auto inline-grid items-center">
+      <span
+        aria-hidden
+        className="invisible col-start-1 row-start-1 min-w-32 max-w-[60vw] px-2.5 py-1 text-center text-sm whitespace-pre"
+      >
+        {draft || " "}
+      </span>
+      <input
+        ref={input}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        // Tabbing away commits; the whole window losing focus should not —
+        // the rename is still there when the user comes back.
+        onBlur={() => {
+          if (document.hasFocus()) commit()
+        }}
+        onKeyDown={(e) => {
+          e.stopPropagation()
+          if (e.key === "Enter") commit()
+          if (e.key === "Escape") st().setRenamingFile(false)
+        }}
+        className="col-start-1 row-start-1 w-full rounded-lg border bg-background px-2.5 py-1 text-center text-sm shadow-sm outline-none"
+      />
+    </span>
+  )
+}

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -5,7 +5,7 @@
 // inline-editable. No toolbar chrome beyond that, on purpose.
 // ---------------------------------------------------------------------------
 
-import { useState } from "react"
+import { useRef } from "react"
 import { useSquig } from "@/lib/store"
 import { exportDoc, importDoc } from "@/lib/file-io"
 import { CaretDownIcon } from "@phosphor-icons/react"
@@ -34,22 +34,17 @@ function Swatch({ name }: { name: ThemeName }) {
 }
 
 export function TopCorner() {
-  const fileName = useSquig((s) => s.fileName)
   const contextRow = useSquig((s) => s.contextRow)
   const theme = useSquig((s) => s.theme)
   const font = useSquig((s) => s.font)
   const st = useSquig.getState
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState(fileName)
-
-  const commit = () => {
-    st().setFileName(draft.trim() || "untitled scribbles")
-    setEditing(false)
-  }
+  // Rename hands focus to the floating name field, so the menu must not yank
+  // focus back to its trigger on the way out.
+  const keepFocus = useRef(false)
 
   return (
     <div
-      className="absolute top-4 left-4 z-30 flex items-center gap-1 rounded-xl border bg-background py-1 pr-3 pl-1.5 shadow-md"
+      className="absolute top-4 left-4 z-30 flex items-center gap-1 rounded-xl border bg-background p-1 shadow-md"
       onPointerDown={(e) => e.stopPropagation()}
     >
       <DropdownMenu>
@@ -68,7 +63,16 @@ export function TopCorner() {
             <CaretDownIcon className="size-3 text-muted-foreground" weight="bold" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuContent
+          align="start"
+          className="w-56"
+          onCloseAutoFocus={(e) => {
+            if (keepFocus.current) {
+              keepFocus.current = false
+              e.preventDefault()
+            }
+          }}
+        >
           <DropdownMenuItem onSelect={() => st().newFile()}>New file</DropdownMenuItem>
           <DropdownMenuItem onSelect={importDoc}>Open…</DropdownMenuItem>
           <DropdownMenuItem onSelect={exportDoc}>
@@ -78,8 +82,8 @@ export function TopCorner() {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onSelect={() => {
-              setDraft(st().fileName)
-              setEditing(true)
+              keepFocus.current = true
+              st().setRenamingFile(true)
             }}
           >
             Rename
@@ -133,35 +137,6 @@ export function TopCorner() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <span className="h-4 w-px bg-border" />
-
-      {editing ? (
-        <input
-          autoFocus
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
-          onKeyDown={(e) => {
-            e.stopPropagation()
-            if (e.key === "Enter") commit()
-            if (e.key === "Escape") setEditing(false)
-          }}
-          className="ml-1 w-44 rounded bg-transparent px-1 text-sm outline-none"
-        />
-      ) : (
-        <button
-          type="button"
-          className="ml-1 max-w-52 truncate rounded px-1 text-sm text-muted-foreground hover:text-foreground"
-          onClick={() => {
-            setDraft(fileName)
-            setEditing(true)
-          }}
-          title="rename"
-        >
-          {fileName}
-        </button>
-      )}
     </div>
   )
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -43,6 +43,8 @@ interface SquigState {
   hydrated: boolean
   commandOpen: boolean
   contextMenu: ContextMenuState | null
+  /** the floating file name is in its editable state */
+  renamingFile: boolean
 
   past: DocSnapshot[]
   future: DocSnapshot[]
@@ -60,6 +62,7 @@ interface SquigState {
   setSelection: (ids: string[]) => void
   setCommandOpen: (open: boolean) => void
   setContextMenu: (m: ContextMenuState | null) => void
+  setRenamingFile: (on: boolean) => void
 
   /** snapshot current doc onto the undo stack (call once at gesture start) */
   checkpoint: () => void
@@ -122,6 +125,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   hydrated: false,
   commandOpen: false,
   contextMenu: null,
+  renamingFile: false,
   past: [],
   future: [],
 
@@ -152,6 +156,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   setSelection: (ids) => set({ selection: ids }),
   setCommandOpen: (open) => set({ commandOpen: open, contextMenu: null, panel: open ? null : get().panel }),
   setContextMenu: (m) => set({ contextMenu: m }),
+  setRenamingFile: (on) => set({ renamingFile: on }),
 
   checkpoint: () => {
     set((s) => ({ past: [...s.past.slice(-MAX_HISTORY + 1), snapshot(s)], future: [] }))
@@ -370,6 +375,7 @@ export const useSquig = create<SquigState>((set, get) => ({
       order: [],
       selection: [],
       viewport: { x: 0, y: 0, zoom: 1 },
+      renamingFile: false,
       past: [],
       future: [],
     })
@@ -390,6 +396,7 @@ export const useSquig = create<SquigState>((set, get) => ({
         nodes: doc.nodes,
         order: doc.order,
         selection: [],
+        renamingFile: false,
         past: [],
         future: [],
       })


### PR DESCRIPTION
The file name moves out of the top-left chip and becomes a floating label centered above the canvas.

- **Centered, floating.** Plain text at the top center — no card, no chrome competing with the canvas.
- **Ducks while you draw.** Any pointer movement fades it out (110ms); it fades back in (260ms) after the pointer has rested for 550ms. It's `pointer-events-none` while hidden, so it never eats a click.
- **Rename stays aligned.** The editor is an auto-sizing grid overlay — an invisible copy of the draft sizes the cell — so the input grows with the name and sits on the exact same center axis as the label. Verified: label center and input center both land on the viewport center.
- **Menu → Rename works.** A `renamingFile` store flag drives it; the dropdown no longer yanks focus back to its trigger on close, and the field claims focus and selects the current name.
- A window-level blur (switching apps) no longer cancels an in-progress rename; New file / Open close it.

The top-left chip is now just the `squig ⌄` file menu.

Checked: `tsc --noEmit` clean, `eslint` clean, `next build` passes, and driven in Chrome — rename via label click and via the menu, Enter commits and persists to localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)