### PR TITLE
Drag components and blocks out of the panel onto the canvas

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -184,6 +184,7 @@ export function Canvas() {
   const tool = useSquig((s) => s.tool)
 
   const placing = useSquig((s) => s.placing)
+  const placingDrag = useSquig((s) => s.placingDrag)
   const editingId = useSquig((s) => s.editingId)
 
   /** marquee box in WORLD units — screen conversion happens at render time */
@@ -221,6 +222,26 @@ export function Canvas() {
       return pickAt(s.nodes, s.order, wx, wy, s.viewport.zoom)
     },
     [st, toWorld]
+  )
+
+  // -- library placement ----------------------------------------------------
+
+  /** drop a pending library item centred on a world point */
+  const dropComponent = useCallback(
+    (kind: string, wx: number, wy: number) => {
+      const def = getDef(kind)
+      if (!def) return
+      st().addNode({
+        type: "component",
+        kind: def.kind,
+        props: { ...def.defaults },
+        x: wx - def.size.w / 2,
+        y: wy - def.size.h / 2,
+        w: def.size.w,
+        h: def.size.h,
+      } as Omit<SquigNode, "id" | "seed">)
+    },
+    [st]
   )
 
   // -- wheel: pan / pinch-zoom ---------------------------------------------
@@ -824,18 +845,7 @@ export function Canvas() {
 
       // placing a component from the library
       if (s.placing) {
-        const def = getDef(s.placing)
-        if (def) {
-          s.addNode({
-            type: "component",
-            kind: def.kind,
-            props: { ...def.defaults },
-            x: wx - def.size.w / 2,
-            y: wy - def.size.h / 2,
-            w: def.size.w,
-            h: def.size.h,
-          } as Omit<SquigNode, "id" | "seed">)
-        }
+        dropComponent(s.placing, wx, wy)
         s.setPlacing(null)
         s.setPanel(null)
         return
@@ -916,7 +926,7 @@ export function Canvas() {
       // empty canvas — marquee, with the current selection as its base
       beginGesture({ kind: "marquee", ...common, wx, wy, base: s.selection }, e)
     },
-    [st, tool, isSpacebarHeld, toWorld, beginGesture]
+    [st, tool, isSpacebarHeld, toWorld, beginGesture, dropComponent]
   )
 
   const onDoubleClick = useCallback(
@@ -965,10 +975,8 @@ export function Canvas() {
     (e: React.PointerEvent) => {
       const s = st()
       pointerWorld.current = toWorld(e)
-      if (s.placing) {
-        setCursor(pointerWorld.current)
-        return
-      }
+      // the ghost is driven at the window level instead — see below
+      if (s.placing) return
       if (gestureRef.current || s.tool !== "select" || isSpacebarHeld || s.editingId) {
         if (hoverId) setHoverId(null)
         return
@@ -986,6 +994,51 @@ export function Canvas() {
   )
 
   const onPointerLeave = useCallback(() => setHoverId(null), [])
+
+  /**
+   * The placement ghost tracks the pointer on `window`, not on the canvas, so a
+   * press that started inside the library panel is already being followed by the
+   * time it crosses onto the canvas. Same preview either way: pick-then-click and
+   * drag-out are the same pending placement, just ended differently.
+   */
+  useEffect(() => {
+    if (!placing) return
+    const onMove = (e: PointerEvent) => setCursor(toWorld(e))
+    window.addEventListener("pointermove", onMove)
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      // drop the stale position with the placement, so the next pick doesn't
+      // flash its ghost wherever the last one was
+      setCursor(null)
+    }
+  }, [placing, toWorld])
+
+  /**
+   * A library item dragged out of the panel lands where the pointer is released.
+   * The press began in the panel, so the canvas never sees a pointerdown for it —
+   * this listener is the whole gesture's ending.
+   */
+  useEffect(() => {
+    if (!placingDrag) return
+    const ac = new AbortController()
+    const finish = (e: PointerEvent) => {
+      const s = st()
+      const kind = s.placing
+      s.setPlacing(null)
+      if (!kind || e.type !== "pointerup") return
+      // released over the rail, the panel, the context row or any other chrome —
+      // nothing lands. The context row floats *inside* the canvas, so being
+      // inside the container isn't enough on its own.
+      const el = containerRef.current
+      const under = document.elementFromPoint(e.clientX, e.clientY)
+      if (!el || !under || !el.contains(under) || under.closest("[data-squig-chrome]")) return
+      const [wx, wy] = toWorld(e)
+      dropComponent(kind, wx, wy)
+    }
+    window.addEventListener("pointerup", finish, { signal: ac.signal })
+    window.addEventListener("pointercancel", finish, { signal: ac.signal })
+    return () => ac.abort()
+  }, [placingDrag, st, toWorld, dropComponent])
 
   useEffect(
     () => () => {

--- a/components/chrome/library-panel.tsx
+++ b/components/chrome/library-panel.tsx
@@ -2,7 +2,8 @@
 
 // ---------------------------------------------------------------------------
 // Library panel — floats next to the rail. Search on top, grouped two-column
-// grid of live sketch previews. Pick one, then click the canvas to drop it.
+// grid of live sketch previews. Pick one, then click the canvas to drop it —
+// or drag one straight out of the grid and let go where you want it.
 // ---------------------------------------------------------------------------
 
 import { useEffect, useMemo, useRef, useState } from "react"
@@ -16,16 +17,76 @@ import { MagnifyingGlassIcon } from "@phosphor-icons/react"
 
 const BOX_W = 118
 const BOX_H = 82
+/** screen px of travel before a press on a preview stops being a click */
+const DRAG_THRESHOLD = 4
 
-function Preview({ def, active, onPick }: { def: ComponentDef; active: boolean; onPick: () => void }) {
+function Preview({
+  def,
+  active,
+  onPick,
+  onDragOut,
+}: {
+  def: ComponentDef
+  active: boolean
+  onPick: () => void
+  onDragOut: () => void
+}) {
   const prims = useMemo(() => def.render(def.defaults, def.size.w, def.size.h), [def])
   const scale = Math.min((BOX_W - 14) / def.size.w, (BOX_H - 14) / def.size.h, 1)
   const ox = (BOX_W - def.size.w * scale) / 2
   const oy = (BOX_H - def.size.h * scale) / 2
+  /** this press turned into a drag, so the click it ends with isn't a pick */
+  const dragged = useRef(false)
+
+  /**
+   * Drag out of the panel: past the threshold this becomes a pending placement,
+   * and the canvas takes it from there — it draws the ghost and does the drop on
+   * pointer up. Nothing happens until the threshold, so a plain click still just
+   * picks the component the way it always did.
+   */
+  const onPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (e.button !== 0 || !e.isPrimary) return
+    const el = e.currentTarget
+    const { pointerId } = e
+    const sx = e.clientX
+    const sy = e.clientY
+    dragged.current = false
+    const ac = new AbortController()
+    const stop = () => {
+      ac.abort()
+      // click fires before timers, so the guard below still sees the drag
+      setTimeout(() => (dragged.current = false), 0)
+    }
+    window.addEventListener(
+      "pointermove",
+      (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId || dragged.current) return
+        if (Math.hypot(ev.clientX - sx, ev.clientY - sy) < DRAG_THRESHOLD) return
+        dragged.current = true
+        // keep the events coming once the pointer leaves the button. Capture is
+        // a nicety, not the mechanism — the listeners are on window either way,
+        // so a pointer that's already gone must not take the drag down with it.
+        try {
+          el.setPointerCapture(pointerId)
+        } catch {
+          // no live pointer to capture — carry on
+        }
+        onDragOut()
+      },
+      { signal: ac.signal }
+    )
+    window.addEventListener("pointerup", stop, { signal: ac.signal })
+    window.addEventListener("pointercancel", stop, { signal: ac.signal })
+  }
+
   return (
     <button
       type="button"
-      onClick={onPick}
+      onPointerDown={onPointerDown}
+      onClick={() => {
+        if (dragged.current) return
+        onPick()
+      }}
       title={def.name}
       className={cn(
         "group flex flex-col items-center gap-1 rounded-lg border p-1 transition-colors hover:border-foreground/40 hover:bg-accent",
@@ -56,6 +117,7 @@ export function LibraryPanel() {
 
 function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
   const placing = useSquig((s) => s.placing)
+  const placingDrag = useSquig((s) => s.placingDrag)
   const st = useSquig.getState
   const [query, setQuery] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
@@ -108,6 +170,7 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
                     def={def}
                     active={placing === def.kind}
                     onPick={() => st().setPlacing(placing === def.kind ? null : def.kind)}
+                    onDragOut={() => st().setPlacing(def.kind, { drag: true })}
                   />
                 ))}
               </div>
@@ -122,7 +185,11 @@ function Panel({ panel }: { panel: Exclude<PanelKind, null> }) {
       </ScrollArea>
 
       <div className="shrink-0 border-t px-3 py-2 text-xs text-muted-foreground">
-        {placing ? "now click the canvas to drop it" : `${total} to choose from — ⌘K searches everything`}
+        {placingDrag
+          ? "let go where you want it"
+          : placing
+            ? "now click the canvas to drop it"
+            : `${total} to choose from — click one or drag it out`}
       </div>
     </div>
   )

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -43,6 +43,9 @@ interface SquigState {
   panel: PanelKind
   /** component kind waiting to be placed on next canvas click */
   placing: string | null
+  /** the pending placement came out of a library drag, so it lands on pointer up
+   *  rather than on the next click */
+  placingDrag: boolean
   editingId: string | null
   contextRow: boolean
   theme: ThemeName
@@ -69,7 +72,7 @@ interface SquigState {
   setTool: (t: Tool) => void
   setShapeKind: (s: ShapeKind) => void
   setPanel: (p: PanelKind) => void
-  setPlacing: (kind: string | null) => void
+  setPlacing: (kind: string | null, opts?: { drag?: boolean }) => void
   setEditing: (id: string | null) => void
   setContextRow: (on: boolean) => void
   setTheme: (t: ThemeName) => void
@@ -276,6 +279,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   shapeKind: "rect",
   panel: null,
   placing: null,
+  placingDrag: false,
   editingId: null,
   contextRow: false,
   theme: DEFAULT_THEME,
@@ -296,10 +300,10 @@ export const useSquig = create<SquigState>((set, get) => ({
     set({ fileName: n })
     scheduleSave(get)
   },
-  setTool: (t) => set({ tool: t, placing: null, panel: null }),
+  setTool: (t) => set({ tool: t, placing: null, placingDrag: false, panel: null }),
   setShapeKind: (s) => set({ shapeKind: s }),
-  setPanel: (p) => set((st) => ({ panel: st.panel === p ? null : p, placing: null })),
-  setPlacing: (kind) => set({ placing: kind }),
+  setPanel: (p) => set((st) => ({ panel: st.panel === p ? null : p, placing: null, placingDrag: false })),
+  setPlacing: (kind, opts) => set({ placing: kind, placingDrag: kind !== null && opts?.drag === true }),
   setEditing: (id) => set({ editingId: id }),
   setContextRow: (on) => {
     set({ contextRow: on })


### PR DESCRIPTION
Press a preview in the library panel and drag: past a 4px threshold it becomes a pending placement — the exact same one a click makes — so the canvas draws the same translucent ghost, and the item lands centred where you let go.

The press starts inside the panel, so the canvas never sees a pointerdown for it. Two changes cover that:

- the placement ghost now tracks the pointer on `window` instead of on the canvas element, so a drag is being followed from the moment it crosses onto the canvas
- a `window` pointerup finishes the gesture and does the drop

`placingDrag` in the store is what tells the two apart: a picked-by-click placement still waits for a canvas click, a dragged one lands on release.

Details worth knowing:

- releasing over the rail, the panel or the context row places nothing and clears the pending placement — the context row floats *inside* the canvas container, so containment alone isn't enough and the drop also rejects anything under `[data-squig-chrome]`
- a plain click still just picks, unchanged; the click that ends a drag is swallowed so it can't toggle the pick straight back off
- after a drag-drop the panel stays open (you dragged out of it, so it isn't in your way), while click-to-place still closes it as before
- Escape mid-drag cancels, same as it cancels a pick
- the panel footer now reads "let go where you want it" during a drag, and advertises the affordance when idle

Verified in the running app: real mouse drag from the panel to the canvas lands the component centred on the release point; the ghost renders mid-drag; release back over the panel places nothing; click-then-click-canvas still works; a short drag that ends on the same tile leaves nothing pending. `tsc --noEmit` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)