### PR TITLE
Reword the empty-canvas nudge

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -1498,9 +1498,9 @@ export function Canvas() {
       {order.length === 0 && !placing && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <p className="max-w-xs -rotate-2 text-center text-xl" style={{ color: "var(--sq-muted)", fontFamily: "var(--sq-font)" }}>
-            draw the idea.
+            draw the idea
             <br />
-            the pixels can wait.
+            before shipping the code.
           </p>
         </div>
       )}


### PR DESCRIPTION
Follow-up to #18. The empty-canvas nudge goes from:

> draw the idea.
> the pixels can wait.

to:

> draw the idea
> before shipping the code.

\"the pixels can wait\" was vague about what you're waiting on; this names it — the sketch comes before the build.

Copy only, one string. Verified rendering on a fresh canvas in the running app; it breaks at the intended line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)