### PR TITLE
Keep every file in the browser, with a recents menu to reopen them

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ component and its pieces become editable primitives. One-way, on purpose.
 **⌘K searches everything.** Tools, actions, and every component and block, in
 one sheet. Enter drops it in the middle of your view.
 
+**Your files stay in your browser.** Every document autosaves as you draw, and
+the file menu keeps a list of the recent ones to open again. New file starts a
+new document rather than painting over the last one. No accounts, no cloud —
+which also means clearing site data clears the lot, so Export a copy
+(`⇧⌘S`) is there when a file matters.
+
 ## Keyboard
 
 Figma's, so your hands already know it. `?` opens the full list in the app.
@@ -48,6 +54,7 @@ Figma's, so your hands already know it. `?` opens the full list in the app.
 | `⌥⌘]` / `⌥⌘[` (or `]` / `[`) | bring to front / send to back |
 | `⇧H` / `⇧V` | flip horizontal / vertical |
 | `⌘B` `⌘I` `⌘U` | bold, italic, underline |
+| `⌘S` / `⇧⌘S` | save to this browser / export a copy |
 | arrows (`⇧` for 10px) | nudge |
 | space-drag, middle-drag | pan |
 | `⌘+` / `⌘-`, `⌘`-scroll | zoom the canvas, never the browser |
@@ -87,6 +94,7 @@ lib/sketch/              drawing primitives + Phosphor icons
 lib/library/             every component and block definition
 lib/canvas/snap-engine   alignment/snapping math
 lib/store.ts             zustand doc state + history
+lib/files.ts             the local file drawer — autosave, recents, prefs
 ```
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ one sheet. Enter drops it in the middle of your view.
 
 **Your files stay in your browser.** Every document autosaves as you draw, and
 the file menu keeps a list of the recent ones to open again. New file starts a
-new document rather than painting over the last one. No accounts, no cloud —
-which also means clearing site data clears the lot, so Export a copy
-(`⇧⌘S`) is there when a file matters.
+new document rather than painting over the last one. The drawer holds the last
+forty; past that, and when the browser runs out of room, the oldest ones go.
+No accounts, no cloud — which also means clearing site data clears the lot, so
+Export a copy (`⇧⌘S`) is there when a file matters.
 
 ## Keyboard
 

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -13,6 +13,7 @@ import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type Snap
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { NodeSketch, SketchPrims } from "./sketch"
 import { getDef, renderComponent } from "@/lib/library/registry"
+import { exportDoc } from "@/lib/file-io"
 import { ContextRow } from "./context-row"
 
 const MIN_ZOOM = 0.1
@@ -512,6 +513,12 @@ export function Canvas() {
           case "KeyD":
             e.preventDefault()
             s.duplicateSelected()
+            return
+          case "KeyS":
+            // squig saves as you draw; ⌘S is for the hand that needs to hear it
+            e.preventDefault()
+            if (e.shiftKey) exportDoc()
+            else s.saveNow()
             return
           case "KeyA":
             e.preventDefault()

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -459,6 +459,20 @@ export function Canvas() {
 
   // -- keyboard -------------------------------------------------------------
 
+  // ⌘S belongs to squig wherever the cursor is — mid-word, mid-rename, palette
+  // open. On the capture phase, because every field that swallows keystrokes
+  // sits downstream of here, and the browser's "save page" is never the point.
+  useEffect(() => {
+    const onSave = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.code !== "KeyS") return
+      e.preventDefault()
+      if (e.shiftKey) exportDoc()
+      else st().saveNow()
+    }
+    window.addEventListener("keydown", onSave, { capture: true })
+    return () => window.removeEventListener("keydown", onSave, { capture: true })
+  }, [st])
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement
@@ -513,12 +527,6 @@ export function Canvas() {
           case "KeyD":
             e.preventDefault()
             s.duplicateSelected()
-            return
-          case "KeyS":
-            // squig saves as you draw; ⌘S is for the hand that needs to hear it
-            e.preventDefault()
-            if (e.shiftKey) exportDoc()
-            else s.saveNow()
             return
           case "KeyA":
             e.preventDefault()

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -10,6 +10,7 @@ import { useSquig } from "@/lib/store"
 import { ALL_DEFS, matches, type ComponentDef } from "@/lib/library/registry"
 import { SketchPrims } from "@/components/canvas/sketch"
 import { exportDoc, importDoc } from "@/lib/file-io"
+import { relativeTime } from "@/lib/files"
 import { kbd } from "@/lib/shortcuts"
 import {
   MagnifyingGlassIcon,
@@ -31,6 +32,7 @@ import {
   CornersOutIcon,
   CornersInIcon,
   FileIcon,
+  FloppyDiskIcon,
   DownloadSimpleIcon,
   UploadSimpleIcon,
   LinkBreakIcon,
@@ -61,7 +63,10 @@ interface Action {
 
 type Row = { kind: "action"; action: Action } | { kind: "def"; def: ComponentDef }
 
-const SECTION_ORDER = ["Tools", "Edit", "Arrange", "Text", "View", "File", "Components", "Blocks"]
+const SECTION_ORDER = ["Tools", "Edit", "Arrange", "Text", "View", "File", "Recent", "Components", "Blocks"]
+
+/** the palette lists a handful of files; the file menu holds the rest */
+const RECENT_IN_PALETTE = 6
 
 /** Mount only while open, so every ⌘K starts from a blank box with no reset dance. */
 export function CommandPalette() {
@@ -73,6 +78,8 @@ export function CommandPalette() {
 function Palette() {
   const selection = useSquig((s) => s.selection)
   const nodes = useSquig((s) => s.nodes)
+  const files = useSquig((s) => s.files)
+  const docId = useSquig((s) => s.docId)
   const st = useSquig.getState
 
   const [query, setQuery] = useState("")
@@ -146,10 +153,25 @@ function Palette() {
       { id: "keys", label: "Keyboard shortcuts", hint: kbd("shift+/"), section: "View", keywords: "hotkeys help cheat sheet", icon: KeyboardIcon, run: () => st().setShortcutsOpen(true) },
 
       { id: "new", label: "New file", section: "File", keywords: "blank clear reset", icon: FileIcon, run: () => st().newFile() },
-      { id: "export", label: "Export .squig", section: "File", keywords: "save download json", icon: DownloadSimpleIcon, run: exportDoc },
-      { id: "import", label: "Import .squig", section: "File", keywords: "open load json", icon: UploadSimpleIcon, run: importDoc },
+      { id: "save", label: "Save", hint: kbd("mod+s"), section: "File", keywords: "keep store local", icon: FloppyDiskIcon, run: () => st().saveNow() },
+      { id: "export", label: "Export .squig", hint: kbd("mod+shift+s"), section: "File", keywords: "save download json copy backup", icon: DownloadSimpleIcon, run: exportDoc },
+      { id: "import", label: "Import .squig", section: "File", keywords: "open load json disk", icon: UploadSimpleIcon, run: importDoc },
+
+      // every file this browser is holding, so ⌘K can open one too
+      ...files
+        .filter((f) => f.id !== docId)
+        .slice(0, RECENT_IN_PALETTE)
+        .map((f) => ({
+          id: `open:${f.id}`,
+          label: f.name,
+          hint: relativeTime(f.updatedAt),
+          section: "Recent",
+          keywords: "open recent file document",
+          icon: FileIcon,
+          run: () => st().openFile(f.id),
+        })),
     ],
-    [st, hasSel, hasComponent, hasText, hasGroup, selection.length]
+    [st, hasSel, hasComponent, hasText, hasGroup, selection.length, files, docId]
   )
 
   const rows = useMemo<Row[]>(() => {

--- a/components/chrome/file-name.tsx
+++ b/components/chrome/file-name.tsx
@@ -12,11 +12,15 @@ import { useSquig } from "@/lib/store"
 /** how long the pointer has to sit still before the name comes back */
 const REST_MS = 550
 
+/** how long "saved" hangs around after ⌘S */
+const SAVED_MS = 1800
+
 export function FileName() {
   const fileName = useSquig((s) => s.fileName)
   const renaming = useSquig((s) => s.renamingFile)
   const st = useSquig.getState
   const [resting, setResting] = useState(true)
+  const [saved, setSaved] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   // mirrors `resting` so a drag's worth of moves doesn't churn React state
   const restingRef = useRef(true)
@@ -43,7 +47,22 @@ export function FileName() {
     }
   }, [])
 
-  const shown = resting || renaming
+  // ⌘S says so out loud — the autosaves along the way stay quiet
+  useEffect(() => {
+    let id: ReturnType<typeof setTimeout> | null = null
+    const unsub = useSquig.subscribe((s, prev) => {
+      if (s.saveFlash === prev.saveFlash) return
+      setSaved(true)
+      if (id) clearTimeout(id)
+      id = setTimeout(() => setSaved(false), SAVED_MS)
+    })
+    return () => {
+      unsub()
+      if (id) clearTimeout(id)
+    }
+  }, [])
+
+  const shown = resting || renaming || saved
 
   return (
     <div
@@ -64,6 +83,13 @@ export function FileName() {
           {fileName}
         </button>
       )}
+      <span
+        aria-live="polite"
+        className="absolute top-full left-1/2 mt-1 -translate-x-1/2 text-[11px] whitespace-nowrap text-muted-foreground transition-opacity duration-200"
+        style={{ opacity: saved ? 1 : 0 }}
+      >
+        {saved ? "saved to this browser" : ""}
+      </span>
     </div>
   )
 }

--- a/components/chrome/recent-files.tsx
+++ b/components/chrome/recent-files.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// The recent files submenu. Everything squig has saved in this browser, newest
+// first — click one to open it, or arm the trash twice to let it go. Deleting
+// takes two clicks on purpose: this list is the only copy.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useRef, useState } from "react"
+import { useSquig } from "@/lib/store"
+import { relativeTime, type FileMeta } from "@/lib/files"
+import { CheckIcon, TrashIcon } from "@phosphor-icons/react"
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu"
+
+/** past this the menu would be a scroll, and old files are the drawer's job */
+const SHOWN = 12
+/** how long the trash stays armed before it forgets you meant it */
+const ARM_MS = 3000
+
+export function RecentFiles() {
+  const files = useSquig((s) => s.files)
+  const docId = useSquig((s) => s.docId)
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        Open recent
+        {files.length > 1 && <span className="ml-auto pl-2 text-xs text-muted-foreground">{files.length}</span>}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-72">
+        {files.length === 0 ? (
+          <p className="px-2 py-1.5 text-sm text-muted-foreground">nothing saved yet</p>
+        ) : (
+          files.slice(0, SHOWN).map((f) => <FileRow key={f.id} file={f} current={f.id === docId} />)
+        )}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+function FileRow({ file, current }: { file: FileMeta; current: boolean }) {
+  const st = useSquig.getState
+  const [armed, setArmed] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => void (timer.current && clearTimeout(timer.current)), [])
+
+  const arm = () => {
+    setArmed(true)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => setArmed(false), ARM_MS)
+  }
+
+  // The trash lives beside the item rather than inside it: a button nested in
+  // a menu item still selects the item, whatever it does with the event.
+  return (
+    <div className="group/row relative flex items-center">
+      <DropdownMenuItem className="flex-1 gap-2 pr-8" onSelect={() => st().openFile(file.id)}>
+        {current && <CheckIcon className="size-3.5 shrink-0 text-muted-foreground" weight="bold" />}
+        <span className="min-w-0 flex-1 truncate">{file.name}</span>
+        <span className={`shrink-0 text-xs ${armed ? "text-destructive" : "text-muted-foreground"}`}>
+          {armed ? "click again" : relativeTime(file.updatedAt)}
+        </span>
+      </DropdownMenuItem>
+      {/* the file you're in stays put — open another one first */}
+      {!current && (
+        <button
+          type="button"
+          aria-label={armed ? `delete ${file.name} for good` : `delete ${file.name}`}
+          title={armed ? "click again to delete" : "delete"}
+          onClick={() => (armed ? st().deleteFile(file.id) : arm())}
+          className={`absolute right-1.5 flex size-6 items-center justify-center rounded-md transition-opacity ${
+            armed
+              ? "text-destructive opacity-100"
+              : "text-muted-foreground opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100"
+          }`}
+        >
+          <TrashIcon className="size-3.5" weight={armed ? "fill" : "regular"} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/chrome/recent-files.tsx
+++ b/components/chrome/recent-files.tsx
@@ -28,10 +28,7 @@ export function RecentFiles() {
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger>
-        Open recent
-        {files.length > 1 && <span className="ml-auto pl-2 text-xs text-muted-foreground">{files.length}</span>}
-      </DropdownMenuSubTrigger>
+      <DropdownMenuSubTrigger>Open recent</DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-72">
         {files.length === 0 ? (
           <p className="px-2 py-1.5 text-sm text-muted-foreground">nothing saved yet</p>

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { THEMES, THEME_NAMES, type ThemeName } from "@/lib/theme"
 import { kbd } from "@/lib/shortcuts"
+import { RecentFiles } from "@/components/chrome/recent-files"
 
 /** Two-tone chip showing a palette's paper and ink. */
 function Swatch({ name }: { name: ThemeName }) {
@@ -75,10 +76,16 @@ export function TopCorner() {
           }}
         >
           <DropdownMenuItem onSelect={() => st().newFile()}>New file</DropdownMenuItem>
-          <DropdownMenuItem onSelect={importDoc}>Open…</DropdownMenuItem>
+          <RecentFiles />
+          <DropdownMenuItem onSelect={importDoc}>Open from disk…</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => st().saveNow()}>
+            Save
+            <DropdownMenuShortcut>{kbd("mod+s")}</DropdownMenuShortcut>
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={exportDoc}>
-            Export
-            <DropdownMenuShortcut>.squig.json</DropdownMenuShortcut>
+            Export a copy
+            <DropdownMenuShortcut>{kbd("mod+shift+s")}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -1,0 +1,200 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// The file drawer — every document this browser has ever held, kept in
+// localStorage. Each doc lives under its own key with a small index on the
+// side, so the file menu can list names and times without parsing every
+// document it has.
+//
+// No cloud, no accounts. Clearing site data still clears everything, which is
+// why Export stays one keystroke away.
+// ---------------------------------------------------------------------------
+
+import type { SquigNode } from "./types"
+import { DEFAULT_FONT, DEFAULT_THEME, THEMES, type FontMode, type ThemeName } from "./theme"
+
+export interface FileMeta {
+  id: string
+  name: string
+  updatedAt: number
+  /** how many objects are on the canvas — shown as a hint, never trusted */
+  count: number
+}
+
+export interface StoredDoc {
+  id: string
+  name: string
+  nodes: Record<string, SquigNode>
+  order: string[]
+  updatedAt: number
+}
+
+/** Everything that belongs to the app rather than to any one document. */
+export interface Prefs {
+  theme: ThemeName
+  font: FontMode
+  contextRow: boolean
+  activeId: string | null
+}
+
+const INDEX_KEY = "squig:files:v1"
+const PREFS_KEY = "squig:prefs:v1"
+const LEGACY_KEY = "squig:doc:v1"
+const fileKey = (id: string) => `squig:file:${id}`
+
+/** Past this many the drawer starts forgetting its oldest documents. */
+const MAX_FILES = 40
+
+function readJSON(key: string): unknown {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+/** Returns false when the browser refuses the write — usually a full quota. */
+function writeJSON(key: string, value: unknown): boolean {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function drop(key: string) {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // nothing to do about it
+  }
+}
+
+function isMeta(v: unknown): v is FileMeta {
+  const m = v as FileMeta
+  return !!m && typeof m.id === "string" && typeof m.name === "string" && typeof m.updatedAt === "number"
+}
+
+const byRecent = (a: FileMeta, b: FileMeta) => b.updatedAt - a.updatedAt
+
+/** Every saved document, newest first. */
+export function listFiles(): FileMeta[] {
+  const parsed = readJSON(INDEX_KEY)
+  if (!Array.isArray(parsed)) return []
+  return parsed.filter(isMeta).sort(byRecent)
+}
+
+function writeIndex(list: FileMeta[]) {
+  writeJSON(INDEX_KEY, list)
+}
+
+export function readFile(id: string): StoredDoc | null {
+  const doc = readJSON(fileKey(id)) as StoredDoc | null
+  if (!doc || typeof doc !== "object" || !doc.nodes || !Array.isArray(doc.order)) return null
+  return { ...doc, id, name: typeof doc.name === "string" ? doc.name : "untitled scribbles" }
+}
+
+/**
+ * Write a document and return the new index. If the browser is out of room we
+ * forget the oldest documents — never the one in hand — and try again.
+ */
+export function saveFile(doc: StoredDoc): FileMeta[] {
+  const meta: FileMeta = { id: doc.id, name: doc.name, updatedAt: doc.updatedAt, count: doc.order.length }
+  let index = [meta, ...listFiles().filter((f) => f.id !== doc.id)]
+
+  // trim the tail first, so the common case never hits the quota at all
+  for (const old of index.slice(MAX_FILES)) drop(fileKey(old.id))
+  index = index.slice(0, MAX_FILES)
+
+  let stored = writeJSON(fileKey(doc.id), doc)
+  while (!stored) {
+    const oldest = [...index].reverse().find((f) => f.id !== doc.id)
+    if (!oldest) break
+    drop(fileKey(oldest.id))
+    index = index.filter((f) => f.id !== oldest.id)
+    stored = writeJSON(fileKey(doc.id), doc)
+  }
+
+  // a document we couldn't store has no business being listed
+  if (!stored) index = index.filter((f) => f.id !== doc.id)
+  writeIndex(index)
+  return index
+}
+
+export function deleteFile(id: string): FileMeta[] {
+  drop(fileKey(id))
+  const index = listFiles().filter((f) => f.id !== id)
+  writeIndex(index)
+  return index
+}
+
+/** A palette that has since been renamed or retired must not take the app down. */
+function knownTheme(t: unknown): ThemeName {
+  return typeof t === "string" && t in THEMES ? (t as ThemeName) : DEFAULT_THEME
+}
+
+function knownFont(f: unknown): FontMode {
+  return f === "hand" || f === "clean" ? f : DEFAULT_FONT
+}
+
+export function loadPrefs(): Prefs {
+  const p = (readJSON(PREFS_KEY) ?? {}) as Partial<Prefs>
+  return {
+    theme: knownTheme(p.theme),
+    font: knownFont(p.font),
+    contextRow: p.contextRow === true,
+    activeId: typeof p.activeId === "string" ? p.activeId : null,
+  }
+}
+
+export function savePrefs(p: Prefs) {
+  writeJSON(PREFS_KEY, p)
+}
+
+/**
+ * squig used to keep a single autosaved document. Move it into the drawer as
+ * a real file the first time we see it, so nobody's canvas disappears.
+ */
+export function migrateLegacyDoc(newId: () => string): { doc: StoredDoc; prefs: Prefs } | null {
+  const old = readJSON(LEGACY_KEY) as
+    | { fileName?: string; nodes?: Record<string, SquigNode>; order?: string[]; theme?: ThemeName; font?: FontMode; contextRow?: boolean }
+    | null
+  if (!old || !old.nodes || !Array.isArray(old.order)) {
+    drop(LEGACY_KEY)
+    return null
+  }
+  const doc: StoredDoc = {
+    id: newId(),
+    name: old.fileName || "untitled scribbles",
+    nodes: old.nodes,
+    order: old.order,
+    updatedAt: Date.now(),
+  }
+  saveFile(doc)
+  const prefs: Prefs = {
+    theme: knownTheme(old.theme),
+    font: knownFont(old.font),
+    contextRow: old.contextRow === true,
+    activeId: doc.id,
+  }
+  savePrefs(prefs)
+  drop(LEGACY_KEY)
+  return { doc, prefs }
+}
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+/** "just now", "20m", "3h", "yesterday", "Mar 4" — short enough for a menu. */
+export function relativeTime(ts: number, now = Date.now()): string {
+  const d = now - ts
+  if (d < MINUTE) return "just now"
+  if (d < HOUR) return `${Math.floor(d / MINUTE)}m ago`
+  if (d < DAY) return `${Math.floor(d / HOUR)}h ago`
+  if (d < 2 * DAY) return "yesterday"
+  if (d < 7 * DAY) return `${Math.floor(d / DAY)}d ago`
+  return new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -17,8 +17,6 @@ export interface FileMeta {
   id: string
   name: string
   updatedAt: number
-  /** how many objects are on the canvas — shown as a hint, never trusted */
-  count: number
 }
 
 export interface StoredDoc {
@@ -101,7 +99,7 @@ export function readFile(id: string): StoredDoc | null {
  * forget the oldest documents — never the one in hand — and try again.
  */
 export function saveFile(doc: StoredDoc): FileMeta[] {
-  const meta: FileMeta = { id: doc.id, name: doc.name, updatedAt: doc.updatedAt, count: doc.order.length }
+  const meta: FileMeta = { id: doc.id, name: doc.name, updatedAt: doc.updatedAt }
   let index = [meta, ...listFiles().filter((f) => f.id !== doc.id)]
 
   // trim the tail first, so the common case never hits the quota at all

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -35,7 +35,8 @@ export interface Prefs {
   activeId: string | null
 }
 
-const INDEX_KEY = "squig:files:v1"
+/** exported so another tab writing the drawer can be noticed */
+export const INDEX_KEY = "squig:files:v1"
 const PREFS_KEY = "squig:prefs:v1"
 const LEGACY_KEY = "squig:doc:v1"
 const fileKey = (id: string) => `squig:file:${id}`

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -147,6 +147,13 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
+    title: "Files",
+    rows: [
+      { keys: ["mod+s"], label: "Save to this browser" },
+      { keys: ["mod+shift+s"], label: "Export a copy" },
+    ],
+  },
+  {
     title: "Everything else",
     rows: [
       { keys: ["mod+k", "mod+/"], label: "Search everything" },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -8,6 +8,7 @@ import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
 import { applyTheme, DEFAULT_FONT, DEFAULT_THEME, type FontMode, type ThemeName } from "./theme"
 import {
+  INDEX_KEY,
   deleteFile as dropFile,
   listFiles,
   loadPrefs,
@@ -219,9 +220,12 @@ function stepOrder(order: string[], ids: string[], dir: 1 | -1): string[] {
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null
+/** true between an edit and the write that records it */
+let dirty = false
 
 /** Every edit calls this; the drawer only gets written once the hand rests. */
 function scheduleSave(get: () => SquigState) {
+  dirty = true
   if (saveTimer) clearTimeout(saveTimer)
   saveTimer = setTimeout(() => flushSave(get), SAVE_DEBOUNCE_MS)
 }
@@ -229,6 +233,10 @@ function scheduleSave(get: () => SquigState) {
 /**
  * Write the current document to the drawer now. A blank canvas nobody has
  * touched stays out of the list — until `force`, which is a person asking.
+ *
+ * A canvas with nothing new on it writes nothing at all: a second tab may be
+ * holding a fresher copy of this same document, and an idle tab closing is no
+ * reason to hand it back an old one.
  */
 function flushSave(get: () => SquigState, force = false) {
   if (saveTimer) {
@@ -237,6 +245,7 @@ function flushSave(get: () => SquigState, force = false) {
   }
   const s = get()
   savePrefs({ theme: s.theme, font: s.font, contextRow: s.contextRow, activeId: s.docId })
+  if (!dirty && !force) return
   const known = s.files.some((f) => f.id === s.docId)
   if (!s.order.length && !known && !force) return
   const files = saveFile({
@@ -247,14 +256,18 @@ function flushSave(get: () => SquigState, force = false) {
     updatedAt: Date.now(),
   })
   useSquig.setState({ files })
+  dirty = false
 }
 
 let watching = false
 /**
  * A tab can close inside the debounce window. Catch it on the way out — and
  * on the way to the background, which is all iOS ever gives you.
+ *
+ * The same listener keeps an eye on the drawer itself, so a file made in
+ * another tab shows up in this one's recents without a reload.
  */
-function watchForExit(get: () => SquigState) {
+function watchWindow(get: () => SquigState) {
   if (watching || typeof window === "undefined") return
   watching = true
   const save = () => flushSave(get)
@@ -262,6 +275,9 @@ function watchForExit(get: () => SquigState) {
   window.addEventListener("pagehide", save)
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "hidden") save()
+  })
+  window.addEventListener("storage", (e) => {
+    if (e.key === INDEX_KEY) useSquig.setState({ files: listFiles() })
   })
 }
 
@@ -493,7 +509,9 @@ export const useSquig = create<SquigState>((set, get) => ({
       hydrated: true,
     })
     applyTheme(prefs.theme, prefs.font)
-    watchForExit(get)
+    // what we just read is, by definition, what the drawer already holds
+    dirty = false
+    watchWindow(get)
   },
 
   clearCanvas: () => {
@@ -777,6 +795,8 @@ export const useSquig = create<SquigState>((set, get) => ({
     // frame what's there, but never past life size — 400% on one small
     // rectangle tells you nothing about where you've landed
     if (doc.order.length) fitBox(set, doc.order.map((nid) => doc.nodes[nid]).filter(Boolean), 1)
+    // straight off the drawer, so there is nothing to write back yet
+    dirty = false
     flushSave(get)
   },
 
@@ -828,6 +848,11 @@ export const useSquig = create<SquigState>((set, get) => ({
         past: [],
         future: [],
       })
+      // an imported file was drawn wherever its author left it — go there,
+      // or the canvas looks empty when it isn't
+      const list = (doc.order as string[]).map((id: string) => doc.nodes[id]).filter(Boolean)
+      if (list.length) fitBox(set, list, 1)
+      else set({ viewport: { x: 0, y: 0, zoom: 1 } })
       scheduleSave(get)
       return true
     } catch {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,6 +7,16 @@ import { screenToWorld, unionBox } from "./types"
 import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
 import { applyTheme, DEFAULT_FONT, DEFAULT_THEME, type FontMode, type ThemeName } from "./theme"
+import {
+  deleteFile as dropFile,
+  listFiles,
+  loadPrefs,
+  migrateLegacyDoc,
+  readFile,
+  saveFile,
+  savePrefs,
+  type FileMeta,
+} from "./files"
 
 // ---------------------------------------------------------------------------
 // Store — flat node map + z-order, selection, viewport, tool, history.
@@ -27,7 +37,13 @@ export interface ContextMenuState {
 }
 
 interface SquigState {
+  /** which file in the drawer this canvas is — every doc has one */
+  docId: string
   fileName: string
+  /** the drawer, newest first; kept in state so menus re-render as it changes */
+  files: FileMeta[]
+  /** bumped by an explicit save, so the file name can say so out loud */
+  saveFlash: number
   nodes: Record<string, SquigNode>
   order: string[]
   selection: string[]
@@ -121,12 +137,17 @@ interface SquigState {
   insertComponent: (kind: string) => void
   alignSelected: (edge: "left" | "hcenter" | "right" | "top" | "vcenter" | "bottom") => void
   newFile: () => void
+  /** swap the canvas to another file in the drawer, saving this one first */
+  openFile: (id: string) => void
+  deleteFile: (id: string) => void
+  /** write to the drawer right now instead of waiting out the debounce */
+  saveNow: () => void
   serialize: () => string
   loadDoc: (json: string) => boolean
 }
 
-const STORAGE_KEY = "squig:doc:v1"
 const MAX_HISTORY = 100
+const SAVE_DEBOUNCE_MS = 400
 const MIN_ZOOM = 0.1
 const MAX_ZOOM = 4
 /** breathing room around a zoom-to-fit, in screen px */
@@ -164,14 +185,14 @@ function cloneNodes(list: SquigNode[], dx: number, dy: number): SquigNode[] {
 }
 
 /** Frame a set of nodes in the window, with a margin so nothing kisses an edge. */
-function fitBox(set: (partial: { viewport: Viewport }) => void, list: SquigNode[]) {
+function fitBox(set: (partial: { viewport: Viewport }) => void, list: SquigNode[], cap = MAX_ZOOM) {
   const box = unionBox(list)
   if (!box) return
   const vw = window.innerWidth
   const vh = window.innerHeight
   const bw = Math.max(box.maxX - box.minX, 1)
   const bh = Math.max(box.maxY - box.minY, 1)
-  const zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.min((vw - FIT_PADDING * 2) / bw, (vh - FIT_PADDING * 2) / bh)))
+  const zoom = Math.min(cap, Math.max(MIN_ZOOM, Math.min((vw - FIT_PADDING * 2) / bw, (vh - FIT_PADDING * 2) / bh)))
   set({
     viewport: {
       zoom,
@@ -198,20 +219,57 @@ function stepOrder(order: string[], ids: string[], dir: 1 | -1): string[] {
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+/** Every edit calls this; the drawer only gets written once the hand rests. */
 function scheduleSave(get: () => SquigState) {
   if (saveTimer) clearTimeout(saveTimer)
-  saveTimer = setTimeout(() => {
-    const { fileName, nodes, order, contextRow, theme, font } = get()
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ fileName, nodes, order, contextRow, theme, font }))
-    } catch {
-      // storage full or unavailable — squig shrugs
-    }
-  }, 400)
+  saveTimer = setTimeout(() => flushSave(get), SAVE_DEBOUNCE_MS)
+}
+
+/**
+ * Write the current document to the drawer now. A blank canvas nobody has
+ * touched stays out of the list — until `force`, which is a person asking.
+ */
+function flushSave(get: () => SquigState, force = false) {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+  }
+  const s = get()
+  savePrefs({ theme: s.theme, font: s.font, contextRow: s.contextRow, activeId: s.docId })
+  const known = s.files.some((f) => f.id === s.docId)
+  if (!s.order.length && !known && !force) return
+  const files = saveFile({
+    id: s.docId,
+    name: s.fileName,
+    nodes: s.nodes,
+    order: s.order,
+    updatedAt: Date.now(),
+  })
+  useSquig.setState({ files })
+}
+
+let watching = false
+/**
+ * A tab can close inside the debounce window. Catch it on the way out — and
+ * on the way to the background, which is all iOS ever gives you.
+ */
+function watchForExit(get: () => SquigState) {
+  if (watching || typeof window === "undefined") return
+  watching = true
+  const save = () => flushSave(get)
+  window.addEventListener("beforeunload", save)
+  window.addEventListener("pagehide", save)
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") save()
+  })
 }
 
 export const useSquig = create<SquigState>((set, get) => ({
+  docId: nanoid(8),
   fileName: "untitled scribbles",
+  files: [],
+  saveFlash: 0,
   nodes: {},
   order: [],
   selection: [],
@@ -416,29 +474,26 @@ export const useSquig = create<SquigState>((set, get) => ({
   },
 
   hydrate: () => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY)
-      if (raw) {
-        const doc = JSON.parse(raw)
-        const theme: ThemeName = doc.theme ?? DEFAULT_THEME
-        const font: FontMode = doc.font ?? DEFAULT_FONT
-        set({
-          fileName: doc.fileName ?? "untitled scribbles",
-          nodes: doc.nodes ?? {},
-          order: doc.order ?? [],
-          contextRow: doc.contextRow ?? false,
-          theme,
-          font,
-          hydrated: true,
-        })
-        applyTheme(theme, font)
-        return
-      }
-    } catch {
-      // corrupted doc — start fresh
-    }
-    applyTheme(get().theme, get().font)
-    set({ hydrated: true })
+    migrateLegacyDoc(() => nanoid(8))
+    const prefs = loadPrefs()
+    const files = listFiles()
+    // last file open wins; failing that, the most recent one we have
+    const wanted = prefs.activeId && files.some((f) => f.id === prefs.activeId) ? prefs.activeId : files[0]?.id
+    const doc = wanted ? readFile(wanted) : null
+
+    set({
+      docId: doc?.id ?? nanoid(8),
+      fileName: doc?.name ?? "untitled scribbles",
+      nodes: doc?.nodes ?? {},
+      order: doc?.order ?? [],
+      files,
+      contextRow: prefs.contextRow,
+      theme: prefs.theme,
+      font: prefs.font,
+      hydrated: true,
+    })
+    applyTheme(prefs.theme, prefs.font)
+    watchForExit(get)
   },
 
   clearCanvas: () => {
@@ -680,7 +735,10 @@ export const useSquig = create<SquigState>((set, get) => ({
   },
 
   newFile: () => {
+    // the file you were on keeps its place in the drawer — this is a new one
+    flushSave(get)
     set({
+      docId: nanoid(8),
       fileName: "untitled scribbles",
       nodes: {},
       order: [],
@@ -691,7 +749,60 @@ export const useSquig = create<SquigState>((set, get) => ({
       past: [],
       future: [],
     })
-    scheduleSave(get)
+    flushSave(get)
+  },
+
+  openFile: (id) => {
+    if (id === get().docId) return
+    flushSave(get)
+    const doc = readFile(id)
+    if (!doc) {
+      // the index knew about it but the document itself is gone
+      set({ files: dropFile(id) })
+      return
+    }
+    set({
+      docId: doc.id,
+      fileName: doc.name,
+      nodes: doc.nodes,
+      order: doc.order,
+      selection: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      renamingFile: false,
+      linkOpen: false,
+      panel: null,
+      past: [],
+      future: [],
+    })
+    // frame what's there, but never past life size — 400% on one small
+    // rectangle tells you nothing about where you've landed
+    if (doc.order.length) fitBox(set, doc.order.map((nid) => doc.nodes[nid]).filter(Boolean), 1)
+    flushSave(get)
+  },
+
+  deleteFile: (id) => {
+    const files = dropFile(id)
+    set({ files })
+    if (id !== get().docId) return
+    // The file you had open just went away. Let go of it before landing
+    // somewhere else, or the save on the way out would write it right back.
+    set({
+      docId: nanoid(8),
+      fileName: "untitled scribbles",
+      nodes: {},
+      order: [],
+      selection: [],
+      past: [],
+      future: [],
+    })
+    const next = files[0]?.id
+    if (next) get().openFile(next)
+    else get().newFile()
+  },
+
+  saveNow: () => {
+    flushSave(get, true)
+    set((s) => ({ saveFlash: s.saveFlash + 1 }))
   },
 
   serialize: () => {
@@ -703,7 +814,11 @@ export const useSquig = create<SquigState>((set, get) => ({
     try {
       const doc = JSON.parse(json)
       if (!doc || typeof doc !== "object" || !doc.nodes || !Array.isArray(doc.order)) return false
+      // an opened file joins the drawer as its own document, so importing
+      // never writes over whatever was on the canvas
+      flushSave(get)
       set({
+        docId: nanoid(8),
         fileName: typeof doc.fileName === "string" ? doc.fileName : "imported scribbles",
         nodes: doc.nodes,
         order: doc.order,


### PR DESCRIPTION
squig autosaved a single document, so **New file** — and importing a `.squig` — painted straight over whatever was on the canvas. This makes every document its own file in a local drawer.

## What changed

- **A file per document.** New file starts a new one; the last is still there. An imported `.squig` lands as its own file too.
- **Open recent** in the file menu: names, when each was last touched, a check on the one you're in. Delete takes two clicks (hover the trash, click, click again) and isn't offered for the open file.
- **⌘K knows your files** — search by name under a Recent section.
- **⌘S** writes immediately and the file name says *saved to this browser* for a moment. **⇧⌘S** exports a copy.
- Opening a file frames its contents, but never past 100%.

## How it's stored

`lib/files.ts` — an index (`squig:files:v1`) beside one key per document (`squig:file:<id>`), so the menu lists names without parsing every canvas. Theme, lettering and the active file moved out of the document into `squig:prefs:v1`.

Saves keep the 400ms debounce and now also flush on `beforeunload` / `pagehide` / tab-hidden, so closing mid-stroke costs nothing. When the browser is out of room, the drawer forgets its oldest documents rather than the one in hand, and never lists a document it couldn't write. It's still local only — clearing site data clears the lot, which is why Export is a keystroke away and the README says so.

The old `squig:doc:v1` autosave migrates into the drawer on first load. A stored palette name that no longer exists now falls back to the default instead of white-screening the app (found while testing the migration).

## Verified in the running app

Migration from the old key; autosave and reload; switching files from the menu and from ⌘K; New file leaving the previous one intact; two-step delete leaving no orphaned document; ⌘S flash; a deliberately filled localStorage quota (no crash, both documents survived). `pnpm build`, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)