### PR TITLE
Flip text layers for real

### DIFF
--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -213,6 +213,18 @@ export function primsToPaths(
   return { paths, texts, crisp }
 }
 
+/**
+ * Turn a mirrored run over about its own anchor — the flipped-text-layer case.
+ * Scaling about the anchor rather than the origin is what keeps the words on
+ * the spot they were drawn instead of throwing them off the far side of the
+ * node.
+ */
+function mirrorGlyphs(t: Extract<Prim, { t: "text" }>): string | undefined {
+  if (!t.mirrorX && !t.mirrorY) return undefined
+  const [sx, sy] = [t.mirrorX ? -1 : 1, t.mirrorY ? -1 : 1]
+  return `translate(${t.x * (1 - sx)} ${t.y * (1 - sy)}) scale(${sx} ${sy})`
+}
+
 export const SketchPrims = memo(function SketchPrims({
   prims,
   seed,
@@ -270,6 +282,7 @@ export const SketchPrims = memo(function SketchPrims({
             textDecoration={t.underline ? "underline" : undefined}
             fill={INK[t.color ?? "ink"]}
             textAnchor={t.align === "center" ? "middle" : t.align === "right" ? "end" : "start"}
+            transform={mirrorGlyphs(t)}
           >
             {t.text}
           </text>

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -83,11 +83,14 @@ function locateLabel(node: ComponentNode, key: string): { prim: TextPrim; index:
 /**
  * A text node's own geometry.
  *
- * Flips are handled the way mirrorPrims handles them — layout moves, glyphs
- * stay upright — so a mirrored node edits where it prints. A flipped *multi*-
- * line node is the one case that can't be honest: the renderer stacks its
- * lines bottom-up, and a textarea only stacks one way, so the editor sits on
- * the topmost baseline and the lines read in typing order.
+ * A flipped node prints its words mirrored, but you edit them the right way
+ * round — a backwards caret helps nobody. The editor stands upright on the
+ * same patch of canvas the mirrored run covers, which is why the alignment is
+ * swapped here even though the prims keep theirs: an upright right-aligned run
+ * ends where a mirrored left-aligned one does. A flipped *multi*-line node is
+ * the one case that can't be honest: the renderer stacks its lines bottom-up,
+ * and a textarea only stacks one way, so the editor sits on the topmost
+ * baseline and the lines read in typing order.
  */
 function textNodeTarget(node: TextNode): EditTarget {
   const lines = node.text.split("\n")

--- a/lib/sketch/kit.ts
+++ b/lib/sketch/kit.ts
@@ -84,6 +84,13 @@ export type Prim =
       italic?: boolean
       underline?: boolean
       maxW?: number
+      /**
+       * Print the glyphs mirrored, about the anchor — what a flipped text
+       * layer asks for. Set by mirrorPrims, never by a def: a wireframe label
+       * always stays readable (see mirrorPrims).
+       */
+      mirrorX?: boolean
+      mirrorY?: boolean
     }
   /**
    * Raw SVG path data in a square viewBox, drawn crisp (not roughened) —
@@ -150,12 +157,16 @@ export function place(prims: Prim[], dx: number, dy: number): Prim[] {
 /**
  * Mirror a batch of prims inside a w×h box.
  *
- * Layout flips; glyphs don't. Mirroring the whole node with `scale(-1, 1)`
- * would be one line, but it would also print every label backwards, and a
- * wireframe with backwards labels reads as a bug rather than as a flip. So the
- * geometry moves and the text stays upright, swapping its alignment instead.
+ * By default layout flips and glyphs don't: a wireframe printing its labels
+ * backwards reads as a rendering bug rather than as a flip, so the geometry
+ * moves and the text stays upright, swapping its alignment instead.
+ *
+ * `glyphs` turns that off, for the one case where the words *are* the drawing:
+ * a text layer. There the run mirrors about its own anchor, which puts the same
+ * ink in the same place as the upright treatment — only backwards, which is the
+ * whole point of flipping it.
  */
-export function mirrorPrims(prims: Prim[], w: number, h: number, fx: boolean, fy: boolean): Prim[] {
+export function mirrorPrims(prims: Prim[], w: number, h: number, fx: boolean, fy: boolean, glyphs = false): Prim[] {
   if (!fx && !fy) return prims
   const mx = (x: number) => (fx ? w - x : x)
   const my = (y: number) => (fy ? h - y : y)
@@ -171,6 +182,12 @@ export function mirrorPrims(prims: Prim[], w: number, h: number, fx: boolean, fy
       case "poly":
         return { ...p, pts: p.pts.map(([px, py]) => [mx(px), my(py)] as [number, number]) }
       case "text": {
+        // Mirrored glyphs turn over about the anchor, so the anchor itself
+        // moves like any other point and the alignment stays as authored —
+        // right-aligned text mirrors to the left edge by turning over, not by
+        // becoming left-aligned. The baseline maps straight across too: the
+        // upside-down run hangs its ascenders below the line.
+        if (glyphs) return { ...p, x: mx(p.x), y: my(p.y), mirrorX: fx, mirrorY: fy }
         // a left-anchored run grows rightward; mirrored, it has to end where it started
         const align = fx
           ? p.align === "center"

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -95,7 +95,13 @@ export function basePrims(node: SquigNode): Prim[] {
   }
 }
 
-/** Everything a node draws, in node-local coordinates, flips applied. */
+/**
+ * Everything a node draws, in node-local coordinates, flips applied.
+ *
+ * A text layer flips for real — the words turn over. Everywhere else the words
+ * are labels on a wireframe and stay readable while the layout mirrors around
+ * them; see mirrorPrims.
+ */
 export function nodePrims(node: SquigNode): Prim[] {
-  return mirrorPrims(basePrims(node), node.w, node.h, !!node.flipX, !!node.flipY)
+  return mirrorPrims(basePrims(node), node.w, node.h, !!node.flipX, !!node.flipY, node.type === "text")
 }


### PR DESCRIPTION
Flipping a text layer did nothing you could see: `mirrorPrims` deliberately keeps glyphs upright while the layout mirrors around them — right for a wireframe, whose labels have to stay readable — but a text layer has no layout apart from its words, so the flip had nothing left to move.

**What changed**

- Text nodes mirror their glyphs. The run turns over about its own anchor, so it lands the same ink on the same spot the upright treatment did — which means a text layer flipped as part of a bigger selection still comes out where the mirror puts it.
- `mirrorPrims` takes a `glyphs` flag; only `nodePrims` sets it, and only for `type: "text"`. Labels drawn inside a component are untouched.
- Editing stays the right way round — the textarea stands upright over the patch the mirrored run covers.

**Checked in the running app**

- Horizontal, vertical, and both flips on a two-line text layer; flipping twice returns to the original.
- Text + rect flipped together: the text swaps sides and mirrors with the group.
- Left / center / right alignment while flipped — the run stays inside its box.
- Double-click on a flipped node opens the editor upright, in place.
- A flipped Card still prints "Card title", "Go" and "Nope" readably.

`npm test` (68 geometry/selection checks) and `tsc --noEmit` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)