### PR TITLE
Drop the layer count from the Page panel header

### DIFF
--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -130,7 +130,6 @@ const TEXT_STYLES = [
 export function Inspector() {
   const nodes = useSquig((s) => s.nodes)
   const selection = useSquig((s) => s.selection)
-  const total = useSquig((s) => s.order.length)
 
   const selected = selection.map((id) => nodes[id]).filter(Boolean) as SquigNode[]
   const empty = selected.length === 0
@@ -145,13 +144,7 @@ export function Inspector() {
         ? (getDef((selected[0] as ComponentNode).kind)?.name ?? (selected[0] as ComponentNode).kind)
         : selected[0].type
 
-  const subtitle = empty
-    ? total === 0
-      ? "empty canvas"
-      : `${total} ${total === 1 ? "layer" : "layers"}`
-    : selected.length > 1
-      ? selectionSummary(selected)
-      : undefined
+  const subtitle = selected.length > 1 ? selectionSummary(selected) : undefined
 
   return (
     <Panel className="absolute top-4 right-4 z-30 max-h-[calc(100vh-2rem)] w-[272px]">


### PR DESCRIPTION
The Page panel header carried a subtitle that restated the canvas: "empty canvas" when it was plainly empty, "7 layers" when the shapes were sitting right there. Nothing in the panel acts on that number, so it was a line of chrome to read past on the way to Paper, Ink and View.

Now the header just names its subject — "Page" — the same way it names "rect" or "3 selected". The multi-selection summary is untouched.

Verified in the running app: nothing selected on an empty canvas and with a shape on it both show a bare "Page" header. `tsc`, `eslint` and the geometry/selection tests are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)