### PR TITLE
Fix the text tool: keep the editor focused when a text node is placed

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -862,6 +862,10 @@ export function Canvas() {
         return
       }
       if (tool === "text") {
+        // the editor mounts and focuses inside this handler, so the compat
+        // mousedown that follows would hand focus straight back to the canvas —
+        // blurring the editor into a commit that deletes the still-empty node
+        e.preventDefault()
         const id = s.addNode({
           type: "text",
           text: "",

--- a/components/canvas/text-edit-overlay.tsx
+++ b/components/canvas/text-edit-overlay.tsx
@@ -92,9 +92,19 @@ function Editor({ node }: { node: SquigNode }) {
     commitRef.current = commit
   })
 
+  // the press that opens the editor is still unwinding while we mount, and its
+  // default action puts focus back on the canvas. Blurs before the editor has
+  // settled are that, not the user leaving — committing on one would delete a
+  // text node the instant it was placed.
+  const settled = useRef(false)
+
   useEffect(() => {
     taRef.current?.focus()
     taRef.current?.select()
+    const raf = requestAnimationFrame(() => {
+      settled.current = true
+    })
+    return () => cancelAnimationFrame(raf)
   }, [])
 
   useEffect(() => {
@@ -117,7 +127,13 @@ function Editor({ node }: { node: SquigNode }) {
       ref={taRef}
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      onBlur={commit}
+      onBlur={() => {
+        if (!settled.current) {
+          requestAnimationFrame(() => taRef.current?.focus())
+          return
+        }
+        commit()
+      }}
       onKeyDown={(e) => {
         e.stopPropagation()
         if (e.key === "Escape") {


### PR DESCRIPTION
## The bug

Pick the text tool, click the canvas — nothing appears and the select tool
quietly takes over again.

## Why

`onPointerDown` creates the text node and mounts the inline editor, which
focuses itself synchronously. The compatibility `mousedown` that follows the
same press then runs its default action and moves focus back to the focusable
canvas container. The textarea blurs, blur commits, and committing an untouched
node means "empty text" — so the node is removed the moment it is placed.

Confirmed in the browser by logging the event order:

```
pointerdown -> DIV
focusin  -> TEXTAREA   (editor mounts and focuses)
mousedown -> DIV
focusout -> TEXTAREA   (browser default steals focus)
textarea REMOVED       (blur -> commit -> empty -> delete)
```

## The fix

- Cancel the pointerdown in the text branch, so no compat mousedown fires and
  nothing steals focus.
- Belt and braces in the editor: ignore blurs until a frame after mount and
  refocus instead, so any other open-time focus steal can't commit a brand-new
  node out of existence.

## Verified in the running app

- Text tool + click: editor opens, stays focused, typing works, ⌘Enter commits.
- `t` shortcut + click: same.
- Click away while editing: commits the text instead of losing it.
- Escape on a fresh node: removes the empty node, no orphan left behind.
- Double-click an existing text node: re-edits, keeps focus; Escape leaves the
  original text intact.
- Shape tool drag still behaves.
- `next build` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)