### PR TITLE
Reframe the copy around ideas, not ugliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ hand-drawing every button from scratch. squig sits in between: an infinite
 canvas where you drag in real UI components, but everything renders as a
 hand-drawn sketch.
 
-The sketchy look is the whole point. It signals "this is not decided yet," so
-people give feedback on structure instead of arguing about corner radius.
+The sketchy look is the whole point. It's a napkin, not a mockup — nothing
+looks decided, so people give feedback on the idea instead of the corner
+radius, and you can try a layout three ways in the time one polished version
+takes.
 
 ## What's in it
 

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -1498,9 +1498,9 @@ export function Canvas() {
       {order.length === 0 && !placing && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <p className="max-w-xs -rotate-2 text-center text-xl" style={{ color: "var(--sq-muted)", fontFamily: "var(--sq-font)" }}>
-            draw something ugly.
+            draw the idea.
             <br />
-            that&apos;s the point.
+            the pixels can wait.
           </p>
         </div>
       )}

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -128,7 +128,7 @@ function EmptyState() {
     <>
       <div className="border-b border-border/60 p-gutter">
         <PanelNote>
-          drop a component, scribble a shape, make a mess. it&apos;s a wireframe, not the Sistine Chapel.
+          drop a component, scribble a shape, try it three ways. it&apos;s a wireframe, not the Sistine Chapel.
         </PanelNote>
       </div>
       <PanelSection id="settings" title="Settings">

--- a/lib/library/defs-blocks-marketing.ts
+++ b/lib/library/defs-blocks-marketing.ts
@@ -359,8 +359,8 @@ export const ctaBlockDef: ComponentDef = {
   size: { w: 760, h: 210 },
   defaults: {
     variant: "centered",
-    headline: "Ready to make a mess?",
-    subline: "Ten seconds to your first ugly rectangle.",
+    headline: "Got an idea?",
+    subline: "Ten seconds from blank canvas to first draft.",
     buttons: 2,
   },
   controls: [
@@ -373,8 +373,8 @@ export const ctaBlockDef: ComponentDef = {
     const prims: Prim[] = []
     const variant = str(p, "variant", "centered")
     const nBtn = int(p, "buttons", 2, 1, 2)
-    const heading = str(p, "headline", "Ready to make a mess?")
-    const subline = str(p, "subline", "Ten seconds to your first ugly rectangle.")
+    const heading = str(p, "headline", "Got an idea?")
+    const subline = str(p, "subline", "Ten seconds from blank canvas to first draft.")
     const l1 = "Start free"
     const l2 = "Talk to a human"
     const boxed = variant === "boxed"


### PR DESCRIPTION
\"draw something ugly, that's the point\" said the wrong thing. The point was never ugliness — it's that a wireframe is a napkin: get the idea down, try it three ways, don't spend the afternoon on fidelity you're going to throw away.

Four places carried the old framing:

- **Empty canvas nudge** — \"draw something ugly. / that's the point.\" → \"draw the idea. / the pixels can wait.\"
- **Inspector empty state** — \"make a mess\" → \"try it three ways\" (the Sistine Chapel line stays; it's about fidelity, not ugliness)
- **CTA block placeholders** — \"Ready to make a mess?\" / \"Ten seconds to your first ugly rectangle.\" → \"Got an idea?\" / \"Ten seconds from blank canvas to first draft.\"
- **README** — the \"why sketchy\" paragraph, rewritten around the napkin and trying a layout three ways

The page metadata already had it right (\"sketched them on a napkin. Argue about structure, not corner radius.\") and is left alone.

Copy only — no behavior change. Typecheck clean; all three UI strings verified rendering in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)