### PR TITLE
Show page options where the inspector used to say "nothing selected"

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,7 @@
   --font-mono: var(--font-geist-mono);
   --font-heading: var(--font-sans);
   --font-sketch: var(--font-sketch), "Patrick Hand", "Comic Sans MS", cursive;
+  --font-serif: var(--font-serif), "Source Serif 4", ui-serif, Georgia, serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Patrick_Hand } from "next/font/google";
+import { Geist, Patrick_Hand, Source_Serif_4 } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +10,13 @@ const geistSans = Geist({
 const patrickHand = Patrick_Hand({
   variable: "--font-sketch",
   weight: "400",
+  subsets: ["latin"],
+});
+
+// The canvas's serif — a text face rather than a display one, because it has to
+// hold up at 12px inside a wireframe's caption, not just in a headline.
+const sourceSerif = Source_Serif_4({
+  variable: "--font-serif",
   subsets: ["latin"],
 });
 
@@ -25,7 +32,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${patrickHand.variable} h-full antialiased`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${patrickHand.variable} ${sourceSerif.variable} h-full antialiased`}
+    >
       <body className="h-full overflow-hidden">{children}</body>
     </html>
   );

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -183,6 +183,7 @@ export function Canvas() {
   const selection = useSquig((s) => s.selection)
   const viewport = useSquig((s) => s.viewport)
   const tool = useSquig((s) => s.tool)
+  const grid = useSquig((s) => s.grid)
 
   const placing = useSquig((s) => s.placing)
   const placingDrag = useSquig((s) => s.placingDrag)
@@ -1392,7 +1393,7 @@ export function Canvas() {
       style={{
         cursor: cursorStyle,
         backgroundColor: "var(--sq-bg)",
-        backgroundImage: "radial-gradient(circle, var(--sq-grid) 1px, transparent 1px)",
+        backgroundImage: grid ? "radial-gradient(circle, var(--sq-grid) 1px, transparent 1px)" : "none",
         backgroundSize: `${24 * v.zoom}px ${24 * v.zoom}px`,
         backgroundPosition: `${v.x}px ${v.y}px`,
       }}

--- a/components/chrome/ink-picker.tsx
+++ b/components/chrome/ink-picker.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// Ink — the palette picker, and the two-tone chip that stands for a palette.
+//
+// A palette is one saturated ink on one sheet of paper, so the chip is exactly
+// that: paper on one diagonal, ink on the other. The same chip serves the
+// closed control and the rows inside it — words alone ("Riso red") would make
+// you imagine the colour instead of seeing it.
+// ---------------------------------------------------------------------------
+
+import { useSquig } from "@/lib/store"
+import { THEMES, THEME_NAMES, type ThemeName } from "@/lib/theme"
+import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+/** Two-tone chip showing a palette's paper and ink. */
+function InkSwatch({ name }: { name: ThemeName }) {
+  const p = THEMES[name]
+  return (
+    <span
+      className="inline-block size-3.5 shrink-0 rounded-full border"
+      style={{ background: `linear-gradient(135deg, ${p.paper} 50%, ${p.ink} 50%)`, borderColor: p.ink }}
+    />
+  )
+}
+
+/** The palette rows. */
+function InkMenuItems() {
+  const theme = useSquig((s) => s.theme)
+  const st = useSquig.getState
+
+  return (
+    <>
+      {THEME_NAMES.map((name) => (
+        <DropdownMenuItem key={name} onClick={() => st().setTheme(name)}>
+          <span className="flex items-center gap-2">
+            <InkSwatch name={name} />
+            {THEMES[name].label}
+          </span>
+          {theme === name && <CheckIcon className="ml-auto size-3.5 text-muted-foreground" weight="bold" />}
+        </DropdownMenuItem>
+      ))}
+    </>
+  )
+}
+
+/**
+ * The panel's ink control: a field that shows the live colour and its name, and
+ * opens the list of palettes. Six is too many for a segmented track and too few
+ * to need searching, so it's a dropdown — and it wears the numeric field's shell
+ * so it lands on the panel's alignment seam like every other control.
+ */
+export function InkPicker() {
+  const theme = useSquig((s) => s.theme)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex h-ctl w-full min-w-0 items-center gap-2 rounded-chrome-sm border border-input bg-transparent px-2 text-label outline-none transition-colors hover:border-border focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/15">
+        <InkSwatch name={theme} />
+        <span className="min-w-0 flex-1 truncate text-left">{THEMES[theme].label}</span>
+        <CaretDownIcon className="size-3 shrink-0 text-muted-foreground" weight="bold" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <InkMenuItems />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/chrome/ink-picker.tsx
+++ b/components/chrome/ink-picker.tsx
@@ -61,7 +61,12 @@ export function InkPicker() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex h-ctl w-full min-w-0 items-center gap-2 rounded-chrome-sm border border-input bg-transparent px-2 text-label outline-none transition-colors hover:border-border focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/15">
+      <DropdownMenuTrigger
+        // the face is a chip and a palette name, so the control needs to say
+        // out loud what it is for anyone not looking at it
+        aria-label={`Palette — ${THEMES[theme].label}`}
+        className="flex h-ctl w-full min-w-0 items-center gap-2 rounded-chrome-sm border border-input bg-transparent px-2 text-label outline-none transition-colors hover:border-border focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/15"
+      >
         <InkSwatch name={theme} />
         <span className="min-w-0 flex-1 truncate text-left">{THEMES[theme].label}</span>
         <CaretDownIcon className="size-3 shrink-0 text-muted-foreground" weight="bold" />

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -174,9 +174,9 @@ export function Inspector() {
 
 /**
  * With nothing selected the panel edits the page instead of apologising for
- * being empty. Everything here is document-wide — the sheet, the ink, the
- * lettering — which is exactly the set of knobs you reach for between drawings
- * rather than during one.
+ * being empty. Paper and Ink belong to the document and are saved inside it —
+ * two drawings can hold two different looks. View is the one app-level section,
+ * which is why it sits apart at the bottom.
  */
 function PageSettings() {
   const paper = useSquig((s) => s.paper)
@@ -224,7 +224,7 @@ function PageSettings() {
             onChange={(f) => st().setFont(f)}
           />
         </Row>
-        <PanelNote>ink and paper travel with every drawing you open</PanelNote>
+        <PanelNote>saved with this drawing — a new file starts from whatever you set last</PanelNote>
       </PanelSection>
 
       <PanelSection id="page-view" title="View">

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -29,15 +29,19 @@ import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
+  ArrowsOutIcon,
   FlipHorizontalIcon,
   FlipVerticalIcon,
   LinkBreakIcon,
+  SelectionAllIcon,
   TextBIcon,
   TextItalicIcon,
   TextUnderlineIcon,
   TrashIcon,
 } from "@phosphor-icons/react"
 import { kbd } from "@/lib/shortcuts"
+import { InkPicker } from "./ink-picker"
+import { bgOf, paletteOf, PAPER_SHADES, type FontMode, type PaperShade } from "@/lib/theme"
 
 // ---------------------------------------------------------------------------
 // Option sets. Declared out here so they aren't rebuilt on every keystroke.
@@ -65,6 +69,43 @@ const FILL_OPTIONS: readonly SegmentOption<FillTone>[] = [
   { value: "strong", label: "Strong shade", content: <ToneChip fill="var(--sq-shade-strong)" /> },
 ]
 
+/**
+ * A sheet sample — the literal colour that shade puts behind the drawing,
+ * filling its whole segment. Three near-whites can only be told apart at size,
+ * so the swatch is the segment rather than a chip beside a word.
+ */
+function PaperSample({ fill }: { fill: string }) {
+  return (
+    <span
+      // a neutral hairline, not the ink's faint: an inked outline would read as
+      // a drawn box rather than as a sheet of paper
+      className="block h-[18px] w-full rounded-chrome-xs border border-border"
+      style={{ background: fill }}
+    />
+  )
+}
+
+/**
+ * The face the canvas letters in, shown rather than named: each segment sets
+ * "Aa" in the face it selects. "Sans serif" is a word you have to translate;
+ * two letters in the actual font you don't.
+ */
+const FONT_OPTIONS: readonly SegmentOption<FontMode>[] = [
+  { value: "hand", label: "Hand-drawn", content: <FontSample family="var(--font-sketch)" /> },
+  { value: "sans", label: "Sans serif", content: <FontSample family="var(--font-sans)" /> },
+  { value: "serif", label: "Serif", content: <FontSample family="var(--font-serif)" /> },
+]
+
+/** "Aa" set in one face — a little large for the row, because two letters at
+    11px don't carry enough of a face to tell it from its neighbour. */
+function FontSample({ family }: { family: string }) {
+  return (
+    <span className="text-[13px] leading-none" style={{ fontFamily: family }}>
+      Aa
+    </span>
+  )
+}
+
 /** A pen-weight chip — the actual relative widths, not three identical bars. */
 function PenChip({ height }: { height: number }) {
   return <span className="block w-4 rounded-full bg-current" style={{ height }} />
@@ -89,49 +130,104 @@ const TEXT_STYLES = [
 export function Inspector() {
   const nodes = useSquig((s) => s.nodes)
   const selection = useSquig((s) => s.selection)
+  const total = useSquig((s) => s.order.length)
 
   const selected = selection.map((id) => nodes[id]).filter(Boolean) as SquigNode[]
+  const empty = selected.length === 0
 
-  const heading =
-    selected.length === 0
-      ? "nothing selected"
-      : selected.length > 1
-        ? `${selected.length} selected`
-        : selected[0].type === "component"
-          ? (getDef((selected[0] as ComponentNode).kind)?.name ?? (selected[0] as ComponentNode).kind)
-          : selected[0].type
+  // Nothing selected is not an absence — it's the page. So the panel keeps its
+  // job and changes its subject rather than going blank.
+  const heading = empty
+    ? "Page"
+    : selected.length > 1
+      ? `${selected.length} selected`
+      : selected[0].type === "component"
+        ? (getDef((selected[0] as ComponentNode).kind)?.name ?? (selected[0] as ComponentNode).kind)
+        : selected[0].type
+
+  const subtitle = empty
+    ? total === 0
+      ? "empty canvas"
+      : `${total} ${total === 1 ? "layer" : "layers"}`
+    : selected.length > 1
+      ? selectionSummary(selected)
+      : undefined
 
   return (
     <Panel className="absolute top-4 right-4 z-30 max-h-[calc(100vh-2rem)] w-[272px]">
-      <PanelHeader title={heading} subtitle={selected.length > 1 ? selectionSummary(selected) : undefined} />
+      <PanelHeader title={heading} subtitle={subtitle} />
 
       <ScrollArea className="min-h-0">
         {/* remounting on a selection change drops any half-typed draft, which
             is what you want — the field now describes different objects */}
         <div key={selection.join(",")} className="flex flex-col">
-          {selected.length ? <SelectionEditor selected={selected} /> : <EmptyState />}
+          {empty ? <PageSettings /> : <SelectionEditor selected={selected} />}
         </div>
       </ScrollArea>
 
-      {selected.length > 0 && <Footer selected={selected} />}
+      {empty ? <PageFooter /> : <Footer selected={selected} />}
     </Panel>
   )
 }
 
 // ---------------------------------------------------------------------------
 
-function EmptyState() {
+/**
+ * With nothing selected the panel edits the page instead of apologising for
+ * being empty. Everything here is document-wide — the sheet, the ink, the
+ * lettering — which is exactly the set of knobs you reach for between drawings
+ * rather than during one.
+ */
+function PageSettings() {
+  const paper = useSquig((s) => s.paper)
+  const grid = useSquig((s) => s.grid)
+  const font = useSquig((s) => s.font)
+  const theme = useSquig((s) => s.theme)
   const contextRow = useSquig((s) => s.contextRow)
   const st = useSquig.getState
 
+  const palette = paletteOf(theme)
+
+  /** Built per palette, not once at module load — the samples preview this
+      theme's actual sheet, which is the whole point of showing them. */
+  const paperOptions: SegmentOption<PaperShade>[] = PAPER_SHADES.map(({ value, label }) => ({
+    value,
+    label: `${label} paper`,
+    content: <PaperSample fill={bgOf(palette, value)} />,
+  }))
+
   return (
     <>
-      <div className="border-b border-border/60 p-gutter">
-        <PanelNote>
-          drop a component, scribble a shape, make a mess. it&apos;s a wireframe, not the Sistine Chapel.
-        </PanelNote>
-      </div>
-      <PanelSection id="settings" title="Settings">
+      <PanelSection id="page-paper" title="Paper">
+        <Row label="Shade">
+          <Segmented
+            ariaLabel="Paper shade"
+            options={paperOptions}
+            shared={{ mixed: false, value: paper }}
+            onChange={(s) => st().setPaper(s)}
+          />
+        </Row>
+        <Row spread label="Dot grid">
+          <Switch checked={grid} aria-label="Dot grid" onCheckedChange={(on) => st().setGrid(on)} className="scale-90" />
+        </Row>
+      </PanelSection>
+
+      <PanelSection id="page-ink" title="Ink">
+        <Row label="Palette">
+          <InkPicker />
+        </Row>
+        <Row label="Font">
+          <Segmented
+            ariaLabel="Font"
+            options={FONT_OPTIONS}
+            shared={{ mixed: false, value: font }}
+            onChange={(f) => st().setFont(f)}
+          />
+        </Row>
+        <PanelNote>ink and paper travel with every drawing you open</PanelNote>
+      </PanelSection>
+
+      <PanelSection id="page-view" title="View">
         <Row spread label="Context menu">
           <Switch
             checked={contextRow}
@@ -143,6 +239,35 @@ function EmptyState() {
         <PanelNote>quick controls float above the selection</PanelNote>
       </PanelSection>
     </>
+  )
+}
+
+/** Footer for the page panel — whole-canvas moves, not selection ones. */
+function PageFooter() {
+  const count = useSquig((s) => s.order.length)
+  const st = useSquig.getState
+
+  return (
+    <PanelFooter>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={count === 0}
+        className="h-ctl flex-1 rounded-chrome-sm text-label"
+        onClick={() => st().zoomToFit()}
+      >
+        <ArrowsOutIcon className="size-3" /> Fit
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={count === 0}
+        className="h-ctl flex-1 rounded-chrome-sm text-label"
+        onClick={() => st().selectAll()}
+      >
+        <SelectionAllIcon className="size-3" /> Select all
+      </Button>
+    </PanelFooter>
   )
 }
 

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -3,43 +3,30 @@
 // ---------------------------------------------------------------------------
 // Top-left corner — the wordmark doubles as the file menu, the file name is
 // inline-editable. No toolbar chrome beyond that, on purpose.
+//
+// It is a *file* menu: documents, saving, editing, the view. How the drawing
+// looks — ink, paper, lettering, the grid — lives in the Page panel, which is
+// what the inspector shows whenever nothing is selected. Two doors onto the
+// same setting is how a menu turns into a junk drawer, so appearance has one.
 // ---------------------------------------------------------------------------
 
 import { useRef } from "react"
 import { useSquig } from "@/lib/store"
 import { exportDoc, importDoc } from "@/lib/file-io"
-import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react"
+import { CaretDownIcon } from "@phosphor-icons/react"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Panel } from "@/components/ui/panel"
-import { THEMES, THEME_NAMES, type ThemeName } from "@/lib/theme"
 import { kbd } from "@/lib/shortcuts"
 import { RecentFiles } from "@/components/chrome/recent-files"
 
-/** Two-tone chip showing a palette's paper and ink. */
-function Swatch({ name }: { name: ThemeName }) {
-  const p = THEMES[name]
-  return (
-    <span
-      className="inline-block size-3.5 shrink-0 rounded-full border"
-      style={{ background: `linear-gradient(135deg, ${p.paper} 50%, ${p.ink} 50%)`, borderColor: p.ink }}
-    />
-  )
-}
-
 export function TopCorner() {
-  const contextRow = useSquig((s) => s.contextRow)
-  const theme = useSquig((s) => s.theme)
-  const font = useSquig((s) => s.font)
   const st = useSquig.getState
   // Rename hands focus to the floating name field, so the menu must not yank
   // focus back to its trigger on the way out.
@@ -112,31 +99,8 @@ export function TopCorner() {
             <DropdownMenuShortcut>⇧⌘Z</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <span className="flex items-center gap-2">
-                <Swatch name={theme} />
-                Ink
-              </span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-48">
-              {THEME_NAMES.map((name) => (
-                <DropdownMenuItem key={name} onClick={() => st().setTheme(name)}>
-                  <span className="flex items-center gap-2">
-                    <Swatch name={name} />
-                    {THEMES[name].label}
-                  </span>
-                  {theme === name && <CheckIcon className="ml-auto size-3.5 text-muted-foreground" weight="bold" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuItem onClick={() => st().setFont(font === "hand" ? "clean" : "hand")}>
-            {font === "hand" ? "Use clean lettering" : "Use hand lettering"}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => st().setContextRow(!contextRow)}>
-            {contextRow ? "Hide context menu" : "Show context menu"}
-          </DropdownMenuItem>
+          {/* ink, paper, lettering and the grid used to sit here; they live in
+              the Page panel now — deselect and the inspector is holding them */}
           <DropdownMenuItem onClick={() => st().setViewport({ x: 0, y: 0, zoom: 1 })}>
             Reset zoom
             <DropdownMenuShortcut>{kbd("mod+0")}</DropdownMenuShortcut>

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -11,7 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import type { SquigNode } from "./types"
-import { DEFAULT_FONT, DEFAULT_PAPER, DEFAULT_THEME, THEMES, type FontMode, type PaperShade, type ThemeName } from "./theme"
+import { DEFAULT_FONT, DEFAULT_LOOK, DEFAULT_PAPER, DEFAULT_THEME, THEMES, type FontMode, type Look, type PaperShade, type ThemeName } from "./theme"
 
 export interface FileMeta {
   id: string
@@ -25,16 +25,14 @@ export interface StoredDoc {
   nodes: Record<string, SquigNode>
   order: string[]
   updatedAt: number
+  /** how this drawing looks — absent on documents saved before looks existed */
+  look?: Look
 }
 
 /** Everything that belongs to the app rather than to any one document. */
 export interface Prefs {
-  theme: ThemeName
-  font: FontMode
-  /** how bright the sheet is */
-  paper: PaperShade
-  /** the canvas dot grid is drawn */
-  grid: boolean
+  /** the last look you set — what a new document starts from, nothing more */
+  look: Look
   contextRow: boolean
   activeId: string | null
 }
@@ -96,7 +94,14 @@ function writeIndex(list: FileMeta[]) {
 export function readFile(id: string): StoredDoc | null {
   const doc = readJSON(fileKey(id)) as StoredDoc | null
   if (!doc || typeof doc !== "object" || !doc.nodes || !Array.isArray(doc.order)) return null
-  return { ...doc, id, name: typeof doc.name === "string" ? doc.name : "untitled scribbles" }
+  return {
+    ...doc,
+    id,
+    name: typeof doc.name === "string" ? doc.name : "untitled scribbles",
+    // a document written before looks existed has none; the caller keeps the
+    // look already on screen rather than snapping the canvas to a default
+    look: doc.look ? knownLook(doc.look, DEFAULT_LOOK) : undefined,
+  }
 }
 
 /**
@@ -148,14 +153,27 @@ function knownPaper(s: unknown): PaperShade {
   return s === "white" || s === "subtle" || s === "shaded" ? s : DEFAULT_PAPER
 }
 
-export function loadPrefs(): Prefs {
-  const p = (readJSON(PREFS_KEY) ?? {}) as Partial<Prefs>
+/**
+ * A look from storage, with every field vouched for. A field that is missing or
+ * no longer valid — a palette we retired, a font mode we renamed — comes from
+ * `fallback` rather than taking the canvas down with it.
+ */
+export function knownLook(v: unknown, fallback: Look): Look {
+  const l = (v ?? {}) as Partial<Look>
   return {
-    theme: knownTheme(p.theme),
-    font: knownFont(p.font),
-    paper: knownPaper(p.paper),
+    theme: l.theme === undefined ? fallback.theme : knownTheme(l.theme),
+    paper: l.paper === undefined ? fallback.paper : knownPaper(l.paper),
+    font: l.font === undefined ? fallback.font : knownFont(l.font),
     // the grid is on unless someone turned it off
-    grid: p.grid !== false,
+    grid: typeof l.grid === "boolean" ? l.grid : fallback.grid,
+  }
+}
+
+export function loadPrefs(): Prefs {
+  const p = (readJSON(PREFS_KEY) ?? {}) as Partial<Prefs> & Partial<Look>
+  return {
+    // prefs used to keep the look's fields flat, so read them either way
+    look: knownLook(p.look ?? p, DEFAULT_LOOK),
     contextRow: p.contextRow === true,
     activeId: typeof p.activeId === "string" ? p.activeId : null,
   }
@@ -177,19 +195,20 @@ export function migrateLegacyDoc(newId: () => string): { doc: StoredDoc; prefs: 
     drop(LEGACY_KEY)
     return null
   }
+  // the legacy doc's theme and font were app settings; they become this
+  // document's look, since it is the only document there was
+  const look = knownLook({ theme: old.theme, font: old.font }, DEFAULT_LOOK)
   const doc: StoredDoc = {
     id: newId(),
     name: old.fileName || "untitled scribbles",
     nodes: old.nodes,
     order: old.order,
     updatedAt: Date.now(),
+    look,
   }
   saveFile(doc)
   const prefs: Prefs = {
-    theme: knownTheme(old.theme),
-    font: knownFont(old.font),
-    paper: DEFAULT_PAPER,
-    grid: true,
+    look,
     contextRow: old.contextRow === true,
     activeId: doc.id,
   }

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -11,7 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import type { SquigNode } from "./types"
-import { DEFAULT_FONT, DEFAULT_THEME, THEMES, type FontMode, type ThemeName } from "./theme"
+import { DEFAULT_FONT, DEFAULT_PAPER, DEFAULT_THEME, THEMES, type FontMode, type PaperShade, type ThemeName } from "./theme"
 
 export interface FileMeta {
   id: string
@@ -31,6 +31,10 @@ export interface StoredDoc {
 export interface Prefs {
   theme: ThemeName
   font: FontMode
+  /** how bright the sheet is */
+  paper: PaperShade
+  /** the canvas dot grid is drawn */
+  grid: boolean
   contextRow: boolean
   activeId: string | null
 }
@@ -135,7 +139,13 @@ function knownTheme(t: unknown): ThemeName {
 }
 
 function knownFont(f: unknown): FontMode {
-  return f === "hand" || f === "clean" ? f : DEFAULT_FONT
+  // "clean" was the old name for the one non-hand face, back when there was one
+  if (f === "clean") return "sans"
+  return f === "hand" || f === "sans" || f === "serif" ? f : DEFAULT_FONT
+}
+
+function knownPaper(s: unknown): PaperShade {
+  return s === "white" || s === "subtle" || s === "shaded" ? s : DEFAULT_PAPER
 }
 
 export function loadPrefs(): Prefs {
@@ -143,6 +153,9 @@ export function loadPrefs(): Prefs {
   return {
     theme: knownTheme(p.theme),
     font: knownFont(p.font),
+    paper: knownPaper(p.paper),
+    // the grid is on unless someone turned it off
+    grid: p.grid !== false,
     contextRow: p.contextRow === true,
     activeId: typeof p.activeId === "string" ? p.activeId : null,
   }
@@ -175,6 +188,8 @@ export function migrateLegacyDoc(newId: () => string): { doc: StoredDoc; prefs: 
   const prefs: Prefs = {
     theme: knownTheme(old.theme),
     font: knownFont(old.font),
+    paper: DEFAULT_PAPER,
+    grid: true,
     contextRow: old.contextRow === true,
     activeId: doc.id,
   }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -6,7 +6,15 @@ import type { ComponentNode, SquigNode, TextNode, Tool, Viewport, ShapeKind } fr
 import { normalizeFill, screenToWorld, unionBox } from "./types"
 import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
-import { applyTheme, DEFAULT_FONT, DEFAULT_THEME, type FontMode, type ThemeName } from "./theme"
+import {
+  applyTheme,
+  DEFAULT_FONT,
+  DEFAULT_PAPER,
+  DEFAULT_THEME,
+  type FontMode,
+  type PaperShade,
+  type ThemeName,
+} from "./theme"
 import {
   INDEX_KEY,
   deleteFile as dropFile,
@@ -67,6 +75,10 @@ interface SquigState {
   contextRow: boolean
   theme: ThemeName
   font: FontMode
+  /** how bright the sheet behind the drawing is */
+  paper: PaperShade
+  /** the canvas dot grid is drawn */
+  grid: boolean
   hydrated: boolean
   commandOpen: boolean
   contextMenu: ContextMenuState | null
@@ -96,6 +108,8 @@ interface SquigState {
   setContextRow: (on: boolean) => void
   setTheme: (t: ThemeName) => void
   setFont: (f: FontMode) => void
+  setPaper: (s: PaperShade) => void
+  setGrid: (on: boolean) => void
   setViewport: (v: Viewport) => void
   setSelection: (ids: string[]) => void
   setCommandOpen: (open: boolean) => void
@@ -310,7 +324,14 @@ function flushSave(get: () => SquigState, force = false) {
     saveTimer = null
   }
   const s = get()
-  savePrefs({ theme: s.theme, font: s.font, contextRow: s.contextRow, activeId: s.docId })
+  savePrefs({
+    theme: s.theme,
+    font: s.font,
+    paper: s.paper,
+    grid: s.grid,
+    contextRow: s.contextRow,
+    activeId: s.docId,
+  })
   if (!dirty && !force) return
   const known = s.files.some((f) => f.id === s.docId)
   if (!s.order.length && !known && !force) return
@@ -365,6 +386,8 @@ export const useSquig = create<SquigState>((set, get) => ({
   contextRow: false,
   theme: DEFAULT_THEME,
   font: DEFAULT_FONT,
+  paper: DEFAULT_PAPER,
+  grid: true,
   hydrated: false,
   commandOpen: false,
   contextMenu: null,
@@ -393,12 +416,21 @@ export const useSquig = create<SquigState>((set, get) => ({
   },
   setTheme: (t) => {
     set({ theme: t })
-    applyTheme(t, get().font)
+    applyTheme(t, get().font, get().paper)
     scheduleSave(get)
   },
   setFont: (f) => {
     set({ font: f })
-    applyTheme(get().theme, f)
+    applyTheme(get().theme, f, get().paper)
+    scheduleSave(get)
+  },
+  setPaper: (s) => {
+    set({ paper: s })
+    applyTheme(get().theme, get().font, s)
+    scheduleSave(get)
+  },
+  setGrid: (on) => {
+    set({ grid: on })
     scheduleSave(get)
   },
   setViewport: (v) => set({ viewport: v }),
@@ -628,9 +660,11 @@ export const useSquig = create<SquigState>((set, get) => ({
       contextRow: prefs.contextRow,
       theme: prefs.theme,
       font: prefs.font,
+      paper: prefs.paper,
+      grid: prefs.grid,
       hydrated: true,
     })
-    applyTheme(prefs.theme, prefs.font)
+    applyTheme(prefs.theme, prefs.font, prefs.paper)
     // what we just read is, by definition, what the drawer already holds
     dirty = false
     watchWindow(get)

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,17 +7,17 @@ import { normalizeFill, screenToWorld, unionBox } from "./types"
 import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
 import {
-  applyTheme,
-  DEFAULT_FONT,
-  DEFAULT_PAPER,
-  DEFAULT_THEME,
+  applyLook,
+  DEFAULT_LOOK,
   type FontMode,
+  type Look,
   type PaperShade,
   type ThemeName,
 } from "./theme"
 import {
   INDEX_KEY,
   deleteFile as dropFile,
+  knownLook,
   listFiles,
   loadPrefs,
   migrateLegacyDoc,
@@ -73,6 +73,9 @@ interface SquigState {
   placingDrag: boolean
   editingId: string | null
   contextRow: boolean
+  /* --- the look, kept flat so a control can subscribe to just its own knob.
+     It belongs to the open document: every setter writes it back to the file,
+     and opening another one brings that file's look with it. */
   theme: ThemeName
   font: FontMode
   /** how bright the sheet behind the drawing is */
@@ -303,6 +306,18 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null
 /** true between an edit and the write that records it */
 let dirty = false
 
+/** The four knobs that make up a look, gathered out of the flat state. */
+function lookOf(s: Pick<SquigState, "theme" | "paper" | "font" | "grid">): Look {
+  return { theme: s.theme, paper: s.paper, font: s.font, grid: s.grid }
+}
+
+/** Put a look on screen and in state — the one path both the panel and an
+    opened file go through, so they can't drift apart. */
+function wearLook(set: (partial: Partial<SquigState>) => void, look: Look) {
+  set(look)
+  applyLook(look)
+}
+
 /** Every edit calls this; the drawer only gets written once the hand rests. */
 function scheduleSave(get: () => SquigState) {
   dirty = true
@@ -324,14 +339,9 @@ function flushSave(get: () => SquigState, force = false) {
     saveTimer = null
   }
   const s = get()
-  savePrefs({
-    theme: s.theme,
-    font: s.font,
-    paper: s.paper,
-    grid: s.grid,
-    contextRow: s.contextRow,
-    activeId: s.docId,
-  })
+  // the look goes to prefs too, but only as the default a new file will start
+  // from — the copy that matters travels inside the document below
+  savePrefs({ look: lookOf(s), contextRow: s.contextRow, activeId: s.docId })
   if (!dirty && !force) return
   const known = s.files.some((f) => f.id === s.docId)
   if (!s.order.length && !known && !force) return
@@ -341,6 +351,7 @@ function flushSave(get: () => SquigState, force = false) {
     nodes: s.nodes,
     order: s.order,
     updatedAt: Date.now(),
+    look: lookOf(s),
   })
   useSquig.setState({ files })
   dirty = false
@@ -384,10 +395,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   placingDrag: false,
   editingId: null,
   contextRow: false,
-  theme: DEFAULT_THEME,
-  font: DEFAULT_FONT,
-  paper: DEFAULT_PAPER,
-  grid: true,
+  ...DEFAULT_LOOK,
   hydrated: false,
   commandOpen: false,
   contextMenu: null,
@@ -414,23 +422,21 @@ export const useSquig = create<SquigState>((set, get) => ({
     set({ contextRow: on })
     scheduleSave(get)
   },
+  // each of these edits the open document, so each schedules a save
   setTheme: (t) => {
-    set({ theme: t })
-    applyTheme(t, get().font, get().paper)
+    wearLook(set, { ...lookOf(get()), theme: t })
     scheduleSave(get)
   },
   setFont: (f) => {
-    set({ font: f })
-    applyTheme(get().theme, f, get().paper)
+    wearLook(set, { ...lookOf(get()), font: f })
     scheduleSave(get)
   },
-  setPaper: (s) => {
-    set({ paper: s })
-    applyTheme(get().theme, get().font, s)
+  setPaper: (p) => {
+    wearLook(set, { ...lookOf(get()), paper: p })
     scheduleSave(get)
   },
   setGrid: (on) => {
-    set({ grid: on })
+    wearLook(set, { ...lookOf(get()), grid: on })
     scheduleSave(get)
   },
   setViewport: (v) => set({ viewport: v }),
@@ -658,13 +664,11 @@ export const useSquig = create<SquigState>((set, get) => ({
       order: clean.order,
       files,
       contextRow: prefs.contextRow,
-      theme: prefs.theme,
-      font: prefs.font,
-      paper: prefs.paper,
-      grid: prefs.grid,
       hydrated: true,
     })
-    applyTheme(prefs.theme, prefs.font, prefs.paper)
+    // the document's own look, or — for one saved before looks existed — the
+    // last look this browser was set to
+    wearLook(set, doc?.look ?? prefs.look)
     // what we just read is, by definition, what the drawer already holds
     dirty = false
     watchWindow(get)
@@ -1043,6 +1047,9 @@ export const useSquig = create<SquigState>((set, get) => ({
       past: [],
       future: [],
     })
+    // a drawing carries its own ink and paper; one saved before looks existed
+    // keeps whatever is on screen rather than snapping to a default
+    if (doc.look) wearLook(set, doc.look)
     // frame what's there, but never past life size — 400% on one small
     // rectangle tells you nothing about where you've landed
     if (clean.order.length) fitBox(set, clean.order.map((nid) => clean.nodes[nid]), 1)
@@ -1077,8 +1084,9 @@ export const useSquig = create<SquigState>((set, get) => ({
   },
 
   serialize: () => {
-    const { fileName, nodes, order } = get()
-    return JSON.stringify({ app: "squig", version: 1, fileName, nodes, order }, null, 2)
+    const s = get()
+    const { fileName, nodes, order } = s
+    return JSON.stringify({ app: "squig", version: 1, fileName, look: lookOf(s), nodes, order }, null, 2)
   },
 
   loadDoc: (json) => {
@@ -1100,6 +1108,8 @@ export const useSquig = create<SquigState>((set, get) => ({
         past: [],
         future: [],
       })
+      // an import brings its author's ink and paper with it, when it has any
+      if (doc.look) wearLook(set, knownLook(doc.look, lookOf(get())))
       // an imported file was drawn wherever its author left it — go there,
       // or the canvas looks empty when it isn't
       if (clean.order.length) fitBox(set, clean.order.map((id) => clean.nodes[id]), 1)

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -116,26 +116,88 @@ export type ThemeName = keyof typeof THEMES
 export const THEME_NAMES = Object.keys(THEMES) as ThemeName[]
 export const DEFAULT_THEME: ThemeName = "internet-blue"
 
-/** Hand-lettered vs. clean — the "is this decided yet" dial. */
-export type FontMode = "hand" | "clean"
+/**
+ * The face the canvas letters in — the "is this decided yet" dial.
+ *
+ * Hand says nothing is settled. Sans and serif are the two ways a wireframe
+ * starts admitting it might ship, and picking between them is a real question
+ * early on, which is why it's a choice of three rather than a switch.
+ */
+export type FontMode = "hand" | "sans" | "serif"
 export const DEFAULT_FONT: FontMode = "hand"
+
+/** What each mode puts in --sq-font. */
+export const FONT_FAMILY: Record<FontMode, string> = {
+  hand: "var(--font-sketch)",
+  sans: "var(--font-sans)",
+  serif: "var(--font-serif)",
+}
+
+// ---------------------------------------------------------------------------
+// Paper.
+//
+// Each palette ships one sheet colour — the warm off-white it was drawn
+// against. This is the dial off it: bleach it to pure white for a screenshot,
+// leave it as authored, or take it a step down toward the grid so a
+// mostly-white wireframe has something to sit on.
+//
+// It moves --sq-bg only. --sq-paper, the opaque fill a card uses to occlude
+// what's behind it, stays the palette's white: darkening the sheet is exactly
+// how you make those cards lift off it.
+// ---------------------------------------------------------------------------
+
+export type PaperShade = "white" | "subtle" | "shaded"
+export const DEFAULT_PAPER: PaperShade = "subtle"
+
+export const PAPER_SHADES: readonly { value: PaperShade; label: string }[] = [
+  { value: "white", label: "White" },
+  { value: "subtle", label: "Subtle" },
+  { value: "shaded", label: "Shaded" },
+]
+
+/** Linear blend of two hex colours — `t` of `b` into `a`. */
+function mix(a: string, b: string, t: number): string {
+  const hex = (s: string) => {
+    const v = s.replace("#", "")
+    const n = v.length === 3 ? v.split("").map((c) => c + c).join("") : v
+    return [parseInt(n.slice(0, 2), 16), parseInt(n.slice(2, 4), 16), parseInt(n.slice(4, 6), 16)]
+  }
+  const [r1, g1, b1] = hex(a)
+  const [r2, g2, b2] = hex(b)
+  const c = (x: number, y: number) => Math.round(x + (y - x) * t)
+  return `#${[c(r1, r2), c(g1, g2), c(b1, b2)].map((n) => n.toString(16).padStart(2, "0")).join("")}`
+}
+
+/** The sheet colour: what sits behind the whole drawing. */
+export function bgOf(p: Palette, shade: PaperShade): string {
+  if (shade === "white") return "#FFFFFF"
+  // far enough toward the grid colour to read as a choice — at half that, the
+  // three shades look like the same white three times
+  if (shade === "shaded") return mix(p.bg, p.grid, 0.7)
+  return p.bg
+}
+
+/** The dot grid, kept readable against whatever the sheet just became. */
+export function gridOf(p: Palette, shade: PaperShade): string {
+  return shade === "shaded" ? mix(p.grid, p.ink, 0.15) : p.grid
+}
 
 export function paletteOf(name: string): Palette {
   return THEMES[name as ThemeName] ?? THEMES[DEFAULT_THEME]
 }
 
-export function applyTheme(name: string, font: FontMode) {
+export function applyTheme(name: string, font: FontMode, paper: PaperShade = DEFAULT_PAPER) {
   if (typeof document === "undefined") return
   const p = paletteOf(name)
   const root = document.documentElement
-  root.style.setProperty("--sq-bg", p.bg)
+  root.style.setProperty("--sq-bg", bgOf(p, paper))
   root.style.setProperty("--sq-paper", p.paper)
   root.style.setProperty("--sq-ink", p.ink)
   root.style.setProperty("--sq-muted", p.muted)
   root.style.setProperty("--sq-faint", p.faint)
   root.style.setProperty("--sq-shade", p.shade)
   root.style.setProperty("--sq-shade-strong", p.shadeStrong)
-  root.style.setProperty("--sq-grid", p.grid)
+  root.style.setProperty("--sq-grid", gridOf(p, paper))
   root.style.setProperty("--sq-select", p.select)
-  root.style.setProperty("--sq-font", font === "clean" ? "var(--font-sans)" : "var(--font-sketch)")
+  root.style.setProperty("--sq-font", FONT_FAMILY[font] ?? FONT_FAMILY.hand)
 }

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -186,9 +186,36 @@ export function paletteOf(name: string): Palette {
   return THEMES[name as ThemeName] ?? THEMES[DEFAULT_THEME]
 }
 
-export function applyTheme(name: string, font: FontMode, paper: PaperShade = DEFAULT_PAPER) {
+// ---------------------------------------------------------------------------
+// The look.
+//
+// Ink, paper, font and grid belong to the drawing, not to the app: a red
+// marker-on-white flow chart and a graphite-on-shaded interface study are two
+// documents you keep side by side, and opening one shouldn't repaint the other.
+// So a look is saved inside the document, and the last one you set is only the
+// default a NEW document starts from.
+// ---------------------------------------------------------------------------
+
+export interface Look {
+  theme: ThemeName
+  paper: PaperShade
+  font: FontMode
+  /** the canvas dot grid is drawn */
+  grid: boolean
+}
+
+export const DEFAULT_LOOK: Look = {
+  theme: DEFAULT_THEME,
+  paper: DEFAULT_PAPER,
+  font: DEFAULT_FONT,
+  grid: true,
+}
+
+/** Write a look onto the document element. `grid` is drawn by the canvas, not
+    by a custom property, so it is the one part this doesn't touch. */
+export function applyLook({ theme, font, paper }: Look) {
   if (typeof document === "undefined") return
-  const p = paletteOf(name)
+  const p = paletteOf(theme)
   const root = document.documentElement
   root.style.setProperty("--sq-bg", bgOf(p, paper))
   root.style.setProperty("--sq-paper", p.paper)


### PR DESCRIPTION
## What

With nothing selected, the inspector used to say *"nothing selected — drop a component, scribble a shape, make a mess. it's a wireframe, not the Sistine Chapel."* plus one stray Settings toggle. Nothing selected isn't an absence — it's the page. The panel now keeps its job and changes its subject.

**Page** holds:

| Section | Control |
| --- | --- |
| Paper | **Shade** — three sheet samples: pure white, the palette's own off-white, one step down toward the grid *(new)* |
| Paper | **Dot grid** on/off *(new)* |
| Ink | **Palette** — the ink picker, live two-tone chip, the same six palettes |
| Ink | **Font** — hand / sans / serif, each segment set in the face it selects *(serif is new)* |
| View | **Context menu** toggle, plus a footer for **Fit** and **Select all** |

The shades are computed from each palette rather than hard-coded, so "shaded" stays in that theme's hue, and the dot grid darkens with it to stay readable.

## The look belongs to the document

Ink, paper, font and grid used to be app settings, so opening a graphite-on-white interface study repainted the red marker flow chart next to it. The four knobs are now a `Look` saved **inside** each `.squig` document and restored when you open it. Prefs keep the last look you set, but only as the default a *new* file starts from. Exports carry it, so an imported drawing arrives wearing its author's ink.

Documents saved before looks existed have none — those keep whatever is on screen rather than snapping to a default, and get a look of their own the first time you touch one. Prefs that still hold the old flat fields are read either way, and the legacy single-document migration hands its app-level theme and font to the document it creates.

## Also

Appearance now has one home, so **ink, paper, lettering and the dot grid come out of the wordmark menu** — it goes back to being a file menu (files, save/export, rename, find, undo/redo, reset zoom, clear canvas). Two doors onto the same setting is how a menu turns into a junk drawer.

New font: Source Serif 4 via `next/font` — a text face rather than a display one, since it has to hold up at caption sizes inside a wireframe. The palette control also gained an accessible name; its face is a chip and a word, which a screen reader can't announce on its own.

## Verified

`tsc --noEmit`, `eslint`, `next build` all clean. Driven in the browser:

- each paper shade repaints the sheet and the grid; the grid toggle hides the dots
- all six palettes apply; all three fonts change the canvas type
- **two documents, two looks**: set file A to riso red / shaded / serif and file B to graphite / white / sans, then switched between them — each came back wearing its own, and `localStorage` shows the look stored per document
- a reload restores the open document's look
- a document with no stored look keeps the look already on screen
- Fit and Select all work and disable on an empty canvas; the header reads "empty canvas" / "N layers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)