### PR TITLE
Make hollow shapes and resize handles easier to hit

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -1513,6 +1513,47 @@ export function Canvas() {
 /** roughly three handles' worth of box, below which they'd overlap into mush */
 const HANDLE_ROOM = 34
 
+/** the white square you actually see, in screen px */
+const HANDLE_DOT = 10
+
+/**
+ * How far past the selection box a handle still answers to the pointer.
+ *
+ * Nothing else is grabbable out there, so the handles may as well be greedy
+ * in that direction — aiming at a 10px square is the whole problem.
+ */
+const GRAB_OUT = 8
+
+/** and how far inward, at most — see `grabPad` for why it's a maximum */
+const GRAB_IN = 8
+
+/**
+ * Inward slop along one axis, in screen px.
+ *
+ * Reaching inward is where handles compete with each other, so the pad shrinks
+ * on small boxes: `crowded` says a third handle sits halfway along this axis,
+ * which halves the room each one gets. Without this a 40px box would resize
+ * from its middle handle when you aimed at its corner.
+ */
+function grabPad(len: number, crowded: boolean): number {
+  const room = (crowded ? len / 4 : len / 2) - HANDLE_DOT / 2
+  return Math.max(0, Math.min(GRAB_IN, room))
+}
+
+/** The handle's hit rect and the offset of its dot inside it, in screen px. */
+function handleHitBox(hd: Handle, w: number, h: number, padX: number, padY: number) {
+  const [hx, hy] = handleOffset(hd, w, h)
+  const r = HANDLE_DOT / 2
+  const span = (edgeLow: boolean, edgeHigh: boolean, pad: number): [number, number] => {
+    const lo = -r - (edgeLow ? GRAB_OUT : pad)
+    const hi = r + (edgeHigh ? GRAB_OUT : pad)
+    return [lo, hi - lo]
+  }
+  const [dx, width] = span(hd.includes("w"), hd.includes("e"), padX)
+  const [dy, height] = span(hd.includes("n"), hd.includes("s"), padY)
+  return { left: hx + dx, top: hy + dy, width, height, dotLeft: -dx - r, dotTop: -dy - r }
+}
+
 function SelectionOverlay({
   selectedNodes,
   viewport,
@@ -1550,6 +1591,10 @@ function SelectionOverlay({
     return true
   }
 
+  // the n/s handles are the ones that crowd the x axis, and e/w the y axis
+  const padX = grabPad(w, showWide)
+  const padY = grabPad(h, showTall)
+
   return (
     <>
       {/* each member gets a hairline, so you can see exactly what's in the set */}
@@ -1572,22 +1617,41 @@ function SelectionOverlay({
         <div className="pointer-events-none absolute" style={{ left, top, width: w, height: h }}>
           <div className="absolute inset-0 rounded-sm" style={{ border: "2px solid var(--sq-select)" }} />
           {showHandles &&
-            HANDLES.filter(visible).map((hd) => {
-              const [hx, hy] = handleOffset(hd, w, h)
-              return (
-                <div
-                  key={hd}
-                  className="pointer-events-auto absolute h-2.5 w-2.5 rounded-[3px] bg-white"
-                  style={{
-                    left: hx - 5,
-                    top: hy - 5,
-                    cursor: HANDLE_CURSORS[hd],
-                    border: "2px solid var(--sq-select)",
-                  }}
-                  onPointerDown={(e) => onStartResize(hd, e)}
-                />
-              )
-            })}
+            // Corners last, so they sit on top: their pads can meet a side's on
+            // a tight box, and a mis-grab costs more on a corner than a side.
+            // Ordering does it — a z-index here would also lift the handles
+            // over the panels that come after the canvas.
+            HANDLES.filter(visible)
+              .slice()
+              .sort((a, b) => a.length - b.length)
+              .map((hd) => {
+                const box = handleHitBox(hd, w, h, padX, padY)
+                return (
+                  <div
+                    key={hd}
+                    className="pointer-events-auto absolute"
+                    style={{
+                      left: box.left,
+                      top: box.top,
+                      width: box.width,
+                      height: box.height,
+                      cursor: HANDLE_CURSORS[hd],
+                    }}
+                    onPointerDown={(e) => onStartResize(hd, e)}
+                  >
+                    <div
+                      className="pointer-events-none absolute rounded-[3px] bg-white"
+                      style={{
+                        left: box.dotLeft,
+                        top: box.dotTop,
+                        width: HANDLE_DOT,
+                        height: HANDLE_DOT,
+                        border: "2px solid var(--sq-select)",
+                      }}
+                    />
+                  </div>
+                )
+              })}
         </div>
       )}
     </>

--- a/lib/canvas/hit-test.ts
+++ b/lib/canvas/hit-test.ts
@@ -12,22 +12,32 @@ import { normalizeFill, type SquigNode } from "../types"
 import type { Bounds } from "../selection"
 
 /**
- * Forgiveness, in world units, for a pointer aimed at a stroke.
+ * How far off a stroke the pointer may be and still count, in screen px.
  *
- * It scales with zoom so it stays ~4 screen px, but it can't grow without
- * bound: at 0.1 zoom an unclamped halo would be 40 world units, wide enough
- * that every node's collar overlaps its neighbour's and no gap is left to
- * start a marquee from.
+ * A 1px outline is not a target anyone can aim at, so the collar does the
+ * aiming for you. 8px is about a fingertip's worth of slop at 1:1 and matches
+ * what other design tools give you.
  */
+const SLOP_PX = 8
+
+/**
+ * The collar can't grow without bound as you zoom out: at 0.1 zoom an
+ * unclamped 8px halo would be 80 world units, wide enough that every node's
+ * collar overlaps its neighbour's and no gap is left to start a marquee from.
+ */
+const MAX_SLOP_WORLD = 14
+
+/** Forgiveness, in world units, for a pointer aimed at a stroke. */
 export function pickTolerance(zoom: number, n?: SquigNode): number {
-  const base = Math.min(4 / Math.max(zoom, 0.01), 8)
+  const base = Math.min(SLOP_PX / Math.max(zoom, 0.01), MAX_SLOP_WORLD)
   if (!n) return base
   // Lines are thin on purpose. A horizontal arrow is ~2 units tall, and
   // shrinking its collar to match would leave a 2px-tall target you can
   // basically never hit — the collar exists precisely for this case.
   if (n.type === "arrow" || n.type === "draw") return base
-  // for areas, never let the collar swallow the node it belongs to
-  return Math.min(base, Math.max(1, 0.25 * Math.min(n.w, n.h)))
+  // For areas, never let the collar swallow the node it belongs to: a hollow
+  // shape has to keep a see-through core, or you can't marquee inside it.
+  return Math.min(base, Math.max(1, 0.35 * Math.min(n.w, n.h)))
 }
 
 function inBox(x: number, y: number, b: Bounds, tol: number): boolean {
@@ -131,12 +141,18 @@ export function hitsPoint(n: SquigNode, x: number, y: number, zoom: number): boo
     const rx = n.w / 2
     const ry = n.h / 2
     if (rx <= 0 || ry <= 0) return true
-    const nx = (x - (n.x + rx)) / rx
-    const ny = (y - (n.y + ry)) / ry
+    const cx = n.x + rx
+    const cy = n.y + ry
+    const nx = (x - cx) / rx
+    const ny = (y - cy) / ry
     const r = Math.hypot(nx, ny)
-    // tolerance expressed in the normalised space of the smaller radius
-    const band = tol / Math.max(1e-6, Math.min(rx, ry))
-    return Math.abs(r - 1) <= band
+    // dead centre of a squashed ellipse: nearest ink is the short radius away
+    if (r < 1e-6) return Math.min(rx, ry) <= tol
+    // Project onto the ring along the ray from the centre and measure in world
+    // units. Measuring in normalised units instead would stretch the collar by
+    // rx/ry, so a 400×40 ellipse would answer to clicks 80 units off its end.
+    const d = Math.hypot((x - cx) * (1 - 1 / r), (y - cy) * (1 - 1 / r))
+    return d <= tol
   }
 
   // unfilled rect — the outline is the target, the middle is see-through

--- a/scripts/test-geometry.ts
+++ b/scripts/test-geometry.ts
@@ -25,7 +25,7 @@ function close(a: number, b: number, eps = 1e-6) {
 
 // -- fixtures ---------------------------------------------------------------
 
-const rect = (id: string, x: number, y: number, w: number, h: number, fill = false): SquigNode => ({
+const rect = (id: string, x: number, y: number, w: number, h: number, filled = false): SquigNode => ({
   id,
   type: "shape",
   shape: "rect",
@@ -33,7 +33,19 @@ const rect = (id: string, x: number, y: number, w: number, h: number, fill = fal
   y,
   w,
   h,
-  fill,
+  fill: filled ? "strong" : "none",
+  seed: 1,
+})
+
+const ellipse = (id: string, x: number, y: number, w: number, h: number): SquigNode => ({
+  id,
+  type: "shape",
+  shape: "ellipse",
+  x,
+  y,
+  w,
+  h,
+  fill: "none",
   seed: 1,
 })
 
@@ -204,6 +216,33 @@ const apply = (ns: SquigNode[], patches: Record<string, Partial<SquigNode>>): Sq
   )
   check("a marquee crossing its outline does grab it", hitsRect(hollow, { x: -10, y: 100, w: 50, h: 50 }, 1))
   check("a marquee inside a filled rect grabs it", hitsRect(solid, { x: 100, y: 100, w: 50, h: 50 }, 1))
+}
+
+{
+  // the thing this whole collar exists for: aiming at a 1px outline
+  const hollow = rect("hollow", 0, 0, 400, 300)
+  check("an unfilled rect answers to a click just outside its edge", hitsPoint(hollow, -6, 150, 1))
+  check("and to one just inside", hitsPoint(hollow, 6, 150, 1))
+  check("but the middle is still see-through", !hitsPoint(hollow, 40, 150, 1))
+
+  // a small shape keeps a see-through core rather than going solid
+  const small = rect("small", 0, 0, 30, 30)
+  check("a small unfilled rect still has a transparent middle", !hitsPoint(small, 15, 15, 1))
+}
+
+{
+  const ring = ellipse("ring", 0, 0, 200, 200)
+  check("an ellipse is grabbable a few px off its ring", hitsPoint(ring, 100, 6, 1))
+  check("an ellipse is hollow in the middle", !hitsPoint(ring, 100, 100, 1))
+  check("the corner of an ellipse's box is empty", !hitsPoint(ring, 4, 4, 1))
+
+  // the collar is measured in world units, not in the ellipse's own squashed
+  // space — otherwise a wide, flat ellipse answers to clicks a long way past
+  // the end of its major axis
+  const flat = ellipse("flat", 0, 0, 400, 40)
+  check("a squashed ellipse is grabbable at the end of its major axis", hitsPoint(flat, 398, 20, 1))
+  check("but not far past it", !hitsPoint(flat, 460, 20, 1))
+  check("its flat side is grabbable too", hitsPoint(flat, 200, 44, 1))
 }
 
 {

--- a/scripts/test-selection.ts
+++ b/scripts/test-selection.ts
@@ -47,7 +47,7 @@ const rect = (id: string, x = 0, y = 0, w = 10, h = 10): SquigNode => ({
   y,
   w,
   h,
-  fill: false,
+  fill: "none",
   seed: 1,
 })
 


### PR DESCRIPTION
Selecting an unfilled rect or circle meant landing on a 1px outline, and grabbing a resize handle meant landing on a 10px square.

**Pick collar: 4 → 8 screen px.** An outline answers to a click about a fingertip either side of it. The see-through core of a hollow shape survives, so you can still marquee inside a big empty box; small shapes keep a transparent middle by capping the collar at 35% of the shorter side.

**Handles get a transparent hit box around the dot they draw** — 26×26 instead of 10×10 on a normal selection. 8px past the selection box, where nothing else is grabbable, and up to 8px inward. The inward pad shrinks on tight boxes so a corner and the side handle beside it never fight over the same pixels (at 34px wide they meet exactly and stop; measured 0px overlap on a 45px box). Corners render last so they win any contact. **The dots look identical.**

**Ellipse fix, found while testing:** its collar was measured in the ellipse's own squashed space, which stretched it by `rx/ry` — a 400×40 ellipse answered to clicks 80 units past the end of its major axis but only 4 off its flat side. It now projects onto the ring and measures in world units, so the collar is 8px the whole way around.

Also: the two test fixtures still wrote `fill: false`, which stopped typechecking when `fill` became `FillTone`. `pnpm test` runs green again on this branch.

## Verified

`pnpm test` — 47 geometry + 21 selection checks pass (10 new). Driven in the running app at 100% zoom:

- unfilled rect selected from 7px outside its edge
- SE handle grabbed ~5px inside the corner, outside the old dot: W/H changed, X/Y did not (resize, not a move)
- same on a 45px box, where the pad is clamped: still a resize, and the 8 hit boxes tile with zero overlap
- flat ellipse: selects 5px past its tip and 6px off its flat side, does not select 24px past the tip
- hollow centre still clicks through to the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)