### PR TITLE
Purple selection ring, one notch heavier

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,7 +58,7 @@
   --sq-muted: #6e7dff;
   --sq-faint: #bfc6ff;
   --sq-grid: #e6e1d3;
-  --sq-select: #ff5a24;
+  --sq-select: #a200ff;
   --sq-font: var(--font-sketch);
 }
 

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -692,7 +692,7 @@ function SelectionOverlay({
     <div className="pointer-events-none absolute" style={{ left, top, width: w, height: h }}>
       <div
         className="absolute inset-0 rounded-sm"
-        style={{ border: "1.5px solid var(--sq-select)" }}
+        style={{ border: "2px solid var(--sq-select)" }}
       />
       {resizable &&
         one &&
@@ -702,7 +702,7 @@ function SelectionOverlay({
             <div
               key={hd}
               className="pointer-events-auto absolute h-2.5 w-2.5 rounded-[3px] bg-white"
-              style={{ left: pos.left, top: pos.top, cursor: pos.cursor, border: "1.5px solid var(--sq-select)" }}
+              style={{ left: pos.left, top: pos.top, cursor: pos.cursor, border: "2px solid var(--sq-select)" }}
               onPointerDown={(e) => onStartResize(hd, one.id, e)}
             />
           )

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -35,7 +35,7 @@ export const THEMES = {
     muted: "#6E7DFF",
     faint: "#BFC6FF",
     grid: "#E6E1D3",
-    select: "#FF5A24",
+    select: "#A200FF",
   },
   "riso-red": {
     label: "Riso red",


### PR DESCRIPTION
Two small fixes to selection styling.

**Color.** The Internet blue theme used `#FF5A24` (orange-red) for selection UI. Against blue ink on warm paper it reads like an error state, not a deliberate accent — and this is the default theme, so it's the one people judge. Swapped for a fully saturated violet `#A200FF`: ~45° around the wheel from the `#2438FF` ink, so it never reads as "the same blue," and saturated enough to hold its own on near-white paper. Other themes' selection colors are unchanged.

**Weight.** Selection ring and resize handle borders go from `1.5px` to `2px`. 1.5px was thinning out against dense wireframe art. 2px is the half-pixel bump — and it lands on a whole device pixel at 1x, so it renders crisper than 2.5px would.

The marquee (drag-to-select) stays at 1px dashed — it's transient and already has an 8% fill behind it.

Verified in the running app: drew a rect, an ellipse, and dropped a CTA block, selecting each. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)