### PR TITLE
Stop node_modules drifting away from the lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,14 @@
+# node_modules that has fallen behind the lockfile is checked before every
+# script pnpm runs, and brought back into line automatically.
+#
+# This is here because it already bit us. The Base UI migration changed
+# package.json and the lockfile; node_modules was never re-installed, so it sat
+# two days behind, still holding the radix-ui set that migration replaced. The
+# app stopped building with "can't resolve @base-ui/react", which reads like a
+# code bug and isn't one. A fresh git worktree — no node_modules at all — heals
+# the same way, so `pnpm dev` in one just works.
+#
+# npm doesn't know this setting and warns that it doesn't. That warning is the
+# expected cost: pnpm is the declared package manager (see packageManager in
+# package.json), and pnpm is where the healing lives.
+verify-deps-before-run=install

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Pin the workspace root to this repo.
+  //
+  // Turbopack works out the root by walking up the tree looking for lockfiles,
+  // and there is a stray package.json + pnpm-lock.yaml sitting in the home
+  // directory. Left to infer, it picked $HOME — which puts ~/node_modules on
+  // the resolution path, so a dependency missing from this repo could quietly
+  // resolve to a different version of itself two directories up. Saying where
+  // the root is means that can't happen, whatever else is lying around.
+  turbopack: {
+    root: path.dirname(fileURLToPath(import.meta.url)),
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "squig",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.4.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Fixes the `Module not found: Can't resolve '@base-ui/react'` that turns up when you least want it — and makes it not come back.

## What actually happened

Nothing was wrong with the code. The Base UI migration (#13) changed `package.json` and the lockfile on Jul 29; `node_modules` was last installed on Jul 27 and nobody re-installed after pulling. So the tree sat two days behind, still holding the `radix-ui` + `lucide-react` set that migration had replaced. The failure reads like a broken import and sends you looking through the inspector.

A second, quieter version of the same thing: there is a stray `package.json` + `pnpm-lock.yaml` + `node_modules` in the **home directory**. Turbopack finds the workspace root by walking up looking for lockfiles, so it was picking `/Users/pablostanley` — which puts `~/node_modules` (holding, among other things, a *different* version of `@phosphor-icons/react`) on the resolution path. A dependency missing from this repo could resolve to a different version of itself two directories up rather than failing honestly.

## The fix

- **`.npmrc` — `verify-deps-before-run=install`.** pnpm compares the installed tree against the lockfile before every script it runs, and installs when they disagree. This is pnpm's own mechanism, not a custom script.
- **`next.config.ts` — `turbopack.root` pinned to this directory.** The stray home-directory lockfile can no longer decide where the workspace root is.
- **`package.json` — `packageManager: "pnpm@10.4.1"`.** Names the tool outright so it can't drift either.

## Verified, not assumed

Reproduced the original failure and watched the guard clear it:

- Deleted `node_modules/@base-ui/react` — the exact state the main checkout was in — then ran `pnpm build`. pnpm restored it *before* the build ran, and the build compiled.
- Deleted `node_modules` **entirely** — a fresh git worktree — then ran `pnpm lint`. Full install in 7s, `0 downloaded` (straight from the local store, so it works offline), then the script ran.
- `turbopack.root`: build compiles and the "inferred your workspace root / detected multiple lockfiles" warning is gone.
- `pnpm lint`, `tsc --noEmit`, and the 68 geometry/selection checks all pass.

I also repaired your actual checkout (`pnpm install` in `/Users/pablostanley/squig`): `@base-ui/react` is present, the stale `radix-ui`/`lucide-react` are gone, no tracked file changed.

## Two things to know

- **`pnpm` is the self-healing path; `npm run` isn't.** pnpm's check only runs for scripts pnpm starts. `npm run dev` still bypasses it — worth knowing, since reaching for npm out of habit is how this hid in the first place.
- **npm warns about the unknown config** whenever it reads `.npmrc`. Cosmetic, and arguably a useful signal you're on the wrong tool, but it is new noise.

The stray `~/package.json` and `~/node_modules` are untouched — they're outside the repo and may well be deliberate. Pinning the root neutralises their effect here regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)