### PR TITLE
Use Phosphor everywhere, and give the context menu icons

### DIFF
--- a/components.json
+++ b/components.json
@@ -10,7 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
-  "iconLibrary": "lucide",
+  "iconLibrary": "phosphor",
   "rtl": false,
   "aliases": {
     "components": "@/components",

--- a/components/chrome/align-row.tsx
+++ b/components/chrome/align-row.tsx
@@ -6,28 +6,29 @@
 // ---------------------------------------------------------------------------
 
 import {
-  AlignCenterHorizontal,
-  AlignCenterVertical,
-  AlignEndHorizontal,
-  AlignEndVertical,
-  AlignHorizontalDistributeCenter,
-  AlignStartHorizontal,
-  AlignStartVertical,
-  AlignVerticalDistributeCenter,
-} from "lucide-react"
+  AlignBottomSimpleIcon,
+  AlignCenterHorizontalSimpleIcon,
+  AlignCenterVerticalSimpleIcon,
+  AlignLeftSimpleIcon,
+  AlignRightSimpleIcon,
+  AlignTopSimpleIcon,
+  ArrowsOutLineHorizontalIcon,
+  ArrowsOutLineVerticalIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react"
 
 import { useSquig } from "@/lib/store"
 import { cn } from "@/lib/utils"
 
 type Edge = "left" | "hcenter" | "right" | "top" | "vcenter" | "bottom"
 
-const ALIGN: { edge: Edge; label: string; icon: typeof AlignStartVertical }[] = [
-  { edge: "left", label: "Align left", icon: AlignStartVertical },
-  { edge: "hcenter", label: "Align horizontal centres", icon: AlignCenterVertical },
-  { edge: "right", label: "Align right", icon: AlignEndVertical },
-  { edge: "top", label: "Align top", icon: AlignStartHorizontal },
-  { edge: "vcenter", label: "Align vertical centres", icon: AlignCenterHorizontal },
-  { edge: "bottom", label: "Align bottom", icon: AlignEndHorizontal },
+const ALIGN: { edge: Edge; label: string; icon: PhosphorIcon }[] = [
+  { edge: "left", label: "Align left", icon: AlignLeftSimpleIcon },
+  { edge: "hcenter", label: "Align horizontal centres", icon: AlignCenterVerticalSimpleIcon },
+  { edge: "right", label: "Align right", icon: AlignRightSimpleIcon },
+  { edge: "top", label: "Align top", icon: AlignTopSimpleIcon },
+  { edge: "vcenter", label: "Align vertical centres", icon: AlignCenterHorizontalSimpleIcon },
+  { edge: "bottom", label: "Align bottom", icon: AlignBottomSimpleIcon },
 ]
 
 function IconButton({
@@ -77,14 +78,14 @@ export function AlignRow({ count, className }: { count: number; className?: stri
         disabled={!canDistribute}
         onClick={() => st().distributeSelected("h")}
       >
-        <AlignHorizontalDistributeCenter className="size-3.5" />
+        <ArrowsOutLineHorizontalIcon className="size-3.5" />
       </IconButton>
       <IconButton
         label={canDistribute ? "Distribute vertically" : "Distribute needs 3 or more"}
         disabled={!canDistribute}
         onClick={() => st().distributeSelected("v")}
       >
-        <AlignVerticalDistributeCenter className="size-3.5" />
+        <ArrowsOutLineVerticalIcon className="size-3.5" />
       </IconButton>
     </div>
   )

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -9,10 +9,48 @@ import { useSquig } from "@/lib/store"
 import { screenToWorld } from "@/lib/types"
 import { getDef } from "@/lib/library/registry"
 import { kbd } from "@/lib/shortcuts"
+import {
+  AlignBottomSimpleIcon,
+  AlignCenterHorizontalSimpleIcon,
+  AlignCenterVerticalSimpleIcon,
+  AlignLeftSimpleIcon,
+  AlignRightSimpleIcon,
+  AlignTopSimpleIcon,
+  ArrowCounterClockwiseIcon,
+  ArrowDownIcon,
+  ArrowLineDownIcon,
+  ArrowLineUpIcon,
+  ArrowUUpLeftIcon,
+  ArrowUUpRightIcon,
+  ArrowUpIcon,
+  ArrowsOutIcon,
+  BoundingBoxIcon,
+  BroomIcon,
+  ClipboardTextIcon,
+  CopyIcon,
+  CopySimpleIcon,
+  EyeSlashIcon,
+  FlipHorizontalIcon,
+  FlipVerticalIcon,
+  KeyboardIcon,
+  LinkBreakIcon,
+  LinkSimpleIcon,
+  MagnifyingGlassIcon,
+  NumberSquareOneIcon,
+  SelectionAllIcon,
+  SelectionIcon,
+  SlidersHorizontalIcon,
+  SquaresFourIcon,
+  StackIcon,
+  TextTIcon,
+  TrashIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react"
 
 interface Item {
   label: string
   hint?: string
+  icon: PhosphorIcon
   run?: () => void
   danger?: boolean
   separator?: never
@@ -73,70 +111,83 @@ export function CanvasContextMenu() {
 
   if (menu.nodeId) {
     entries = [
-      { label: "Duplicate", hint: kbd("mod+d"), run: () => st().duplicateSelected() },
-      { label: "Copy", hint: kbd("mod+c"), run: () => st().copySelected() },
-      ...(targets.length > 1 ? [{ label: "Group", hint: kbd("mod+g"), run: () => st().groupSelected() } as Entry] : []),
-      ...(hasGroup ? [{ label: "Ungroup", hint: kbd("mod+shift+g"), run: () => st().ungroupSelected() } as Entry] : []),
+      { label: "Duplicate", hint: kbd("mod+d"), icon: CopyIcon, run: () => st().duplicateSelected() },
+      { label: "Copy", hint: kbd("mod+c"), icon: CopySimpleIcon, run: () => st().copySelected() },
+      ...(targets.length > 1
+        ? [{ label: "Group", hint: kbd("mod+g"), icon: BoundingBoxIcon, run: () => st().groupSelected() } as Entry]
+        : []),
+      ...(hasGroup
+        ? [{ label: "Ungroup", hint: kbd("mod+shift+g"), icon: SelectionIcon, run: () => st().ungroupSelected() } as Entry]
+        : []),
       ...(hasComponent
-        ? [{ label: "Detach instance", hint: kbd("alt+mod+b"), run: () => st().detachSelected() } as Entry]
+        ? [{ label: "Detach instance", hint: kbd("alt+mod+b"), icon: LinkBreakIcon, run: () => st().detachSelected() } as Entry]
         : []),
       ...(hasText
-        ? [{ label: "Link text…", hint: kbd("mod+k"), run: () => st().setLinkOpen(true) } as Entry]
+        ? [{ label: "Link text…", hint: kbd("mod+k"), icon: LinkSimpleIcon, run: () => st().setLinkOpen(true) } as Entry]
         : []),
       ...(one?.type === "text" || (one?.type === "component" && getDef(one.kind)?.controls.some((c) => c.type === "text"))
-        ? [{ label: "Edit text", hint: "double-click", run: () => st().setEditing(one.id) } as Entry]
+        ? [{ label: "Edit text", hint: "double-click", icon: TextTIcon, run: () => st().setEditing(one.id) } as Entry]
         : []),
       { separator: true },
-      { label: "Bring to front", hint: kbd("far+]"), run: () => st().bringToFront(targets) },
-      { label: "Bring forward", hint: kbd("mod+]"), run: () => st().bringForward(targets) },
-      { label: "Send backward", hint: kbd("mod+["), run: () => st().sendBackward(targets) },
-      { label: "Send to back", hint: kbd("far+["), run: () => st().sendToBack(targets) },
+      { label: "Bring to front", hint: kbd("far+]"), icon: ArrowLineUpIcon, run: () => st().bringToFront(targets) },
+      { label: "Bring forward", hint: kbd("mod+]"), icon: ArrowUpIcon, run: () => st().bringForward(targets) },
+      { label: "Send backward", hint: kbd("mod+["), icon: ArrowDownIcon, run: () => st().sendBackward(targets) },
+      { label: "Send to back", hint: kbd("far+["), icon: ArrowLineDownIcon, run: () => st().sendToBack(targets) },
       { separator: true },
-      { label: "Flip horizontal", hint: kbd("shift+h"), run: () => st().flipSelected("x") },
-      { label: "Flip vertical", hint: kbd("shift+v"), run: () => st().flipSelected("y") },
+      { label: "Flip horizontal", hint: kbd("shift+h"), icon: FlipHorizontalIcon, run: () => st().flipSelected("x") },
+      { label: "Flip vertical", hint: kbd("shift+v"), icon: FlipVerticalIcon, run: () => st().flipSelected("y") },
       ...(selection.length > 1
         ? ([
             { separator: true },
-            { label: "Align left", run: () => st().alignSelected("left") },
-            { label: "Align centres", run: () => st().alignSelected("hcenter") },
-            { label: "Align right", run: () => st().alignSelected("right") },
-            { label: "Align top", run: () => st().alignSelected("top") },
-            { label: "Align middles", run: () => st().alignSelected("vcenter") },
-            { label: "Align bottom", run: () => st().alignSelected("bottom") },
+            { label: "Align left", icon: AlignLeftSimpleIcon, run: () => st().alignSelected("left") },
+            { label: "Align centres", icon: AlignCenterVerticalSimpleIcon, run: () => st().alignSelected("hcenter") },
+            { label: "Align right", icon: AlignRightSimpleIcon, run: () => st().alignSelected("right") },
+            { label: "Align top", icon: AlignTopSimpleIcon, run: () => st().alignSelected("top") },
+            { label: "Align middles", icon: AlignCenterHorizontalSimpleIcon, run: () => st().alignSelected("vcenter") },
+            { label: "Align bottom", icon: AlignBottomSimpleIcon, run: () => st().alignSelected("bottom") },
           ] as Entry[])
         : []),
       { separator: true },
-      { label: "Delete", hint: kbd("del"), danger: true, run: () => st().removeNodes(targets) },
+      { label: "Delete", hint: kbd("del"), icon: TrashIcon, danger: true, run: () => st().removeNodes(targets) },
     ]
   } else {
     entries = [
-      { label: "Search everything", hint: kbd("mod+k"), run: () => st().setCommandOpen(true) },
-      { label: "Components", hint: kbd("c"), run: () => st().setPanel("components") },
-      { label: "Blocks", hint: kbd("b"), run: () => st().setPanel("blocks") },
+      { label: "Search everything", hint: kbd("mod+k"), icon: MagnifyingGlassIcon, run: () => st().setCommandOpen(true) },
+      { label: "Components", hint: kbd("c"), icon: SquaresFourIcon, run: () => st().setPanel("components") },
+      { label: "Blocks", hint: kbd("b"), icon: StackIcon, run: () => st().setPanel("blocks") },
       { separator: true },
-      { label: "Select all", hint: kbd("mod+a"), run: () => st().setSelection([...st().order]) },
+      { label: "Select all", hint: kbd("mod+a"), icon: SelectionAllIcon, run: () => st().setSelection([...st().order]) },
       ...(clipboard.length
-        ? [{ label: "Paste here", hint: kbd("mod+v"), run: () => pasteAt(menu.x, menu.y) } as Entry]
+        ? [{ label: "Paste here", hint: kbd("mod+v"), icon: ClipboardTextIcon, run: () => pasteAt(menu.x, menu.y) } as Entry]
         : []),
       { separator: true },
-      { label: "Undo", hint: kbd("mod+z"), run: () => st().undo() },
-      { label: "Redo", hint: kbd("mod+shift+z"), run: () => st().redo() },
+      { label: "Undo", hint: kbd("mod+z"), icon: ArrowUUpLeftIcon, run: () => st().undo() },
+      { label: "Redo", hint: kbd("mod+shift+z"), icon: ArrowUUpRightIcon, run: () => st().redo() },
       { separator: true },
-      { label: "Zoom to fit", hint: kbd("shift+1"), run: () => st().zoomToFit() },
-      { label: "Zoom to 100%", hint: kbd("shift+0"), run: () => st().zoomTo100() },
-      { label: "Reset zoom", hint: kbd("mod+0"), run: () => st().setViewport({ x: 0, y: 0, zoom: 1 }) },
-      { label: contextRow ? "Hide context menu" : "Show context menu", run: () => st().setContextRow(!contextRow) },
-      { label: "Hide the interface", hint: kbd("mod+\\"), run: () => st().setUiHidden(true) },
-      { label: "Keyboard shortcuts", hint: kbd("shift+/"), run: () => st().setShortcutsOpen(true) },
+      { label: "Zoom to fit", hint: kbd("shift+1"), icon: ArrowsOutIcon, run: () => st().zoomToFit() },
+      { label: "Zoom to 100%", hint: kbd("shift+0"), icon: NumberSquareOneIcon, run: () => st().zoomTo100() },
+      {
+        label: "Reset zoom",
+        hint: kbd("mod+0"),
+        icon: ArrowCounterClockwiseIcon,
+        run: () => st().setViewport({ x: 0, y: 0, zoom: 1 }),
+      },
+      {
+        label: contextRow ? "Hide context menu" : "Show context menu",
+        icon: SlidersHorizontalIcon,
+        run: () => st().setContextRow(!contextRow),
+      },
+      { label: "Hide the interface", hint: kbd("mod+\\"), icon: EyeSlashIcon, run: () => st().setUiHidden(true) },
+      { label: "Keyboard shortcuts", hint: kbd("shift+/"), icon: KeyboardIcon, run: () => st().setShortcutsOpen(true) },
       { separator: true },
-      { label: "Clear canvas", danger: true, run: () => st().clearCanvas() },
+      { label: "Clear canvas", icon: BroomIcon, danger: true, run: () => st().clearCanvas() },
     ]
   }
 
   return (
     <div
       ref={ref}
-      className="fixed z-50 min-w-[196px] rounded-xl border bg-background p-1 shadow-lg"
+      className="fixed z-50 min-w-[220px] rounded-xl border bg-background p-1 shadow-lg"
       style={{ left: pos.x, top: pos.y }}
       onPointerDown={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.preventDefault()}
@@ -152,12 +203,16 @@ export function CanvasContextMenu() {
               entry.run?.()
               close()
             }}
-            className={`flex w-full items-center gap-6 rounded-lg px-2.5 py-1.5 text-left text-[13px] hover:bg-accent ${
+            className={`group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-[13px] hover:bg-accent ${
               entry.danger ? "text-muted-foreground hover:text-destructive" : ""
             }`}
           >
+            <entry.icon
+              className={`size-4 shrink-0 ${entry.danger ? "" : "text-muted-foreground group-hover:text-foreground"}`}
+              weight="fill"
+            />
             <span className="flex-1 truncate">{entry.label}</span>
-            {entry.hint && <span className="font-mono text-[10px] text-muted-foreground">{entry.hint}</span>}
+            {entry.hint && <span className="pl-4 font-mono text-[10px] text-muted-foreground">{entry.hint}</span>}
           </button>
         )
       )}

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -21,7 +21,7 @@ import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Unlink, Trash2, Link as LinkIcon } from "lucide-react"
+import { LinkBreakIcon, LinkSimpleIcon, TrashIcon } from "@phosphor-icons/react"
 import { kbd } from "@/lib/shortcuts"
 
 export function Inspector() {
@@ -243,7 +243,7 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
               mixed={shared(texts.map((n) => !!n.link)).mixed}
               onClick={() => st().setLinkOpen(true)}
             >
-              <LinkIcon className="size-3.5" />
+              <LinkSimpleIcon className="size-3.5" />
             </StyleToggle>
           </div>
 
@@ -281,7 +281,7 @@ function Footer({ selected }: { selected: SquigNode[] }) {
     <div className="flex shrink-0 gap-1.5 border-t p-2.5">
       {components.length > 0 && (
         <Button variant="outline" size="sm" className="h-7 flex-1 text-xs" onClick={() => st().detachSelected()}>
-          <Unlink className="size-3" /> Detach
+          <LinkBreakIcon className="size-3" /> Detach
           {components.length > 1 && <span className="tabular-nums">({components.length})</span>}
         </Button>
       )}
@@ -291,7 +291,7 @@ function Footer({ selected }: { selected: SquigNode[] }) {
         className="h-7 flex-1 text-xs text-muted-foreground hover:text-destructive"
         onClick={() => st().deleteSelected()}
       >
-        <Trash2 className="size-3" /> Delete
+        <TrashIcon className="size-3" /> Delete
       </Button>
     </div>
   )

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -8,7 +8,7 @@
 import { useRef } from "react"
 import { useSquig } from "@/lib/store"
 import { exportDoc, importDoc } from "@/lib/file-io"
-import { CaretDownIcon } from "@phosphor-icons/react"
+import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -129,7 +129,7 @@ export function TopCorner() {
                     <Swatch name={name} />
                     {THEMES[name].label}
                   </span>
-                  {theme === name && <DropdownMenuShortcut>✓</DropdownMenuShortcut>}
+                  {theme === name && <CheckIcon className="ml-auto size-3.5 text-muted-foreground" weight="bold" />}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuSubContent>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Checkbox as CheckboxPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-import { CheckIcon } from "lucide-react"
+import { CheckIcon } from "@phosphor-icons/react"
 
 function Checkbox({
   className,
@@ -23,8 +23,7 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
-        <CheckIcon
-        />
+        <CheckIcon weight="bold" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { CaretRightIcon, CheckIcon } from "@phosphor-icons/react"
 
 function DropdownMenu({
   ...props
@@ -106,8 +106,7 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon weight="bold" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -149,8 +148,7 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon weight="bold" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -232,7 +230,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      <CaretRightIcon className="ml-auto" weight="bold" />
     </DropdownMenuPrimitive.SubTrigger>
   )
 }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Select as SelectPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { CaretDownIcon, CaretUpIcon, CheckIcon } from "@phosphor-icons/react"
 
 function Select({
   ...props
@@ -51,7 +51,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        <CaretDownIcon className="pointer-events-none size-4 text-muted-foreground" weight="bold" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )
@@ -119,7 +119,7 @@ function SelectItem({
     >
       <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="pointer-events-none" />
+          <CheckIcon className="pointer-events-none" weight="bold" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -153,8 +153,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <CaretUpIcon weight="bold" />
     </SelectPrimitive.ScrollUpButton>
   )
 }
@@ -172,8 +171,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <CaretDownIcon weight="bold" />
     </SelectPrimitive.ScrollDownButton>
   )
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@phosphor-icons/react": "^2.1.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.27.0",
     "nanoid": "^6.0.0",
     "next": "16.2.12",
     "radix-ui": "^1.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      lucide-react:
-        specifier: ^1.27.0
-        version: 1.27.0(react@19.2.4)
       nanoid:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2780,11 +2777,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lucide-react@1.27.0:
-    resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -6538,10 +6530,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@1.27.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
Every icon in the app now comes from `@phosphor-icons/react`. Rebased on latest main, which brought new lucide usages and a much bigger context menu — both swept in.

**Swapped from lucide**
- `inspector.tsx` — `Unlink` → `LinkBreakIcon`, `Trash2` → `TrashIcon`, `Link` → `LinkSimpleIcon`
- `align-row.tsx` (new on main) — the six align icons → Phosphor `Align*SimpleIcon`, distribute → `ArrowsOutLineHorizontal/VerticalIcon`
- `ui/checkbox.tsx`, `ui/dropdown-menu.tsx`, `ui/select.tsx` — checks and chevrons → Phosphor `CheckIcon` / `CaretRightIcon` / `CaretUpIcon` / `CaretDownIcon`, all `weight="bold"` so they stay legible at 12–16px
- `top-corner.tsx` — the theme submenu's `✓` text glyph is now a real `CheckIcon`

**Context menu**
Every row has an icon, in `weight="fill"` rather than the outline default — including everything main added since: copy, group/ungroup, detach instance, link text, bring forward/send backward, flip h/v, zoom to fit, zoom to 100%, hide the interface, keyboard shortcuts. Min width 196 → 220px for the icon column. Note that line-shaped Phosphor glyphs (arrows, corners) render identically in fill and regular — inherent to the set, not a missed weight.

**Housekeeping**
`lucide-react` dropped from `package.json` and the lockfile; `components.json` `iconLibrary` set to `phosphor` so future shadcn adds pull from the same set.

Verified with `pnpm lint`, `pnpm build`, and `pnpm test` (58 checks) all clean, plus driving the running app after the rebase: both context menus with the new entries, the align/distribute row in the inspector and context row, the file menu with its recents and Ink submenus, the command palette, and a select popup.

Unrelated, found while testing: a doc persisted before commit 48f2c87 keeps the old theme id `internet`, and `Swatch` in `top-corner.tsx:27` reads `THEMES[name].paper` unguarded, so opening the file menu throws `Cannot read properties of undefined`. Left it alone — happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)