### PR TITLE
Edit text where it already is

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -24,6 +24,8 @@ import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type Snap
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type Handle } from "@/lib/canvas/transform"
 import { pickAt, pickInRect } from "@/lib/canvas/hit-test"
+import { editTarget } from "@/lib/canvas/edit-target"
+import { textBlockHeight } from "@/lib/sketch/text-layout"
 import { unionBounds, type Bounds } from "@/lib/selection"
 import { NodeSketch, SketchPrims } from "./sketch"
 import { getDef, renderComponent } from "@/lib/library/registry"
@@ -188,6 +190,11 @@ export function Canvas() {
   const placing = useSquig((s) => s.placing)
   const placingDrag = useSquig((s) => s.placingDrag)
   const editingId = useSquig((s) => s.editingId)
+
+  // where the words being edited actually sit — the editor stands there, and
+  // the renderer leaves that one run out so they don't print on top of it
+  const editingNode = editingId ? nodes[editingId] : null
+  const editing = useMemo(() => (editingNode ? editTarget(editingNode) : null), [editingNode])
 
   /** marquee box in WORLD units — screen conversion happens at render time */
   const [marquee, setMarquee] = useState<Bounds | null>(null)
@@ -874,14 +881,17 @@ export function Canvas() {
         // mousedown that follows would hand focus straight back to the canvas —
         // blurring the editor into a commit that deletes the still-empty node
         e.preventDefault()
+        const fontSize = 18
+        const h = textBlockHeight(1, fontSize)
         const id = s.addNode({
           type: "text",
           text: "",
-          fontSize: 18,
+          fontSize,
           x: wx,
-          y: wy - 13,
+          // the click lands in the middle of the line it just started
+          y: wy - h / 2,
           w: 120,
-          h: 26,
+          h,
         } as Omit<SquigNode, "id" | "seed">)
         s.setTool("select")
         s.setEditing(id)
@@ -1410,7 +1420,7 @@ export function Canvas() {
             if (!n) return null
             return (
               <g key={id} transform={`translate(${n.x} ${n.y})`}>
-                <NodeSketch node={n} />
+                <NodeSketch node={n} hiddenText={id === editingId ? editing?.hidden : undefined} />
               </g>
             )
           })}
@@ -1490,7 +1500,7 @@ export function Canvas() {
       )}
 
       {/* inline text editing */}
-      {editingId && <TextEditOverlay key={editingId} />}
+      {editingNode && editing && <TextEditOverlay key={editingNode.id} node={editingNode} target={editing} />}
 
       {/* context row */}
       <ContextRow selectedNodes={selectedNodes} viewport={v} busy={!!gestureKind} />

--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -13,27 +13,11 @@ import { memo, useMemo } from "react"
 import rough from "roughjs"
 import type { Options } from "roughjs/bin/core"
 import type { RoughGenerator } from "roughjs/bin/generator"
-import { INK, SHADE, mirrorPrims, type InkColor, type Prim, type PrimOpts } from "@/lib/sketch/kit"
-import { normalizeFill, type FillTone, type Outlined, type SquigNode, type StrokeWeight } from "@/lib/types"
-import { renderComponent } from "@/lib/library/registry"
+import { HAND, INK, SHADE, type InkColor, type Prim, type PrimOpts } from "@/lib/sketch/kit"
+import { nodePrims } from "@/lib/sketch/node-prims"
+import type { SquigNode } from "@/lib/types"
 
 const gen: RoughGenerator = rough.generator()
-
-/**
- * House defaults.
- *
- * The hand is deliberately restrained: enough irregularity that a line reads
- * as drawn rather than generated, but not so much that corners fall open.
- * `preserveVertices` pins every endpoint to its exact coordinate, so closed
- * shapes actually close — the wobble lives in the middle of each segment.
- */
-const HAND = {
-  roughness: 0.25,
-  bowing: 0.35,
-  strokeWidth: 1.4,
-  /** default corner rounding for rects that don't ask for one */
-  radius: 3,
-}
 
 /** How far the early-desktop block shadow sits behind a surface. */
 const SHADOW_OFFSET = 4
@@ -229,7 +213,20 @@ export function primsToPaths(
   return { paths, texts, crisp }
 }
 
-export const SketchPrims = memo(function SketchPrims({ prims, seed }: { prims: Prim[]; seed: number }) {
+export const SketchPrims = memo(function SketchPrims({
+  prims,
+  seed,
+  hiddenText,
+}: {
+  prims: Prim[]
+  seed: number
+  /**
+   * A run the inline editor is standing in for — "all" while a text node is
+   * being edited, or the index of one label inside a component. Drawing it as
+   * well would print the words twice, half a pixel apart.
+   */
+  hiddenText?: "all" | number
+}) {
   const { paths, texts, crisp } = useMemo(() => primsToPaths(prims, seed), [prims, seed])
   return (
     <>
@@ -260,22 +257,24 @@ export const SketchPrims = memo(function SketchPrims({ prims, seed }: { prims: P
           ))}
         </g>
       ))}
-      {texts.map((t, i) => (
-        <text
-          key={`t${i}`}
-          x={t.x}
-          y={t.y}
-          fontSize={t.size}
-          fontFamily="var(--sq-font)"
-          fontWeight={t.bold ? 700 : 400}
-          fontStyle={t.italic ? "italic" : undefined}
-          textDecoration={t.underline ? "underline" : undefined}
-          fill={INK[t.color ?? "ink"]}
-          textAnchor={t.align === "center" ? "middle" : t.align === "right" ? "end" : "start"}
-        >
-          {t.text}
-        </text>
-      ))}
+      {texts.map((t, i) =>
+        hiddenText === "all" || hiddenText === i ? null : (
+          <text
+            key={`t${i}`}
+            x={t.x}
+            y={t.y}
+            fontSize={t.size}
+            fontFamily="var(--sq-font)"
+            fontWeight={t.bold ? 700 : 400}
+            fontStyle={t.italic ? "italic" : undefined}
+            textDecoration={t.underline ? "underline" : undefined}
+            fill={INK[t.color ?? "ink"]}
+            textAnchor={t.align === "center" ? "middle" : t.align === "right" ? "end" : "start"}
+          >
+            {t.text}
+          </text>
+        )
+      )}
     </>
   )
 })
@@ -287,7 +286,14 @@ export const SketchPrims = memo(function SketchPrims({ prims, seed }: { prims: P
  * the parent <g transform> handles. Without that, dragging a template would
  * re-run rough.js over hundreds of prims on every pointer move.
  */
-export const NodeSketch = memo(function NodeSketch({ node }: { node: SquigNode }) {
+export const NodeSketch = memo(function NodeSketch({
+  node,
+  hiddenText,
+}: {
+  node: SquigNode
+  /** see SketchPrims — the run the inline editor has taken over */
+  hiddenText?: "all" | number
+}) {
   const shapeKey = useMemo(() => {
     const flip = `${node.flipX ? 1 : 0}${node.flipY ? 1 : 0}`
     // outline settings change the generated geometry, so they belong in the key
@@ -302,96 +308,14 @@ export const NodeSketch = memo(function NodeSketch({ node }: { node: SquigNode }
       case "arrow":
         return `a:${node.w}:${node.h}:${flip}:${node.head}:${node.points.flat().join()}:${pen}`
       case "text":
-        return `t:${node.text}:${node.fontSize}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
+        // w and align place the anchor, so a resize or a realignment is a
+        // different set of marks even when the words haven't changed
+        return `t:${node.text}:${node.fontSize}:${node.w}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
     }
   }, [node])
 
-  const prims = useMemo<Prim[]>(() => {
-    const base = basePrims(node)
-    return mirrorPrims(base, node.w, node.h, !!node.flipX, !!node.flipY)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shapeKey, node.type])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const prims = useMemo<Prim[]>(() => nodePrims(node), [shapeKey, node.type])
 
-  return <SketchPrims prims={prims} seed={node.seed} />
+  return <SketchPrims prims={prims} seed={node.seed} hiddenText={hiddenText} />
 })
-
-/**
- * A shape's fill tone, as prim options.
- *
- * These reuse the component ladder rather than inventing a second one: `light`
- * and `strong` are the same two shades every card and button prints with, so a
- * filled scribble sits in the same tonal world as the library. `paper` is
- * genuinely opaque — it's the tone you reach for when a box has to hide what
- * it overlaps rather than tint it.
- */
-const FILL_OPTS: Record<FillTone, PrimOpts | undefined> = {
-  none: undefined,
-  paper: { fill: "solid", fillColor: "paper" },
-  light: { fill: "shade", fillColor: "faint" },
-  strong: { fill: "shade", fillColor: "ink" },
-}
-
-/**
- * Pen pressure, as a multiplier on whatever weight the mark draws at by
- * default. A multiplier rather than three absolute widths because an arrow, a
- * freehand line and a rectangle don't start from the same weight, and "heavy"
- * should mean the same *relative* press on all three.
- */
-const PEN_SCALE: Record<StrokeWeight, number> = { light: 0.65, regular: 1, heavy: 1.7 }
-
-/** Merge a node's outline settings into the options for one of its marks. */
-function outline(node: Outlined, baseWidth: number, o?: PrimOpts): PrimOpts {
-  return {
-    ...o,
-    strokeWidth: baseWidth * PEN_SCALE[node.stroke ?? "regular"],
-    dashed: node.dashed,
-  }
-}
-
-/** A node's prims before any flip is applied. */
-function basePrims(node: SquigNode): Prim[] {
-  switch (node.type) {
-    case "component":
-      return renderComponent(node.kind, node.props, node.w, node.h)
-    case "shape": {
-      const o = outline(node, HAND.strokeWidth, FILL_OPTS[normalizeFill(node.fill)])
-      if (node.shape === "ellipse") return [{ t: "ellipse", x: 0, y: 0, w: node.w, h: node.h, o }]
-      return [{ t: "rect", x: 0, y: 0, w: node.w, h: node.h, r: 6, o }]
-    }
-    case "draw":
-      // freehand is already the user's own line — barely roughen it
-      return [{ t: "poly", pts: node.points, o: outline(node, 1.9, { roughness: 0.2 }) }]
-    case "arrow": {
-      const [[x1, y1], [x2, y2]] = node.points
-      const o = outline(node, 1.6)
-      const out: Prim[] = [{ t: "line", x1, y1, x2, y2, o }]
-      if (node.head) {
-        const a = Math.atan2(y2 - y1, x2 - x1)
-        const L = 12
-        out.push({
-          t: "poly",
-          pts: [
-            [x2 - L * Math.cos(a - 0.45), y2 - L * Math.sin(a - 0.45)],
-            [x2, y2],
-            [x2 - L * Math.cos(a + 0.45), y2 - L * Math.sin(a + 0.45)],
-          ],
-          // a dashed arrowhead reads as a rendering fault, not a style
-          o: { ...o, dashed: false },
-        })
-      }
-      return out
-    }
-    case "text":
-      return node.text.split("\n").map((lineText, i): Prim => ({
-        t: "text",
-        x: 0,
-        y: node.fontSize * (i + 1),
-        text: lineText,
-        size: node.fontSize,
-        bold: node.bold,
-        italic: node.italic,
-        // a link is a link because it's underlined — no blue in a wireframe
-        underline: node.underline || !!node.link,
-      }))
-  }
-}

--- a/components/canvas/text-edit-overlay.tsx
+++ b/components/canvas/text-edit-overlay.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 // ---------------------------------------------------------------------------
-// Inline text editing — a textarea parked over the node being edited.
+// Inline text editing — the editor stands exactly where the words already are.
+//
+// Nothing moves when you start typing. The drawn run is hidden, and a bare
+// textarea takes its place on the same baseline, at the same size, weight and
+// alignment, growing around the same edge the renderer anchors to. No box, no
+// panel, no field: a caret in the drawing, and the words you're changing.
 //
 // Enter (or ⌘Enter on a multi-line text node) and clicking away both commit.
 // Escape cancels, which is what Escape means everywhere else in squig.
@@ -10,33 +15,21 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useSquig } from "@/lib/store"
-import type { SquigNode, TextNode, ComponentNode } from "@/lib/types"
-import { getDef } from "@/lib/library/registry"
+import type { ComponentNode, SquigNode, TextNode } from "@/lib/types"
+import type { EditTarget } from "@/lib/canvas/edit-target"
+import { fontMetrics, measureLinesWidth } from "@/lib/canvas/text-metrics"
+import { fitTextBox } from "@/lib/canvas/text-reflow"
+import { TEXT_LINE_HEIGHT, anchorFactor } from "@/lib/sketch/text-layout"
 
-export function TextEditOverlay() {
-  const editingId = useSquig((s) => s.editingId)
-  const node = useSquig((s) => (s.editingId ? s.nodes[s.editingId] : null))
-  if (!node || !editingId) return null
-  return <Editor node={node} />
-}
+/** Room for a caret at either end of the run, in screen px. */
+const CARET_PAD = 2
 
-function Editor({ node }: { node: SquigNode }) {
-  const viewport = useSquig((s) => s.viewport)
+export function TextEditOverlay({ node, target }: { node: SquigNode; target: EditTarget }) {
+  const v = useSquig((s) => s.viewport)
   const st = useSquig.getState
 
   const isText = node.type === "text"
-  const textControlKey = useMemo(() => {
-    if (node.type !== "component") return null
-    return getDef(node.kind)?.controls.find((c) => c.type === "text")?.key ?? null
-  }, [node])
-
-  const initial = isText
-    ? (node as TextNode).text
-    : node.type === "component" && textControlKey
-      ? String((node as ComponentNode).props[textControlKey] ?? "")
-      : ""
-
-  const [value, setValue] = useState(initial)
+  const [value, setValue] = useState(target.value)
   const taRef = useRef<HTMLTextAreaElement>(null)
 
   const commit = () => {
@@ -50,7 +43,7 @@ function Editor({ node }: { node: SquigNode }) {
       s.setEditing(null)
       return
     }
-    if (value === initial) {
+    if (value === target.value) {
       // nothing changed — don't spend an undo step saying so
       s.setEditing(null)
       return
@@ -61,18 +54,11 @@ function Editor({ node }: { node: SquigNode }) {
       if (!trimmed) {
         s.removeNodes([node.id], { checkpoint: false })
       } else {
-        const lines = trimmed.split("\n")
-        const fs = (node as TextNode).fontSize
-        const wGuess = Math.max(...lines.map((l) => l.length)) * fs * 0.5 + 10
-        s.updateNode(node.id, {
-          text: trimmed,
-          w: Math.max(40, wGuess),
-          h: lines.length * fs * 1.35,
-        } as Partial<SquigNode>)
+        s.updateNode(node.id, fitTextBox(node as TextNode, trimmed) as Partial<SquigNode>)
       }
-    } else if (textControlKey) {
+    } else if (target.propKey) {
       s.updateNode(node.id, {
-        props: { ...(node as ComponentNode).props, [textControlKey]: value },
+        props: { ...(node as ComponentNode).props, [target.propKey]: value },
       } as Partial<SquigNode>)
     }
     s.setEditing(null)
@@ -119,14 +105,48 @@ function Editor({ node }: { node: SquigNode }) {
     return () => window.removeEventListener("pointerdown", onDown, true)
   }, [])
 
-  const v = viewport
-  const fontSize = isText ? (node as TextNode).fontSize * v.zoom : 15 * v.zoom
+  const placeholder = isText ? "say something" : "label"
+
+  /**
+   * Put the textarea's first baseline on the renderer's.
+   *
+   * A line box centres the face's em box inside itself and sets the baseline at
+   * half-leading + ascent — so measuring the ascent off the live font is what
+   * lands the caret on the line the words were already printing on. The padding
+   * is slack for ascenders, descenders and a caret at either end; the top-left
+   * walks back by exactly that much, so none of it shifts anything.
+   */
+  const box = useMemo(() => {
+    const size = target.fontSize * v.zoom
+    const style = { size, bold: target.bold, italic: target.italic }
+    const lines = value.split("\n")
+    const lineHeight = size * TEXT_LINE_HEIGHT
+    const { ascent, descent } = fontMetrics(style)
+
+    // an empty run still needs somewhere to show its placeholder
+    const run = measureLinesWidth(value ? lines : [placeholder], style)
+    const padY = size * 0.35
+    const anchorX = (node.x + target.x) * v.zoom + v.x
+    const baselineY = (node.y + target.baseline) * v.zoom + v.y
+
+    return {
+      left: anchorX - CARET_PAD - anchorFactor(target.align) * run,
+      top: baselineY - ((lineHeight - (ascent + descent)) / 2 + ascent) - padY,
+      width: run + CARET_PAD * 2,
+      height: lines.length * lineHeight + padY * 2,
+      padding: `${padY}px ${CARET_PAD}px`,
+      fontSize: size,
+      lineHeight: `${lineHeight}px`,
+    }
+  }, [node.x, node.y, target, value, v, placeholder])
 
   return (
     <textarea
       ref={taRef}
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      wrap="off"
+      spellCheck={false}
+      onChange={(e) => setValue(target.multiline ? e.target.value : e.target.value.replace(/\n/g, ""))}
       onBlur={() => {
         if (!settled.current) {
           requestAnimationFrame(() => taRef.current?.focus())
@@ -141,25 +161,35 @@ function Editor({ node }: { node: SquigNode }) {
           cancel()
           return
         }
-        if (e.key === "Enter" && (e.metaKey || !isText)) {
+        if (e.key === "Enter" && (e.metaKey || !target.multiline)) {
           e.preventDefault()
           commit()
         }
       }}
-      className="absolute resize-none overflow-hidden rounded-md px-2 py-1 outline-none"
+      className="absolute resize-none overflow-hidden border-0 outline-none"
       style={{
-        left: node.x * v.zoom + v.x - 8,
-        top: node.y * v.zoom + v.y - 6,
-        minWidth: Math.max(node.w * v.zoom + 16, 140),
-        height: Math.max(node.h * v.zoom + 12, fontSize * 1.8),
-        fontSize,
+        left: box.left,
+        top: box.top,
+        width: box.width,
+        height: box.height,
+        padding: box.padding,
+        boxSizing: "border-box",
+        fontSize: box.fontSize,
+        lineHeight: box.lineHeight,
         fontFamily: "var(--sq-font)",
-        lineHeight: 1.35,
-        color: "var(--sq-ink)",
-        background: "rgba(255,255,255,0.92)",
-        border: "1.5px dashed var(--sq-select)",
+        fontWeight: target.bold ? 700 : 400,
+        fontStyle: target.italic ? "italic" : undefined,
+        textDecoration: target.underline ? "underline" : undefined,
+        textAlign: target.align,
+        whiteSpace: "pre",
+        color: target.color,
+        caretColor: "var(--sq-ink)",
+        // the one tell that this run is live: a wash the width of the words,
+        // rather than a field the words have been moved into
+        background: "color-mix(in srgb, var(--sq-select) 12%, transparent)",
+        borderRadius: 2,
       }}
-      placeholder={isText ? "say something" : "label"}
+      placeholder={placeholder}
     />
   )
 }

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -15,11 +15,12 @@
 // ---------------------------------------------------------------------------
 
 import { useSquig } from "@/lib/store"
-import type { ArrowNode, ComponentNode, FillTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
+import type { ArrowNode, ComponentNode, FillTone, ShapeNode, SquigNode, StrokeWeight, TextAlign, TextNode } from "@/lib/types"
 import { normalizeFill } from "@/lib/types"
 import { getDef } from "@/lib/library/registry"
 import { selectionSummary, shared, sharedControls, sharedNumber, unionBounds } from "@/lib/selection"
 import { scaleNodes, MIN_SIZE } from "@/lib/canvas/transform"
+import { fitTextBox } from "@/lib/canvas/text-reflow"
 import { VariantControl } from "./variant-controls"
 import { MixedNumberField, MixedSwitch, MixedTextField } from "./mixed-fields"
 import { AlignRow } from "./align-row"
@@ -34,6 +35,9 @@ import {
   FlipVerticalIcon,
   LinkBreakIcon,
   SelectionAllIcon,
+  TextAlignCenterIcon,
+  TextAlignLeftIcon,
+  TextAlignRightIcon,
   TextBIcon,
   TextItalicIcon,
   TextUnderlineIcon,
@@ -115,6 +119,17 @@ const STROKE_OPTIONS: readonly SegmentOption<StrokeWeight>[] = [
   { value: "light", label: "Light pen", content: <PenChip height={1} /> },
   { value: "regular", label: "Regular pen", content: <PenChip height={1.75} /> },
   { value: "heavy", label: "Heavy pen", content: <PenChip height={3} /> },
+]
+
+/**
+ * Three, not four: squig text doesn't wrap, so there is no justify to be had —
+ * a line ends where you pressed Return. What these do decide is which edge the
+ * run is pinned to, which is the edge that holds still while you type.
+ */
+const ALIGN_OPTIONS: readonly SegmentOption<TextAlign>[] = [
+  { value: "left", label: "Align left", content: <TextAlignLeftIcon className="size-4" /> },
+  { value: "center", label: "Align centre", content: <TextAlignCenterIcon className="size-4" /> },
+  { value: "right", label: "Align right", content: <TextAlignRightIcon className="size-4" /> },
 ]
 
 /** Drawn as icons, not as styled letters — a glyph small enough to fit the
@@ -376,9 +391,18 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
             <MixedTextField
               ariaLabel="Text"
               shared={shared(texts.map((n) => n.text))}
-              onCommit={(v) => patch((n) => (n.type === "text" ? (reflowText(n, v, n.fontSize) as Partial<SquigNode>) : null))}
+              onCommit={(v) => patch((n) => (n.type === "text" ? (fitTextBox(n, v) as Partial<SquigNode>) : null))}
             />
           </StackRow>
+
+          <Row label="Align">
+            <Segmented
+              ariaLabel="Text alignment"
+              options={ALIGN_OPTIONS}
+              shared={shared(texts.map((n) => n.align ?? "left"))}
+              onChange={(align) => patch((n) => (n.type === "text" ? ({ align } as Partial<SquigNode>) : null))}
+            />
+          </Row>
 
           <Row label="Style">
             {TEXT_STYLES.map(({ key, label, icon: Icon }) => {
@@ -419,11 +443,11 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
               shared={sharedNumber(texts, (n) => (n as TextNode).fontSize)}
               onGestureStart={startGesture}
               onCommit={(v) =>
-                live((n) => (n.type === "text" && v > 0 ? (reflowText(n, n.text, v) as Partial<SquigNode>) : null))
+                live((n) => (n.type === "text" && v > 0 ? (fitTextBox(n, n.text, v) as Partial<SquigNode>) : null))
               }
               onStep={(d) =>
                 live((n) =>
-                  n.type === "text" ? (reflowText(n, n.text, Math.max(4, n.fontSize + d)) as Partial<SquigNode>) : null
+                  n.type === "text" ? (fitTextBox(n, n.text, Math.max(4, n.fontSize + d)) as Partial<SquigNode>) : null
                 )
               }
             />
@@ -551,11 +575,4 @@ function isOutlined(n: SquigNode): boolean {
 function resizeTo(n: SquigNode, w: number, h: number): Partial<SquigNode> {
   const from = unionBounds([n])!
   return scaleNodes([n], from, { x: n.x, y: n.y, w, h })[n.id]
-}
-
-/** Text nodes size themselves from their content — keep the box honest. */
-function reflowText(n: TextNode, text: string, fontSize: number): Partial<TextNode> {
-  const lines = (text || " ").split("\n")
-  const wGuess = Math.max(...lines.map((l) => l.length)) * fontSize * 0.5 + 10
-  return { text, fontSize, w: Math.max(40, wGuess), h: lines.length * fontSize * 1.35 }
 }

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -43,6 +43,9 @@ export interface EditTarget {
 /** Unlikely to be anyone's label, short enough to survive truncation. */
 const MARKER = "⁣zqx"
 
+/** An index no run has — "the editor is standing in for nothing drawn". */
+const NO_RUN = -1
+
 function textPrims(prims: Prim[]): TextPrim[] {
   return prims.filter((p): p is TextPrim => p.t === "text")
 }
@@ -123,20 +126,22 @@ export function editTarget(node: SquigNode): EditTarget | null {
 
   // Nothing found means the def draws this prop some way we can't see — an
   // empty label with no placeholder, most likely. Edit at the middle of the
-  // node, which is where a label would land once there was one.
+  // node, on the centre line a label would sit on once there was one. The
+  // size and the nudge below the middle are what a button label uses.
   if (!found) {
+    const fontSize = 15
     return {
       value,
       x: node.w / 2,
-      baseline: node.h / 2 + 15 * 0.35,
-      fontSize: 15,
+      baseline: node.h / 2 + fontSize * 0.35,
+      fontSize,
       align: "center",
       bold: false,
       italic: false,
       underline: false,
       color: INK.ink,
       multiline: false,
-      hidden: -1,
+      hidden: NO_RUN,
       propKey: key,
     }
   }

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------------
+// What double-clicking a node actually puts you into.
+//
+// Editing should happen where the words are — same baseline, same size, same
+// alignment — so the editor needs the geometry of the *drawn* run, not the
+// node's bounding box. For a text node that's arithmetic. For a component the
+// label is buried somewhere inside authored prims (centred in a button, hung
+// off an icon, offset inside a card), so we find it the only way that can't go
+// stale: render the component twice, once with the label swapped for a marker,
+// and see which run changed.
+// ---------------------------------------------------------------------------
+
+import { INK, type Prim } from "@/lib/sketch/kit"
+import { nodePrims } from "@/lib/sketch/node-prims"
+import { textAnchorX, textBaseline } from "@/lib/sketch/text-layout"
+import { getDef } from "@/lib/library/registry"
+import type { ComponentNode, SquigNode, TextAlign, TextNode } from "@/lib/types"
+
+type TextPrim = Extract<Prim, { t: "text" }>
+
+export interface EditTarget {
+  /** the string the editor starts on */
+  value: string
+  /** anchor x, node-local — which edge of the run `align` pins */
+  x: number
+  /** first baseline, node-local */
+  baseline: number
+  fontSize: number
+  align: TextAlign
+  bold: boolean
+  italic: boolean
+  underline: boolean
+  /** the ink this run prints in, as a css colour */
+  color: string
+  /** a text node takes Return; a component label is one line */
+  multiline: boolean
+  /** which drawn run the editor stands in for, so the canvas can hide it */
+  hidden: "all" | number
+  /** for a component, the prop the edited string lives in */
+  propKey?: string
+}
+
+/** Unlikely to be anyone's label, short enough to survive truncation. */
+const MARKER = "⁣zqx"
+
+function textPrims(prims: Prim[]): TextPrim[] {
+  return prims.filter((p): p is TextPrim => p.t === "text")
+}
+
+/** The text control a double-click edits — the first one the def declares. */
+export function textControlKey(node: ComponentNode): string | null {
+  return getDef(node.kind)?.controls.find((c) => c.type === "text")?.key ?? null
+}
+
+function currentValue(node: ComponentNode, key: string): string {
+  const def = getDef(node.kind)
+  const value = node.props[key] ?? def?.defaults[key]
+  return value == null ? "" : String(value)
+}
+
+/** Which of the node's drawn runs prints `key`, and where it sits. */
+function locateLabel(node: ComponentNode, key: string): { prim: TextPrim; index: number } | null {
+  const runs = textPrims(nodePrims(node))
+  if (!runs.length) return null
+
+  const marked = textPrims(nodePrims({ ...node, props: { ...node.props, [key]: MARKER } }))
+  if (marked.length === runs.length) {
+    const i = runs.findIndex((run, n) => run.text !== marked[n].text)
+    if (i >= 0) return { prim: runs[i], index: i }
+  }
+
+  // A def whose layout changes with the label's length renders a different
+  // number of runs for the marker. Fall back to matching the string itself,
+  // truncation and all.
+  const value = currentValue(node, key)
+  const i = runs.findIndex((run) => run.text === value || (run.text.endsWith("…") && value.startsWith(run.text.slice(0, -1))))
+  return i >= 0 ? { prim: runs[i], index: i } : null
+}
+
+/**
+ * A text node's own geometry.
+ *
+ * Flips are handled the way mirrorPrims handles them — layout moves, glyphs
+ * stay upright — so a mirrored node edits where it prints. A flipped *multi*-
+ * line node is the one case that can't be honest: the renderer stacks its
+ * lines bottom-up, and a textarea only stacks one way, so the editor sits on
+ * the topmost baseline and the lines read in typing order.
+ */
+function textNodeTarget(node: TextNode): EditTarget {
+  const lines = node.text.split("\n")
+  const align: TextAlign = node.align ?? "left"
+  const flipped: TextAlign = node.flipX ? (align === "left" ? "right" : align === "right" ? "left" : "center") : align
+
+  const x = node.flipX ? node.w - textAnchorX(align, node.w) : textAnchorX(align, node.w)
+  const top = node.flipY
+    ? node.h - textBaseline(Math.max(0, lines.length - 1), node.fontSize) + node.fontSize * 0.6
+    : textBaseline(0, node.fontSize)
+
+  return {
+    value: node.text,
+    x,
+    baseline: top,
+    fontSize: node.fontSize,
+    align: flipped,
+    bold: !!node.bold,
+    italic: !!node.italic,
+    underline: !!node.underline || !!node.link,
+    color: INK.ink,
+    multiline: true,
+    hidden: "all",
+  }
+}
+
+/** Where — and how — a node's text should be edited, or null if it has none. */
+export function editTarget(node: SquigNode): EditTarget | null {
+  if (node.type === "text") return textNodeTarget(node)
+  if (node.type !== "component") return null
+
+  const key = textControlKey(node)
+  if (!key) return null
+  const value = currentValue(node, key)
+  const found = locateLabel(node, key)
+
+  // Nothing found means the def draws this prop some way we can't see — an
+  // empty label with no placeholder, most likely. Edit at the middle of the
+  // node, which is where a label would land once there was one.
+  if (!found) {
+    return {
+      value,
+      x: node.w / 2,
+      baseline: node.h / 2 + 15 * 0.35,
+      fontSize: 15,
+      align: "center",
+      bold: false,
+      italic: false,
+      underline: false,
+      color: INK.ink,
+      multiline: false,
+      hidden: -1,
+      propKey: key,
+    }
+  }
+
+  const { prim, index } = found
+  return {
+    value,
+    x: prim.x,
+    baseline: prim.y,
+    fontSize: prim.size,
+    align: prim.align ?? "left",
+    bold: !!prim.bold,
+    italic: !!prim.italic,
+    underline: !!prim.underline,
+    color: INK[prim.color ?? "ink"],
+    multiline: false,
+    hidden: index,
+    propKey: key,
+  }
+}

--- a/lib/canvas/text-metrics.ts
+++ b/lib/canvas/text-metrics.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// Measuring the canvas face.
+//
+// The inline editor has to put a textarea's first baseline exactly where the
+// renderer drew one, and a textarea's baseline depends on the font's own
+// ascent and descent — numbers only the browser knows. So we ask it, through a
+// 2D context set to the same face the drawing letters in.
+//
+// Everything falls back to the same rough em-ratios the sketch kit uses, so a
+// server render (or a browser without the metrics) still produces a sane box.
+// ---------------------------------------------------------------------------
+
+export interface TypeStyle {
+  /** in whatever units you want the answer in — px on screen, canvas units off it */
+  size: number
+  bold?: boolean
+  italic?: boolean
+}
+
+const FALLBACK_ASCENT = 0.8
+const FALLBACK_DESCENT = 0.2
+/** Patrick Hand averages about this; see textWidth in the sketch kit. */
+const FALLBACK_WIDTH = 0.46
+
+let probe: HTMLSpanElement | null = null
+let ctx: CanvasRenderingContext2D | null = null
+
+/**
+ * The face `--sq-font` currently resolves to.
+ *
+ * It's a var pointing at another var, so the value has to be read off an
+ * element that has already been styled with it. The probe is one hidden span,
+ * created once and left in place — it keeps resolving as the document's look
+ * changes, which is exactly what we want.
+ */
+function resolvedFamily(): string | null {
+  if (typeof document === "undefined") return null
+  if (!probe) {
+    probe = document.createElement("span")
+    probe.setAttribute("aria-hidden", "true")
+    probe.style.cssText =
+      "position:absolute;top:-9999px;left:-9999px;visibility:hidden;pointer-events:none;font-family:var(--sq-font)"
+    document.body.appendChild(probe)
+  }
+  return getComputedStyle(probe).fontFamily || null
+}
+
+function context(style: TypeStyle): CanvasRenderingContext2D | null {
+  const family = resolvedFamily()
+  if (!family) return null
+  if (!ctx) ctx = document.createElement("canvas").getContext("2d")
+  if (!ctx) return null
+  ctx.font = `${style.italic ? "italic " : ""}${style.bold ? "700" : "400"} ${style.size}px ${family}`
+  return ctx
+}
+
+/** Width of one line, in the same units as `style.size`. */
+export function measureTextWidth(text: string, style: TypeStyle): number {
+  if (!text) return 0
+  const c = context(style)
+  if (!c) return text.length * style.size * FALLBACK_WIDTH
+  return c.measureText(text).width
+}
+
+/** Widest of a run's lines. */
+export function measureLinesWidth(lines: string[], style: TypeStyle): number {
+  return lines.reduce((max, line) => Math.max(max, measureTextWidth(line, style)), 0)
+}
+
+/**
+ * The face's own ascent and descent at this size — the em box a browser
+ * centres inside a line box before it puts the baseline down.
+ */
+export function fontMetrics(style: TypeStyle): { ascent: number; descent: number } {
+  const c = context(style)
+  const m = c?.measureText("Hxg")
+  const ascent = m?.fontBoundingBoxAscent
+  const descent = m?.fontBoundingBoxDescent
+  if (typeof ascent !== "number" || typeof descent !== "number" || !(ascent + descent > 0)) {
+    return { ascent: style.size * FALLBACK_ASCENT, descent: style.size * FALLBACK_DESCENT }
+  }
+  return { ascent, descent }
+}

--- a/lib/canvas/text-reflow.ts
+++ b/lib/canvas/text-reflow.ts
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// Keeping a text node's box honest about what's in it.
+// ---------------------------------------------------------------------------
+
+import { anchorFactor, textBlockHeight } from "@/lib/sketch/text-layout"
+import { measureLinesWidth } from "./text-metrics"
+import type { TextNode } from "@/lib/types"
+
+/** Narrow enough to hug an "i", wide enough to still be worth clicking. */
+const MIN_WIDTH = 24
+/** A hair past the last glyph, so the selection ring never clips an overhang. */
+const SLACK = 2
+
+/**
+ * Fit the box to the words.
+ *
+ * The box grows and shrinks around whichever edge the alignment pins, so
+ * centred text stays centred where it was and right-aligned text keeps its
+ * right edge instead of sliding off it. Vertically it always grows downward —
+ * the first baseline is the one thing that never moves while you type.
+ */
+export function fitTextBox(n: TextNode, text: string, fontSize = n.fontSize): Partial<TextNode> {
+  const lines = (text || " ").split("\n")
+  const measured = measureLinesWidth(lines, { size: fontSize, bold: n.bold, italic: n.italic })
+  const w = Math.max(MIN_WIDTH, measured + SLACK)
+  return {
+    text,
+    fontSize,
+    x: n.x + (n.w - w) * anchorFactor(n.align),
+    w,
+    h: textBlockHeight(lines.length, fontSize),
+  }
+}

--- a/lib/canvas/text-reflow.ts
+++ b/lib/canvas/text-reflow.ts
@@ -18,15 +18,19 @@ const SLACK = 2
  * centred text stays centred where it was and right-aligned text keeps its
  * right edge instead of sliding off it. Vertically it always grows downward —
  * the first baseline is the one thing that never moves while you type.
+ *
+ * A mirrored node pins the opposite edge: flipping swaps which end of the box
+ * the run hangs off (see mirrorPrims), so the anchor has to swap with it.
  */
 export function fitTextBox(n: TextNode, text: string, fontSize = n.fontSize): Partial<TextNode> {
   const lines = (text || " ").split("\n")
   const measured = measureLinesWidth(lines, { size: fontSize, bold: n.bold, italic: n.italic })
   const w = Math.max(MIN_WIDTH, measured + SLACK)
+  const pinned = n.flipX ? 1 - anchorFactor(n.align) : anchorFactor(n.align)
   return {
     text,
     fontSize,
-    x: n.x + (n.w - w) * anchorFactor(n.align),
+    x: n.x + (n.w - w) * pinned,
     w,
     h: textBlockHeight(lines.length, fontSize),
   }

--- a/lib/canvas/transform.ts
+++ b/lib/canvas/transform.ts
@@ -162,8 +162,9 @@ export function scaleNodes(
     } else if (n.type === "arrow") {
       patch.points = n.points.map(([px, py]) => [px * sx, py * sy]) as [[number, number], [number, number]]
     } else if (n.type === "text") {
-      // the renderer lays lines out at fontSize * (i + 1), so the type has to
-      // follow the vertical scale or the box and the words come apart
+      // the renderer lays every baseline out in multiples of the type size, so
+      // the type has to follow the vertical scale or the box and the words
+      // come apart — see lib/sketch/text-layout
       patch.fontSize = Math.max(4, n.fontSize * sy)
     }
 

--- a/lib/library/break-apart.ts
+++ b/lib/library/break-apart.ts
@@ -5,7 +5,9 @@
 
 import { nanoid } from "nanoid"
 import type { ComponentNode, FillTone, SquigNode } from "@/lib/types"
+import { measureTextWidth } from "@/lib/canvas/text-metrics"
 import { mirrorPrims, type PrimOpts } from "@/lib/sketch/kit"
+import { anchorFactor, textBlockHeight } from "@/lib/sketch/text-layout"
 import { renderComponent } from "./registry"
 
 const seed = () => Math.floor(Math.random() * 2 ** 31)
@@ -96,13 +98,16 @@ export function breakApart(node: ComponentNode): SquigNode[] {
         break
       }
       case "text": {
-        const approxW = p.text.length * p.size * 0.46
-        const x = p.align === "center" ? p.x - approxW / 2 : p.align === "right" ? p.x - approxW : p.x
+        // the box hangs off the same edge the run was anchored to, so a label
+        // that was centred in its component comes out centred on its old spot
+        const w = Math.max(measureTextWidth(p.text, { size: p.size, bold: p.bold, italic: p.italic }), 20)
         out.push({
           id: nanoid(8), type: "text",
-          x: node.x + x, y: node.y + p.y - p.size,
-          w: Math.max(approxW, 20), h: p.size * 1.4,
-          text: p.text, fontSize: p.size,
+          x: node.x + p.x - anchorFactor(p.align) * w,
+          y: node.y + p.y - p.size,
+          w, h: textBlockHeight(1, p.size),
+          text: p.text, fontSize: p.size, align: p.align,
+          bold: p.bold, italic: p.italic, underline: p.underline,
           seed: seed(),
         })
         break

--- a/lib/sketch/kit.ts
+++ b/lib/sketch/kit.ts
@@ -7,6 +7,21 @@
 export type InkColor = "ink" | "muted" | "faint" | "paper" | "accent"
 
 /**
+ * House defaults for the hand.
+ *
+ * Deliberately restrained: enough irregularity that a line reads as drawn
+ * rather than generated, but not so much that corners fall open. The renderer
+ * reads all four; anything that draws a plain line starts from `strokeWidth`.
+ */
+export const HAND = {
+  roughness: 0.25,
+  bowing: 0.35,
+  strokeWidth: 1.4,
+  /** default corner rounding for rects that don't ask for one */
+  radius: 3,
+}
+
+/**
  * Colours resolve through CSS custom properties, so switching theme restyles
  * every node without regenerating a single path. See lib/theme.ts.
  */

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------
+// A node's marks, before anything draws them.
+//
+// The canvas renders these; the inline editor reads them to find out where a
+// label actually sits. Both need the same answer, so the geometry lives here
+// rather than inside the renderer.
+// ---------------------------------------------------------------------------
+
+import { HAND, mirrorPrims, type Prim, type PrimOpts } from "./kit"
+import { textAnchorX, textBaseline } from "./text-layout"
+import { normalizeFill, type FillTone, type Outlined, type SquigNode, type StrokeWeight } from "@/lib/types"
+import { renderComponent } from "@/lib/library/registry"
+
+/**
+ * A shape's fill tone, as prim options.
+ *
+ * These reuse the component ladder rather than inventing a second one: `light`
+ * and `strong` are the same two shades every card and button prints with, so a
+ * filled scribble sits in the same tonal world as the library. `paper` is
+ * genuinely opaque — it's the tone you reach for when a box has to hide what
+ * it overlaps rather than tint it.
+ */
+const FILL_OPTS: Record<FillTone, PrimOpts | undefined> = {
+  none: undefined,
+  paper: { fill: "solid", fillColor: "paper" },
+  light: { fill: "shade", fillColor: "faint" },
+  strong: { fill: "shade", fillColor: "ink" },
+}
+
+/**
+ * Pen pressure, as a multiplier on whatever weight the mark draws at by
+ * default. A multiplier rather than three absolute widths because an arrow, a
+ * freehand line and a rectangle don't start from the same weight, and "heavy"
+ * should mean the same *relative* press on all three.
+ */
+const PEN_SCALE: Record<StrokeWeight, number> = { light: 0.65, regular: 1, heavy: 1.7 }
+
+/** Merge a node's outline settings into the options for one of its marks. */
+function outline(node: Outlined, baseWidth: number, o?: PrimOpts): PrimOpts {
+  return {
+    ...o,
+    strokeWidth: baseWidth * PEN_SCALE[node.stroke ?? "regular"],
+    dashed: node.dashed,
+  }
+}
+
+/** A node's prims before any flip is applied. */
+export function basePrims(node: SquigNode): Prim[] {
+  switch (node.type) {
+    case "component":
+      return renderComponent(node.kind, node.props, node.w, node.h)
+    case "shape": {
+      const o = outline(node, HAND.strokeWidth, FILL_OPTS[normalizeFill(node.fill)])
+      if (node.shape === "ellipse") return [{ t: "ellipse", x: 0, y: 0, w: node.w, h: node.h, o }]
+      return [{ t: "rect", x: 0, y: 0, w: node.w, h: node.h, r: 6, o }]
+    }
+    case "draw":
+      // freehand is already the user's own line — barely roughen it
+      return [{ t: "poly", pts: node.points, o: outline(node, 1.9, { roughness: 0.2 }) }]
+    case "arrow": {
+      const [[x1, y1], [x2, y2]] = node.points
+      const o = outline(node, 1.6)
+      const out: Prim[] = [{ t: "line", x1, y1, x2, y2, o }]
+      if (node.head) {
+        const a = Math.atan2(y2 - y1, x2 - x1)
+        const L = 12
+        out.push({
+          t: "poly",
+          pts: [
+            [x2 - L * Math.cos(a - 0.45), y2 - L * Math.sin(a - 0.45)],
+            [x2, y2],
+            [x2 - L * Math.cos(a + 0.45), y2 - L * Math.sin(a + 0.45)],
+          ],
+          // a dashed arrowhead reads as a rendering fault, not a style
+          o: { ...o, dashed: false },
+        })
+      }
+      return out
+    }
+    case "text": {
+      const anchor = textAnchorX(node.align, node.w)
+      return node.text.split("\n").map((lineText, i): Prim => ({
+        t: "text",
+        x: anchor,
+        y: textBaseline(i, node.fontSize),
+        text: lineText,
+        size: node.fontSize,
+        align: node.align,
+        bold: node.bold,
+        italic: node.italic,
+        // a link is a link because it's underlined — no blue in a wireframe
+        underline: node.underline || !!node.link,
+      }))
+    }
+  }
+}
+
+/** Everything a node draws, in node-local coordinates, flips applied. */
+export function nodePrims(node: SquigNode): Prim[] {
+  return mirrorPrims(basePrims(node), node.w, node.h, !!node.flipX, !!node.flipY)
+}

--- a/lib/sketch/text-layout.ts
+++ b/lib/sketch/text-layout.ts
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------
+// Where the lines of a text node sit inside its box.
+//
+// The renderer, the inline editor and the box-fitting maths all have to agree
+// on these numbers or the words jump the moment you start — or stop — typing.
+// So they live here, and nowhere else.
+// ---------------------------------------------------------------------------
+
+import type { TextAlign } from "@/lib/types"
+
+/** Line spacing, as a multiple of the type size. */
+export const TEXT_LINE_HEIGHT = 1.35
+
+/**
+ * The first baseline, as a multiple of the type size, measured from the top of
+ * the box. A browser puts it at half-leading + ascent, which for an ordinary
+ * face at this line height lands within a hair of one em — so the editor, which
+ * computes it from the real font metrics, sits on the line the renderer drew.
+ */
+export const TEXT_FIRST_BASELINE = 1
+
+/** Descender room under the last baseline, again as a multiple of the size. */
+const DESCENDER = 0.3
+
+export function textBaseline(line: number, fontSize: number): number {
+  return fontSize * (TEXT_FIRST_BASELINE + line * TEXT_LINE_HEIGHT)
+}
+
+/** The height a run of lines needs: first baseline, the gaps, the descenders. */
+export function textBlockHeight(lineCount: number, fontSize: number): number {
+  return fontSize * (TEXT_FIRST_BASELINE + Math.max(0, lineCount - 1) * TEXT_LINE_HEIGHT + DESCENDER)
+}
+
+/**
+ * Which edge of the box an alignment pins the text to — 0 is the left edge,
+ * 1 the right. Used both to place the anchor and to hold it still while the
+ * box grows around it.
+ */
+export function anchorFactor(align: TextAlign | undefined): number {
+  return align === "center" ? 0.5 : align === "right" ? 1 : 0
+}
+
+/** Where the anchor for an alignment sits inside a box of width `w`. */
+export function textAnchorX(align: TextAlign | undefined, w: number): number {
+  return anchorFactor(align) * w
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -81,10 +81,19 @@ export interface DrawNode extends BaseNode, Outlined {
   points: [number, number][]
 }
 
+/**
+ * Squig text doesn't wrap — a line ends where you pressed Return — so there is
+ * no justify to be had. The three that remain are real: they decide which edge
+ * of the box the run is pinned to, which is what holds still while you type.
+ */
+export type TextAlign = "left" | "center" | "right"
+
 export interface TextNode extends BaseNode {
   type: "text"
   text: string
   fontSize: number
+  /** left when absent — most text is */
+  align?: TextAlign
   bold?: boolean
   italic?: boolean
   underline?: boolean


### PR DESCRIPTION
Double-clicking a label used to park a textarea at the node's top-left — a white box with a dashed border, the words pulled out of the drawing and re-set in a field. A centred button label jumped to the left edge; everything landed somewhere else again on commit.

Now the editor stands where the words are. The drawn run is hidden and a bare textarea takes its place: same baseline, size, weight, alignment, growing around the same edge the renderer anchors to. The first baseline is computed from the live font's own ascent (measured through a 2D context), so the caret lands on the line the words were already printing on. The only tell that a run is live is a wash the width of the words.

For a component the label is buried somewhere in authored prims, so we find it by rendering the component twice — once with the label swapped for a marker — and seeing which run changed. That handles centred button labels, icon-offset ones, and labels truncated to fit.

**Along the way**

- Text nodes gain an **Align** control (left / centre / right). No justify: squig text doesn't wrap, so a line ends where you pressed Return. Alignment decides which edge the box grows around, so words don't slide sideways as you type.
- Line spacing, first baseline and box-fitting move into one module (`lib/sketch/text-layout`) that the renderer, the editor and the inspector all read. They disagreed before — lines were drawn one em apart inside a box measured at 1.35.
- Text boxes are measured with the real font instead of counting characters, so the selection ring hugs the words.
- Breaking a component apart keeps each run's alignment and style.
- `basePrims` moved out of the renderer into `lib/sketch/node-prims`, so the editor can ask where a mark sits without importing a component.

**Verified in the running app** (not just types): text nodes at 100% and 156% zoom, multi-line, centred and flipped; button labels centred and icon-offset; a truncated label reopening with its full value; commit via Enter, ⌘Enter and click-away; Escape restoring the hidden run; a fresh text node from the T tool. Ghosting the renderer's own `<text>` over the live editor shows no fringe — the glyphs land on the same pixels.

Types, lint and `pnpm test` (68 checks) pass.

Known rough edge, pre-existing: the inspector's Text field is single-line, so committing it on a multi-line text node flattens the line breaks. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)