### PR TITLE
Center the context menu over the selection

### DIFF
--- a/components/canvas/context-row.tsx
+++ b/components/canvas/context-row.tsx
@@ -20,9 +20,11 @@ export function ContextRow({ selectedNodes, viewport }: { selectedNodes: SquigNo
   if (!enabled || editingId || selectedNodes.length !== 1) return null
   const node = selectedNodes[0]
 
-  const left = node.x * viewport.zoom + viewport.x
+  // Centered on the selection: anchor at its horizontal midpoint, then pull
+  // back by half the row's own width.
+  const left = (node.x + node.w / 2) * viewport.zoom + viewport.x
   const top = node.y * viewport.zoom + viewport.y - 46
-  const style = { left, top: Math.max(top, 8) }
+  const style = { left, top: Math.max(top, 8), transform: "translateX(-50%)" }
 
   if (node.type === "component") {
     const def = getDef(node.kind)

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -116,7 +116,7 @@ export function CanvasContextMenu() {
       { label: "Undo", hint: "⌘Z", run: () => st().undo() },
       { label: "Redo", hint: "⇧⌘Z", run: () => st().redo() },
       { separator: true },
-      { label: contextRow ? "Hide context row" : "Show context row", run: () => st().setContextRow(!contextRow) },
+      { label: contextRow ? "Hide context menu" : "Show context menu", run: () => st().setContextRow(!contextRow) },
       { label: "Reset zoom", hint: "⌘0", run: () => st().setViewport({ x: 0, y: 0, zoom: 1 }) },
       { separator: true },
       { label: "Clear canvas", danger: true, run: () => st().clearCanvas() },

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -62,7 +62,7 @@ export function Inspector() {
               <Separator />
               <div className="flex items-center justify-between">
                 <div>
-                  <Label className="text-xs font-normal">Context row</Label>
+                  <Label className="text-xs font-normal">Context menu</Label>
                   <p className="text-[11px] text-muted-foreground">quick controls above selection</p>
                 </div>
                 <Switch checked={contextRow} onCheckedChange={(on) => st().setContextRow(on)} className="scale-90" />

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -125,7 +125,7 @@ export function TopCorner() {
             {font === "hand" ? "Use clean lettering" : "Use hand lettering"}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => st().setContextRow(!contextRow)}>
-            {contextRow ? "Hide context row" : "Show context row"}
+            {contextRow ? "Hide context menu" : "Show context menu"}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => st().setViewport({ x: 0, y: 0, zoom: 1 })}>
             Reset zoom


### PR DESCRIPTION
The floating quick-controls row was pinned to the left edge of the selection. It now anchors at the selection's horizontal midpoint and pulls back half its own width, so it stays centered regardless of how wide the row or the node is.

Also renamed the feature to "Context menu" in the user-facing labels — the inspector panel toggle, the top-corner menu item, and the right-click menu item. Internal names (`contextRow`, `ContextRow`) are unchanged.

Checked: `tsc --noEmit` clean, `eslint components` clean, `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)