### PR TITLE
Paste into squig — layers, words and pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ component and its pieces become editable primitives. One-way, on purpose.
 **⌘K searches everything.** Tools, actions, and every component and block, in
 one sheet. Enter drops it in the middle of your view.
 
+**Paste whatever you've got.** ⌘V takes the clipboard and puts it where the
+pointer is: a screenshot to wireframe around, a paragraph of copy, or layers
+copied out of another squig tab. Pictures land as themselves inside a drawn
+frame — a reference you can't read is no reference — and get shrunk on the way
+in, so a retina screenshot doesn't eat the drawer.
+
 **Your files stay in your browser.** Every document autosaves as you draw, and
 the file menu keeps a list of the recent ones to open again. New file starts a
 new document rather than painting over the last one. The drawer holds the last

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -24,6 +24,8 @@ import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type Snap
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type Handle } from "@/lib/canvas/transform"
 import { pickAt, pickInRect } from "@/lib/canvas/hit-test"
+import { canvasOwnsKeyboard } from "@/lib/canvas/keyboard-owner"
+import { useClipboard } from "@/lib/canvas/use-clipboard"
 import { editTarget } from "@/lib/canvas/edit-target"
 import { textBlockHeight } from "@/lib/sketch/text-layout"
 import { unionBounds, type Bounds } from "@/lib/selection"
@@ -134,35 +136,6 @@ type Gesture =
 const canAutoPan = (g: Gesture | null) =>
   !!g && (g.kind === "marquee" || g.kind === "move" || g.kind === "resize" || g.kind === "create")
 
-/**
- * Does the canvas get to act on this keystroke?
- *
- * Only two things take the keyboard away: somewhere you're typing, and an open
- * menu/listbox/dialog whose own typeahead would otherwise fire alongside the
- * tool hotkeys. Radix portals those outside the panel's DOM subtree, so this
- * looks for their roles document-wide rather than walking up from the target.
- *
- * Deliberately NOT here: chrome buttons, which keep DOM focus after a click —
- * gating on those meant one tap on the rail silently killed every shortcut.
- * Tooltips are excluded too: they're `role="tooltip"`, and hovering the button
- * that advertises a hotkey must not be what stops the hotkey working.
- */
-// NOT `[role=combobox]`: that is Radix's Select *trigger*, which sits in the
-// inspector permanently and keeps focus after use — matching it would kill the
-// keyboard for good. The open listbox it portals in is what matters.
-const KEYBOARD_OWNERS = "[role=dialog],[role=menu],[role=listbox]"
-
-function canvasOwnsKeyboard(target: EventTarget | null): boolean {
-  const el = target as HTMLElement | null
-  if (el && el !== document.body) {
-    const tag = el.tagName
-    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return false
-    if (el.isContentEditable) return false
-    if (el.closest?.(KEYBOARD_OWNERS)) return false
-  }
-  return !document.querySelector(KEYBOARD_OWNERS)
-}
-
 export function Canvas() {
   const containerRef = useRef<HTMLDivElement>(null)
   const gestureRef = useRef<Gesture | null>(null)
@@ -206,6 +179,8 @@ export function Canvas() {
   const [gestureKind, setGestureKind] = useState<Gesture["kind"] | null>(null)
 
   const { isSpacebarHeld } = useSpacebarPan()
+  // ⌘C/⌘X/⌘V live on the browser's clipboard events, not in onKey below
+  useClipboard(pointerWorld)
 
   const st = useSquig.getState
 
@@ -1172,25 +1147,10 @@ export function Canvas() {
             e.preventDefault()
             s.toggleTextStyle("underline")
             return
-          case "KeyC":
-            e.preventDefault()
-            s.copySelected()
-            return
-          case "KeyX":
-            e.preventDefault()
-            s.cutSelected()
-            return
-          case "KeyV": {
-            e.preventDefault()
-            if (e.shiftKey) {
-              // paste in place — right back where it was copied from
-              const cb = s.clipboard
-              if (cb.length) s.pasteClipboard([Math.min(...cb.map((n) => n.x)), Math.min(...cb.map((n) => n.y))])
-            } else {
-              s.pasteClipboard(pointerWorld.current ?? undefined)
-            }
-            return
-          }
+          // C, X and V are deliberately absent: preventing their default is
+          // what would stop the browser's copy/cut/paste events from firing,
+          // and those are where the clipboard actually happens — see
+          // lib/canvas/use-clipboard
           // one step on its own; all the way with ⌥ (Mac) or ⇧ (Windows)
           case "BracketRight":
             e.preventDefault()

--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -311,11 +311,40 @@ export const NodeSketch = memo(function NodeSketch({
         // w and align place the anchor, so a resize or a realignment is a
         // different set of marks even when the words haven't changed
         return `t:${node.text}:${node.fontSize}:${node.w}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
+      case "image":
+        // the src doesn't shape a single mark — only the frame's box does
+        return `i:${node.w}:${node.h}:${flip}`
     }
   }, [node])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const prims = useMemo<Prim[]>(() => nodePrims(node), [shapeKey, node.type])
 
-  return <SketchPrims prims={prims} seed={node.seed} hiddenText={hiddenText} />
+  return (
+    <>
+      {node.type === "image" && (
+        <image
+          href={node.src}
+          x={0}
+          y={0}
+          width={node.w}
+          height={node.h}
+          // the box is the truth about how big this is — a resize that squashes
+          // it should squash the picture, the way dragging any other node does
+          preserveAspectRatio="none"
+          // a flip is a property of the node, so the pixels turn with the frame
+          transform={flipTransform(node.w, node.h, node.flipX, node.flipY)}
+        />
+      )}
+      <SketchPrims prims={prims} seed={node.seed} hiddenText={hiddenText} />
+    </>
+  )
 })
+
+/** Mirror about the node's own box — same flip the prims get, in SVG terms. */
+function flipTransform(w: number, h: number, flipX?: boolean, flipY?: boolean): string | undefined {
+  if (!flipX && !flipY) return undefined
+  const sx = flipX ? -1 : 1
+  const sy = flipY ? -1 : 1
+  return `translate(${flipX ? w : 0} ${flipY ? h : 0}) scale(${sx} ${sy})`
+}

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSquig } from "@/lib/store"
 import { ALL_DEFS, matches, type ComponentDef } from "@/lib/library/registry"
 import { SketchPrims } from "@/components/canvas/sketch"
+import { pasteFromSystem } from "@/lib/clipboard"
 import { exportDoc, importDoc } from "@/lib/file-io"
 import { relativeTime } from "@/lib/files"
 import { kbd } from "@/lib/shortcuts"
@@ -113,7 +114,7 @@ function Palette() {
       { id: "dup", label: "Duplicate", hint: kbd("mod+d"), section: "Edit", icon: CopyIcon, disabled: !hasSel, run: () => st().duplicateSelected() },
       { id: "copy", label: "Copy", hint: kbd("mod+c"), section: "Edit", icon: CopyIcon, disabled: !hasSel, run: () => st().copySelected() },
       { id: "cut", label: "Cut", hint: kbd("mod+x"), section: "Edit", icon: ScissorsIcon, disabled: !hasSel, run: () => st().cutSelected() },
-      { id: "paste", label: "Paste", hint: kbd("mod+v"), section: "Edit", icon: ClipboardIcon, run: () => st().pasteClipboard() },
+      { id: "paste", label: "Paste", hint: kbd("mod+v"), section: "Edit", keywords: "image picture screenshot", icon: ClipboardIcon, run: () => void pasteFromSystem() },
       { id: "del", label: "Delete", hint: kbd("del"), section: "Edit", icon: TrashIcon, disabled: !hasSel, run: () => st().deleteSelected() },
       { id: "group", label: "Group", hint: kbd("mod+g"), section: "Edit", keywords: "combine bundle", icon: BoundingBoxIcon, disabled: selection.length < 2, run: () => st().groupSelected() },
       { id: "ungroup", label: "Ungroup", hint: kbd("mod+shift+g"), section: "Edit", keywords: "split apart", icon: LinkBreakIcon, disabled: !hasGroup, run: () => st().ungroupSelected() },

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { pasteFromSystem } from "@/lib/clipboard"
 import { useSquig } from "@/lib/store"
 import { screenToWorld } from "@/lib/types"
 import { getDef } from "@/lib/library/registry"
@@ -62,7 +63,6 @@ export function CanvasContextMenu() {
   const nodes = useSquig((s) => s.nodes)
   const selection = useSquig((s) => s.selection)
   const contextRow = useSquig((s) => s.contextRow)
-  const clipboard = useSquig((s) => s.clipboard)
   const st = useSquig.getState
   const ref = useRef<HTMLDivElement>(null)
   const [pos, setPos] = useState({ x: 0, y: 0 })
@@ -157,9 +157,9 @@ export function CanvasContextMenu() {
       { label: "Blocks", hint: kbd("b"), icon: StackIcon, run: () => st().setPanel("blocks") },
       { separator: true },
       { label: "Select all", hint: kbd("mod+a"), icon: SelectionAllIcon, run: () => st().setSelection([...st().order]) },
-      ...(clipboard.length
-        ? [{ label: "Paste here", hint: kbd("mod+v"), icon: ClipboardTextIcon, run: () => pasteAt(menu.x, menu.y) } as Entry]
-        : []),
+      // always offered now: whatever is on the system clipboard is something
+      // this can paste, and there is no way to know what that is from here
+      { label: "Paste here", hint: kbd("mod+v"), icon: ClipboardTextIcon, run: () => pasteAt(menu.x, menu.y) },
       { separator: true },
       { label: "Undo", hint: kbd("mod+z"), icon: ArrowUUpLeftIcon, run: () => st().undo() },
       { label: "Redo", hint: kbd("mod+shift+z"), icon: ArrowUUpRightIcon, run: () => st().redo() },
@@ -223,5 +223,7 @@ export function CanvasContextMenu() {
 /** Drop the clipboard where the menu was opened. */
 function pasteAt(sx: number, sy: number) {
   const s = useSquig.getState()
-  s.pasteClipboard(screenToWorld(s.viewport, sx, sy))
+  // a menu click is a gesture, so the browser will let us ask for the real
+  // clipboard here — squig's own is the fallback inside pasteFromSystem
+  void pasteFromSystem(screenToWorld(s.viewport, sx, sy))
 }

--- a/lib/canvas/hit-test.ts
+++ b/lib/canvas/hit-test.ts
@@ -116,7 +116,7 @@ function polylineOf(n: SquigNode): [number, number][] | null {
 /** Shapes are only solid to the pointer when they're actually filled. */
 function isSolid(n: SquigNode): boolean {
   if (n.type === "shape") return normalizeFill(n.fill) !== "none"
-  return n.type === "component" || n.type === "text"
+  return n.type === "component" || n.type === "text" || n.type === "image"
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/canvas/keyboard-owner.ts
+++ b/lib/canvas/keyboard-owner.ts
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------
+// Who the keyboard belongs to right now.
+//
+// Shared by the canvas's own shortcuts and by the clipboard, which have to
+// agree: a ⌘V while you're typing in the file name is that field's paste, not
+// the canvas's, and a hotkey that fires in both places at once is worse than
+// one that doesn't fire at all.
+// ---------------------------------------------------------------------------
+
+/**
+ * Does the canvas get to act on this keystroke?
+ *
+ * Only two things take the keyboard away: somewhere you're typing, and an open
+ * menu/listbox/dialog whose own typeahead would otherwise fire alongside the
+ * tool hotkeys. Radix portals those outside the panel's DOM subtree, so this
+ * looks for their roles document-wide rather than walking up from the target.
+ *
+ * Deliberately NOT here: chrome buttons, which keep DOM focus after a click —
+ * gating on those meant one tap on the rail silently killed every shortcut.
+ * Tooltips are excluded too: they're `role="tooltip"`, and hovering the button
+ * that advertises a hotkey must not be what stops the hotkey working.
+ */
+// NOT `[role=combobox]`: that is Radix's Select *trigger*, which sits in the
+// inspector permanently and keeps focus after use — matching it would kill the
+// keyboard for good. The open listbox it portals in is what matters.
+const KEYBOARD_OWNERS = "[role=dialog],[role=menu],[role=listbox]"
+
+export function canvasOwnsKeyboard(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  if (el && el !== document.body) {
+    const tag = el.tagName
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return false
+    if (el.isContentEditable) return false
+    if (el.closest?.(KEYBOARD_OWNERS)) return false
+  }
+  return !document.querySelector(KEYBOARD_OWNERS)
+}

--- a/lib/canvas/use-clipboard.ts
+++ b/lib/canvas/use-clipboard.ts
@@ -1,0 +1,100 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// ⌘C / ⌘X / ⌘V, on the real clipboard.
+//
+// These ride the browser's own copy/cut/paste events rather than the keydown
+// handler, which is why the canvas no longer claims those three keys: calling
+// preventDefault on the keystroke is exactly what stops the clipboard event
+// from firing. Going through the events instead means the OS clipboard, other
+// tabs, other apps and the Edit menu all work without a second code path.
+// ---------------------------------------------------------------------------
+
+import { useEffect, type RefObject } from "react"
+
+import { pasteFrom, pasteFromSystem, writeNodes } from "@/lib/clipboard"
+import { useSquig } from "@/lib/store"
+import type { SquigNode } from "@/lib/types"
+import { canvasOwnsKeyboard } from "./keyboard-owner"
+
+/**
+ * Wire the canvas up to the system clipboard.
+ *
+ * `pointerWorld` is where ⌘V lands — the last place the pointer was over the
+ * canvas. It's read at the moment of the paste, since decoding a picture takes
+ * long enough for the hand to have moved on.
+ */
+export function useClipboard(pointerWorld: RefObject<[number, number] | null>) {
+  useEffect(() => {
+    const st = useSquig.getState
+
+    const selectedNodes = (): SquigNode[] => {
+      const s = st()
+      return s.order.filter((id) => s.selection.includes(id)).map((id) => s.nodes[id]).filter(Boolean)
+    }
+
+    /**
+     * The canvas only takes a clipboard event when nothing else wants it: not
+     * while typing, and not when there are words highlighted on the page —
+     * copying the file name out of its field has to keep working.
+     */
+    const mine = (e: ClipboardEvent): boolean =>
+      canvasOwnsKeyboard(e.target) && !window.getSelection()?.toString()
+
+    const onCopy = (e: ClipboardEvent) => {
+      if (!mine(e) || !e.clipboardData) return
+      const sel = selectedNodes()
+      if (!sel.length) return
+      e.preventDefault()
+      writeNodes(e.clipboardData, sel)
+      // the private clipboard stays in step, so paste-in-place and the context
+      // menu still have something to work from when the system one is refused
+      st().copySelected()
+    }
+
+    const onCut = (e: ClipboardEvent) => {
+      if (!mine(e) || !e.clipboardData) return
+      const sel = selectedNodes()
+      if (!sel.length) return
+      e.preventDefault()
+      writeNodes(e.clipboardData, sel)
+      st().cutSelected()
+    }
+
+    const onPaste = (e: ClipboardEvent) => {
+      if (!mine(e) || !e.clipboardData) return
+      e.preventDefault()
+      // the DataTransfer is only alive for this turn of the loop, so anything
+      // async has to have taken what it needs off it before we return
+      void pasteFrom(e.clipboardData, pointerWorld.current ?? undefined)
+    }
+
+    /**
+     * ⇧⌘V is the one that has to be caught on the way down.
+     *
+     * A browser only treats it as a paste inside something editable — out here
+     * it produces no paste event at all — so paste-in-place asks squig's own
+     * clipboard first, which is where it came from in nearly every case, and
+     * only goes to the system one when this tab has nothing to give.
+     */
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.code !== "KeyV") return
+      if (!canvasOwnsKeyboard(e.target)) return
+      e.preventDefault()
+      const own = st().clipboard
+      if (own.length) {
+        st().pasteClipboard([Math.min(...own.map((n) => n.x)), Math.min(...own.map((n) => n.y))])
+      } else {
+        void pasteFromSystem(undefined, true)
+      }
+    }
+
+    const ac = new AbortController()
+    const opts = { signal: ac.signal }
+    window.addEventListener("keydown", onKey, opts)
+    document.addEventListener("copy", onCopy, opts)
+    document.addEventListener("cut", onCut, opts)
+    document.addEventListener("paste", onPaste, opts)
+    return () => ac.abort()
+  }, [pointerWorld])
+}

--- a/lib/clipboard-payload.ts
+++ b/lib/clipboard-payload.ts
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------
+// What squig puts on the clipboard, and what it will take back off it.
+//
+// Two carriers go on every copy. `text/html` holds the real payload in a data
+// attribute, because a browser hands HTML back untouched and nobody has to
+// look at it. `text/plain` holds the words when there are any, so copying a
+// label out of a wireframe and pasting it into a message does what you meant —
+// and the payload when there aren't, so a paste still lands as layers even
+// where the HTML got stripped on the way.
+//
+// Everything coming in is treated as a stranger: only known node types, only
+// finite geometry, only `data:image/…` sources. The clipboard is one of the
+// few places a document can arrive from somewhere that isn't this app.
+//
+// Kept free of the store and the DOM so it can be tested on its own.
+// ---------------------------------------------------------------------------
+
+import type { SquigNode, TextNode } from "./types"
+
+const PAYLOAD_VERSION = 1
+/** the attribute the HTML carrier hides the payload in */
+const HTML_ATTR = "data-squig"
+
+interface Payload {
+  app: "squig"
+  kind: "nodes"
+  version: number
+  nodes: SquigNode[]
+}
+
+export function encodeNodes(nodes: readonly SquigNode[]): string {
+  const payload: Payload = { app: "squig", kind: "nodes", version: PAYLOAD_VERSION, nodes: [...nodes] }
+  return JSON.stringify(payload)
+}
+
+/** The layers in a payload, or null for anything that isn't one. */
+export function decodeNodes(text: string | null | undefined): SquigNode[] | null {
+  if (!text) return null
+  const trimmed = text.trim()
+  // cheap gate first — most pastes are prose, and JSON.parse on a novel is not
+  if (!trimmed.startsWith("{") || !trimmed.includes('"squig"')) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+  const p = parsed as Partial<Payload> | null
+  if (!p || p.app !== "squig" || p.kind !== "nodes" || !Array.isArray(p.nodes)) return null
+  const clean = p.nodes.map(validNode).filter(Boolean) as SquigNode[]
+  return clean.length ? clean : null
+}
+
+export function payloadHtml(json: string): string {
+  return `<div ${HTML_ATTR}="${encodeURIComponent(json)}"></div>`
+}
+
+/**
+ * Pull the payload back out of pasted HTML.
+ *
+ * Browsers rewrap what they hand over — Chrome prepends a `<meta>`, some add
+ * fragment comments — but they leave attributes alone, so a match anywhere in
+ * the string is the right one. `encodeURIComponent` escapes quotes, so the
+ * value can't close the attribute early.
+ */
+export function payloadFromHtml(html: string | null | undefined): string | null {
+  if (!html) return null
+  const m = new RegExp(`${HTML_ATTR}="([^"]*)"`).exec(html)
+  if (!m) return null
+  try {
+    return decodeURIComponent(m[1])
+  } catch {
+    return null
+  }
+}
+
+/** The words in a selection, in document order — what `text/plain` carries. */
+export function wordsOf(nodes: readonly SquigNode[]): string {
+  return nodes
+    .filter((n): n is TextNode => n.type === "text")
+    .map((n) => n.text)
+    .filter(Boolean)
+    .join("\n")
+}
+
+// -- reading a stranger's nodes ---------------------------------------------
+
+const NODE_TYPES = new Set(["component", "shape", "draw", "text", "arrow", "image"])
+const num = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v)
+const str = (v: unknown): v is string => typeof v === "string"
+
+function validPoints(v: unknown): v is [number, number][] {
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((p) => Array.isArray(p) && p.length === 2 && num(p[0]) && num(p[1]))
+  )
+}
+
+/**
+ * A node we're willing to put on the canvas, or null.
+ *
+ * Geometry is the part that matters: one NaN through here lands in the
+ * document, gets autosaved, and wedges the file across reloads — the same
+ * reason `sanitize` exists in the store.
+ */
+export function validNode(v: unknown): SquigNode | null {
+  const n = v as SquigNode | null
+  if (!n || typeof n !== "object") return null
+  if (!str(n.type) || !NODE_TYPES.has(n.type)) return null
+  if (!num(n.x) || !num(n.y) || !num(n.w) || !num(n.h)) return null
+  if (n.groupIds !== undefined && !(Array.isArray(n.groupIds) && n.groupIds.every(str))) return null
+
+  switch (n.type) {
+    case "component":
+      if (!str(n.kind) || !n.props || typeof n.props !== "object") return null
+      break
+    case "shape":
+      if (n.shape !== "rect" && n.shape !== "ellipse") return null
+      break
+    case "draw":
+      if (!validPoints(n.points)) return null
+      break
+    case "arrow":
+      if (!validPoints(n.points) || n.points.length !== 2) return null
+      break
+    case "text":
+      if (!str(n.text) || !num(n.fontSize)) return null
+      break
+    case "image":
+      // the only scheme this app ever writes, and the only one it will read:
+      // a pasted document has no business pointing the canvas at a URL
+      if (!str(n.src) || !/^data:image\//i.test(n.src)) return null
+      break
+  }
+
+  return {
+    ...n,
+    // both are replaced when the paste is placed, so a payload that forgot
+    // them shouldn't be the thing that stops it
+    id: str(n.id) ? n.id : "pasted",
+    seed: num(n.seed) ? n.seed : 1,
+    w: Math.max(0, n.w),
+    h: Math.max(0, n.h),
+  }
+}

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -1,0 +1,371 @@
+"use client"
+
+// ---------------------------------------------------------------------------
+// The system clipboard.
+//
+// squig keeps its own private clipboard for ⌘C/⌘V inside one canvas, but that
+// stops at the tab. This is the other half: layers written out in a form a
+// second squig tab can read back, and everything else the world might hand us
+// — a screenshot, a logo, a paragraph — turned into something on the paper.
+//
+// The payload's own format, and the vetting every incoming node goes through,
+// live next door in clipboard-payload.
+// ---------------------------------------------------------------------------
+
+import { nanoid } from "nanoid"
+
+import { decodeNodes, encodeNodes, payloadFromHtml, payloadHtml, wordsOf } from "./clipboard-payload"
+import { useSquig } from "./store"
+import { measureTextWidth } from "./canvas/text-metrics"
+import { fitTextBox } from "./canvas/text-reflow"
+import { screenToWorld, type ImageNode, type SquigNode, type TextNode } from "./types"
+
+// -- copying out ------------------------------------------------------------
+
+/** Put a selection on the clipboard, both ways round. */
+export function writeNodes(dt: DataTransfer, nodes: readonly SquigNode[]): void {
+  const json = encodeNodes(nodes)
+  dt.setData("text/html", payloadHtml(json))
+  dt.setData("text/plain", wordsOf(nodes) || json)
+}
+
+// -- pictures ---------------------------------------------------------------
+
+/**
+ * How big a pasted picture is allowed to be once it's in the document.
+ *
+ * Documents live in localStorage, which is a handful of megabytes for the
+ * whole drawer — and a full-quota save doesn't fail quietly, it starts
+ * evicting other files to make room (see saveFile). So a screenshot gets
+ * re-encoded down before it's ever a node, and the budget is set by how many
+ * of them one document should be able to hold rather than by how good any one
+ * of them could look: ~10 at a few hundred KB each, which is more reference
+ * than a wireframe has ever needed.
+ */
+const MAX_EDGE = 1280
+/** past this, re-encode rather than keep the original bytes */
+const KEEP_ORIGINAL_BYTES = 120_000
+/** the ceiling a re-encode aims to come in under, in data-URL characters */
+const MAX_STORED = 400_000
+
+/**
+ * Quality then scale, tried in order.
+ *
+ * Quality first because it's free — a screenshot at 0.7 is indistinguishable
+ * at wireframe size. Scale only when a picture is genuinely enormous, and only
+ * as far as the point where it stops being worth pasting at all.
+ */
+const ATTEMPTS: { scale: number; quality: number }[] = [
+  { scale: 1, quality: 0.85 },
+  { scale: 1, quality: 0.7 },
+  { scale: 0.75, quality: 0.7 },
+  { scale: 0.5, quality: 0.65 },
+  { scale: 0.35, quality: 0.6 },
+]
+
+/** How wide a picture lands on the canvas — big enough to see, small enough to move. */
+const PLACED_EDGE = 420
+
+let webpOk: boolean | null = null
+
+/** Does this browser's canvas encode WebP? Asked once, answered forever. */
+function supportsWebp(): boolean {
+  if (webpOk === null) {
+    try {
+      const c = document.createElement("canvas")
+      c.width = 1
+      c.height = 1
+      webpOk = c.toDataURL("image/webp").startsWith("data:image/webp")
+    } catch {
+      webpOk = false
+    }
+  }
+  return webpOk
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error("image failed to load"))
+    img.src = src
+  })
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader()
+    r.onload = () => resolve(String(r.result))
+    r.onerror = () => reject(new Error("could not read the file"))
+    r.readAsDataURL(blob)
+  })
+}
+
+/**
+ * Redraw a picture small enough to keep, and hand back a data URL.
+ *
+ * WebP where there is one — it holds transparency and beats both JPEG and PNG
+ * on a screenshot. Where there isn't, a photo falls back to JPEG and anything
+ * that might have an alpha channel stays PNG, which the size loop then has to
+ * shrink its way out of instead.
+ */
+function reencode(img: HTMLImageElement, nw: number, nh: number, sourceType: string): string | null {
+  const type = supportsWebp() ? "image/webp" : sourceType === "image/jpeg" ? "image/jpeg" : "image/png"
+  const base = Math.min(1, MAX_EDGE / Math.max(nw, nh))
+  let last: string | null = null
+
+  for (const attempt of ATTEMPTS) {
+    const k = base * attempt.scale
+    const canvas = document.createElement("canvas")
+    canvas.width = Math.max(1, Math.round(nw * k))
+    canvas.height = Math.max(1, Math.round(nh * k))
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return null
+    // JPEG has no alpha, and an unpainted canvas behind a transparent PNG
+    // comes out black rather than absent
+    if (type === "image/jpeg") {
+      ctx.fillStyle = "#ffffff"
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+    }
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+    try {
+      last = canvas.toDataURL(type, attempt.quality)
+    } catch {
+      return null
+    }
+    if (last.length <= MAX_STORED) return last
+  }
+  // even the smallest attempt is over: take it anyway rather than refusing the
+  // paste. One oversized picture is a document that saves slowly, not a lost one
+  return last
+}
+
+/** Turn a picture off the clipboard into a node, or null if it isn't one. */
+export async function imageNodeFrom(blob: Blob, name?: string): Promise<ImageNode | null> {
+  if (!blob.type.startsWith("image/")) return null
+  const url = URL.createObjectURL(blob)
+  try {
+    const img = await loadImage(url)
+    const nw = img.naturalWidth || img.width
+    const nh = img.naturalHeight || img.height
+    if (!nw || !nh) return null
+
+    // small enough already: keep the original bytes rather than re-encoding
+    // them. That's what keeps a crisp UI screenshot crisp — and an animated
+    // GIF animated, since a redraw would flatten it to its first frame
+    const asIs = blob.size <= KEEP_ORIGINAL_BYTES && Math.max(nw, nh) <= MAX_EDGE
+    const src = asIs ? await blobToDataUrl(blob) : reencode(img, nw, nh, blob.type)
+    if (!src) return null
+
+    const k = Math.min(1, PLACED_EDGE / Math.max(nw, nh))
+    return {
+      id: nanoid(8),
+      type: "image",
+      src,
+      naturalW: nw,
+      naturalH: nh,
+      name,
+      x: 0,
+      y: 0,
+      w: Math.round(nw * k),
+      h: Math.round(nh * k),
+      seed: Math.floor(Math.random() * 2 ** 31),
+    }
+  } catch {
+    return null
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+// -- words ------------------------------------------------------------------
+
+/** The size pasted words land at — the same one the text tool starts from. */
+const PASTED_FONT_SIZE = 18
+/** How wide a pasted run is allowed to run before it's broken up. */
+const PASTED_WIDTH = 420
+
+/**
+ * Break a pasted line to a readable width.
+ *
+ * squig text doesn't wrap — a line ends where you pressed Return — so this is
+ * not a layout rule, it's a one-time decision about where the returns go. A
+ * paragraph off a web page arrives as a single line, and a single line is
+ * three thousand units wide and no use to anybody.
+ */
+function wrap(line: string, style: { size: number }): string[] {
+  if (measureTextWidth(line, style) <= PASTED_WIDTH) return [line]
+  const out: string[] = []
+  let current = ""
+  for (const word of line.split(/(?<=\s)/)) {
+    const next = current + word
+    if (current && measureTextWidth(next.trimEnd(), style) > PASTED_WIDTH) {
+      out.push(current.trimEnd())
+      current = word.trimStart()
+    } else {
+      current = next
+    }
+  }
+  if (current.trimEnd()) out.push(current.trimEnd())
+  return out.length ? out : [line]
+}
+
+function textNodeFrom(text: string, at: [number, number]): TextNode | null {
+  // a clipboard full of newlines and nothing else is not a paste worth making
+  const normalized = text.replace(/\r\n?/g, "\n").replace(/\s+$/, "")
+  if (!normalized.trim()) return null
+  const cleaned = normalized
+    .split("\n")
+    .flatMap((line) => wrap(line, { size: PASTED_FONT_SIZE }))
+    .join("\n")
+  const base: TextNode = {
+    id: nanoid(8),
+    type: "text",
+    text: "",
+    fontSize: PASTED_FONT_SIZE,
+    x: at[0],
+    y: at[1],
+    w: 0,
+    h: 0,
+    seed: Math.floor(Math.random() * 2 ** 31),
+  }
+  return { ...base, ...fitTextBox(base, cleaned) }
+}
+
+// -- putting it down --------------------------------------------------------
+
+/** Where a paste lands when the pointer has never been over the canvas. */
+function viewportCentre(): [number, number] {
+  const v = useSquig.getState().viewport
+  return screenToWorld(v, window.innerWidth / 2, window.innerHeight / 2)
+}
+
+/** Stagger, so pasting four pictures at once doesn't stack them into one. */
+const CASCADE = 24
+
+interface Incoming {
+  html?: string | null
+  text?: string | null
+  images: Blob[]
+}
+
+/**
+ * Everything a paste could be, in the order it should be tried.
+ *
+ * Layers first: a squig payload arrives as text, so reading the words before
+ * looking for the payload would turn every cross-tab paste into a paragraph of
+ * JSON. Pictures next, then whatever text is left over.
+ *
+ * `at` is the top-left corner the paste lands on — the same convention ⌘V has
+ * always had here. `inPlace` ignores it and puts the layers back at the
+ * coordinates they were copied from.
+ */
+async function place(c: Incoming, at?: [number, number], inPlace = false): Promise<boolean> {
+  const s = useSquig.getState()
+
+  const nodes = decodeNodes(payloadFromHtml(c.html)) ?? decodeNodes(c.text)
+  if (nodes) {
+    const corner: [number, number] | undefined = inPlace
+      ? [Math.min(...nodes.map((n) => n.x)), Math.min(...nodes.map((n) => n.y))]
+      : at
+    s.pasteNodes(nodes, corner)
+    return true
+  }
+
+  if (c.images.length) {
+    const made: ImageNode[] = []
+    for (const blob of c.images) {
+      const node = await imageNodeFrom(blob, blob instanceof File ? blob.name : undefined)
+      if (node) made.push(node)
+    }
+    if (!made.length) return false
+    // the pointer may well have moved while those were decoding, so the
+    // position captured when the paste began is the one that counts. With no
+    // pointer at all we're aiming at the middle of the view, and "top-left
+    // there" would hang the picture off the corner — centre it instead
+    const [px, py] = at ?? viewportCentre()
+    const [ox, oy] = at ? [px, py] : [px - made[0].w / 2, py - made[0].h / 2]
+    made.forEach((n, i) => {
+      n.x = Math.round(ox + i * CASCADE)
+      n.y = Math.round(oy + i * CASCADE)
+    })
+    s.addNodes(made)
+    return true
+  }
+
+  if (c.text) {
+    const node = textNodeFrom(c.text, at ?? viewportCentre())
+    if (node) {
+      s.addNodes([node])
+      return true
+    }
+  }
+
+  return false
+}
+
+/** Pictures on a paste or a drop, in the order the clipboard listed them. */
+function imagesIn(dt: DataTransfer): Blob[] {
+  const out: Blob[] = []
+  for (const item of dt.items) {
+    if (item.kind !== "file") continue
+    const file = item.getAsFile()
+    if (file && file.type.startsWith("image/")) out.push(file)
+  }
+  return out
+}
+
+/** Handle a real paste event. Returns whether anything landed. */
+export function pasteFrom(dt: DataTransfer, at?: [number, number]): Promise<boolean> {
+  // everything comes off the DataTransfer now: it is only alive for this turn
+  // of the event loop, and placing a picture takes several
+  return place({ html: dt.getData("text/html"), text: dt.getData("text/plain"), images: imagesIn(dt) }, at)
+}
+
+/**
+ * How long to wait for a browser to hand over the clipboard before giving up
+ * on it. Some refuse the read outright, which is fine — and some never answer
+ * at all, which would leave the menu item quietly doing nothing for ever.
+ */
+const SYSTEM_READ_TIMEOUT = 1200
+
+/**
+ * Paste without a paste event — the command palette and the context menu.
+ *
+ * Reading the clipboard from a click means asking the browser for it, which
+ * some will refuse and others will prompt about. Either way there's still a
+ * private clipboard underneath, so the menu item does something whenever squig
+ * itself has something to give. Whichever route gets there first wins; the
+ * other one stands down rather than pasting twice.
+ */
+export async function pasteFromSystem(at?: [number, number], inPlace = false): Promise<void> {
+  let settled = false
+  const ownClipboard = () => {
+    if (settled) return
+    settled = true
+    useSquig.getState().pasteClipboard(at)
+  }
+
+  const giveUp = setTimeout(ownClipboard, SYSTEM_READ_TIMEOUT)
+  try {
+    const items = await navigator.clipboard.read()
+    if (settled) return
+    settled = true
+    const c: Incoming = { images: [] }
+    for (const item of items) {
+      const imageType = item.types.find((t) => t.startsWith("image/"))
+      if (imageType) {
+        c.images.push(await item.getType(imageType))
+        continue
+      }
+      if (!c.html && item.types.includes("text/html")) c.html = await (await item.getType("text/html")).text()
+      if (!c.text && item.types.includes("text/plain")) c.text = await (await item.getType("text/plain")).text()
+    }
+    // nothing on it we could use — squig's own clipboard is still an answer
+    if (!(await place(c, at, inPlace))) useSquig.getState().pasteClipboard(at)
+  } catch {
+    ownClipboard()
+  } finally {
+    clearTimeout(giveUp)
+  }
+}

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -35,6 +35,9 @@ const FILL_OPTS: Record<FillTone, PrimOpts | undefined> = {
  */
 const PEN_SCALE: Record<StrokeWeight, number> = { light: 0.65, regular: 1, heavy: 1.7 }
 
+/** How far a picture's frame is drawn outside the picture, in world units. */
+const FRAME_GAP = 2.5
+
 /** Merge a node's outline settings into the options for one of its marks. */
 function outline(node: Outlined, baseWidth: number, o?: PrimOpts): PrimOpts {
   return {
@@ -76,6 +79,17 @@ export function basePrims(node: SquigNode): Prim[] {
         })
       }
       return out
+    }
+    // the picture itself is drawn by the renderer, which is the one thing here
+    // that isn't made of pen marks. What the hand contributes is the frame
+    // around it, so a pasted screenshot still sits on the same paper.
+    //
+    // Drawn just outside the box rather than on it: half a line sitting on the
+    // picture disappears into whatever colour it happens to land on, and a red
+    // screenshot in a red ink would come out with no frame at all.
+    case "image": {
+      const g = FRAME_GAP
+      return [{ t: "rect", x: -g, y: -g, w: node.w + g * 2, h: node.h + g * 2, r: 2, o: { stroke: "muted" } }]
     }
     case "text": {
       const anchor = textAnchorX(node.align, node.w)

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -169,6 +169,8 @@ interface SquigState {
   cutSelected: () => void
   /** paste at a world point, or nudged off the original when none is given */
   pasteClipboard: (at?: [number, number]) => void
+  /** the same, for layers that came from somewhere other than this canvas */
+  pasteNodes: (nodes: readonly SquigNode[], at?: [number, number]) => void
 
   zoomBy: (factor: number, center?: [number, number]) => void
   zoomTo100: () => void
@@ -229,6 +231,9 @@ function sanitize(
     // shapes stored a boolean fill before they had a tonal ladder; upgrade on
     // the way in so nothing downstream has to know the old spelling existed
     if (node.type === "shape") node.fill = normalizeFill(node.fill)
+    // an imported file is a stranger's document: a picture in it carries its
+    // own pixels or it doesn't render at all — never a URL we'd go and fetch
+    if (node.type === "image" && !/^data:image\//i.test(node.src ?? "")) continue
     clean[id] = node
   }
   const seen = new Set<string>()
@@ -831,13 +836,14 @@ export const useSquig = create<SquigState>((set, get) => ({
     get().deleteSelected()
   },
 
-  pasteClipboard: (at) => {
-    const { clipboard } = get()
-    if (!clipboard.length) return
-    const box = unionBox(clipboard)!
+  pasteClipboard: (at) => get().pasteNodes(get().clipboard, at),
+
+  pasteNodes: (list, at) => {
+    if (!list.length) return
+    const box = unionBox([...list])!
     const [dx, dy] = at ? [at[0] - box.minX, at[1] - box.minY] : [16, 16]
     get().checkpoint()
-    const clones = cloneNodes(clipboard, dx, dy)
+    const clones = cloneNodes([...list], dx, dy)
     set((s) => ({
       nodes: { ...s.nodes, ...Object.fromEntries(clones.map((c) => [c.id, c])) },
       order: [...s.order, ...clones.map((c) => c.id)],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -108,7 +108,28 @@ export interface ArrowNode extends BaseNode, Outlined {
   head: boolean
 }
 
-export type SquigNode = ComponentNode | ShapeNode | DrawNode | TextNode | ArrowNode
+/**
+ * A picture someone pasted in. The only node that isn't drawn by hand: a
+ * screenshot you're wireframing around has to stay legible, so it prints as
+ * itself and gets a drawn frame instead — a photo taped to the napkin.
+ *
+ * The pixels live in the document as a data URL. That keeps a file one
+ * self-contained thing you can export and open anywhere, at the cost of
+ * needing every paste re-encoded down to a size a browser will hold; see
+ * lib/clipboard.ts.
+ */
+export interface ImageNode extends BaseNode {
+  type: "image"
+  /** data:image/… — nothing else is ever put here, or ever read back out */
+  src: string
+  /** the pixels' own size — the ratio the box started life at */
+  naturalW: number
+  naturalH: number
+  /** the file it came from, when the clipboard said */
+  name?: string
+}
+
+export type SquigNode = ComponentNode | ShapeNode | DrawNode | TextNode | ArrowNode | ImageNode
 
 export interface Viewport {
   x: number

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts"
+    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/test-clipboard.ts
+++ b/scripts/test-clipboard.ts
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------------
+// Checks for what squig writes to the clipboard and what it accepts back.
+//
+// The reading half matters most: a paste is the one door into the document
+// that anyone can knock on, so the tests below are as interested in what gets
+// turned away as in what round-trips.
+//
+//   node --experimental-strip-types --import ./scripts/register-loader.mjs \
+//        scripts/test-clipboard.ts
+// ---------------------------------------------------------------------------
+
+import {
+  decodeNodes,
+  encodeNodes,
+  payloadFromHtml,
+  payloadHtml,
+  validNode,
+  wordsOf,
+} from "../lib/clipboard-payload.ts"
+import type { ImageNode, ShapeNode, SquigNode, TextNode } from "../lib/types.ts"
+
+let passed = 0
+const failures: string[] = []
+const check = (name: string, cond: boolean, detail = "") => {
+  if (cond) passed++
+  else failures.push(`${name}${detail ? ` — ${detail}` : ""}`)
+}
+
+const rect = (id: string, x = 0, y = 0): ShapeNode => ({
+  id,
+  type: "shape",
+  shape: "rect",
+  fill: "none",
+  x,
+  y,
+  w: 100,
+  h: 40,
+  seed: 7,
+})
+
+const label = (id: string, text: string): TextNode => ({
+  id,
+  type: "text",
+  text,
+  fontSize: 18,
+  x: 0,
+  y: 0,
+  w: 80,
+  h: 24,
+  seed: 7,
+})
+
+// a declaration, not an arrow: an object-returning arrow immediately before a
+// bare `{` block is a parse the compiler resolves the other way
+function pic(src: string): ImageNode {
+  return { id: "p", type: "image", src, naturalW: 100, naturalH: 50, x: 0, y: 0, w: 100, h: 50, seed: 7 }
+}
+
+// -- round trips ------------------------------------------------------------
+
+{
+  const nodes = [rect("a"), label("b", "hello"), pic("data:image/png;base64,AAA")]
+  const back = decodeNodes(encodeNodes(nodes))
+  check("a payload round-trips through text", back?.length === 3, JSON.stringify(back?.length))
+  check("and keeps what each node was", back?.map((n) => n.type).join() === "shape,text,image", back?.map((n) => n.type).join())
+
+  const html = payloadHtml(encodeNodes(nodes))
+  check("the html carrier round-trips too", decodeNodes(payloadFromHtml(html))?.length === 3)
+  // Chrome wraps pasted HTML in a charset meta and fragment comments
+  const wrapped = `<meta charset="utf-8"><!--StartFragment-->${html}<!--EndFragment-->`
+  check("even once the browser has rewrapped it", decodeNodes(payloadFromHtml(wrapped))?.length === 3)
+  check("quotes in the payload can't close the attribute", !payloadHtml('{"a":"b"}').includes('"}"'))
+}
+
+// -- things that are not a payload -----------------------------------------
+
+{
+  check("prose is not a payload", decodeNodes("just some words I copied") === null)
+  check("neither is empty", decodeNodes("") === null && decodeNodes(null) === null)
+  check("nor broken json", decodeNodes('{"app":"squig","kind":"nodes","nodes":[') === null)
+  check("nor someone else's json", decodeNodes('{"app":"figma","nodes":[]}') === null)
+  check("nor a payload with nothing usable in it", decodeNodes(encodeNodes([])) === null)
+  check("html with no payload in it yields nothing", payloadFromHtml("<p>hello</p>") === null)
+}
+
+// -- vetting incoming nodes -------------------------------------------------
+
+{
+  check("a good node comes back", validNode(rect("a")) !== null)
+  check("an unknown type does not", validNode({ ...rect("a"), type: "video" }) === null)
+  check("nor does a NaN coordinate", validNode({ ...rect("a"), x: NaN }) === null)
+  check("nor an infinite one", validNode({ ...rect("a"), w: Infinity }) === null)
+  check("nor a missing box", validNode({ id: "a", type: "shape", shape: "rect" }) === null)
+  check("nor a shape that isn't one", validNode({ ...rect("a"), shape: "hexagon" }) === null)
+  check("nor a text node with no words", validNode({ ...label("a", "hi"), text: 42 }) === null)
+  check("nor group ids that aren't strings", validNode({ ...rect("a"), groupIds: [1, 2] }) === null)
+  check("a negative size is clamped, not refused", validNode({ ...rect("a"), w: -5 })?.w === 0)
+  check("a node with no seed still gets one", typeof validNode({ ...rect("a"), seed: undefined })?.seed === "number")
+
+  check("an arrow needs both ends", validNode({ id: "a", type: "arrow", x: 0, y: 0, w: 10, h: 10, seed: 1, head: true, points: [[0, 0]] }) === null)
+  check("a scribble needs points", validNode({ id: "a", type: "draw", x: 0, y: 0, w: 10, h: 10, seed: 1, points: [] }) === null)
+
+  check("a picture may carry its own pixels", validNode(pic("data:image/png;base64,AAA")) !== null)
+  check("but never a url we'd go and fetch", validNode(pic("https://example.com/tracker.png")) === null)
+  check("and not a script either", validNode(pic("javascript:alert(1)")) === null)
+  check("a payload drops the bad ones and keeps the rest", decodeNodes(encodeNodes([rect("a"), pic("http://x/y.png") as SquigNode]))?.length === 1)
+}
+
+// -- the plain-text carrier -------------------------------------------------
+
+{
+  check("words come out in order", wordsOf([label("a", "one"), rect("b"), label("c", "two")]) === "one\ntwo")
+  check("a selection with no words has none", wordsOf([rect("a")]) === "")
+}
+
+// ---------------------------------------------------------------------------
+
+if (failures.length) {
+  console.error(`\n✗ ${failures.length} failed, ${passed} passed\n`)
+  for (const f of failures) console.error("  ✗ " + f)
+  process.exit(1)
+}
+console.log(`✓ ${passed} clipboard checks passed`)


### PR DESCRIPTION
⌘V now takes whatever is on the clipboard: layers copied from another squig tab, a screenshot to wireframe around, or a paragraph of text. And ⌘C puts squig's layers somewhere other tabs can reach.

## What changed

**The clipboard moved onto the browser's own events.** ⌘C/⌘X/⌘V are no longer claimed on keydown — preventing their default is precisely what stopped the copy/cut/paste events from firing. A copy writes the layers into `text/html` as a payload and the words into `text/plain`, so another squig tab gets layers back and a chat window gets the sentence.

**A new node type: `image`.** The only node not drawn by hand — a screenshot you're wireframing around has to stay legible. It prints as itself with a hand-drawn frame, and the frame sits just *outside* the box so the line never vanishes into the picture (a red screenshot in a red ink came out with no frame at all).

**Pictures are re-encoded on the way in.** WebP where there is one, ~1280px, a few hundred KB — small ones keep their original bytes, which is what keeps a crisp UI screenshot crisp and an animated GIF animated. The drawer is a few megabytes for every file you own, and `saveFile` evicts other documents when a save doesn't fit, so the budget is set by how many pictures one document should hold.

**Pasted text is wrapped once, at insert time.** squig text doesn't wrap — a line ends where you pressed Return — so a paragraph off a web page would otherwise arrive as one line three thousand units wide.

**⇧⌘V stays on the keydown, alone.** No browser fires a paste event for it outside an editable, so paste-in-place asks squig's own clipboard and only falls through to the system one when this tab has nothing to give.

**Everything incoming is vetted like a stranger.** Known node types, finite geometry, and pictures only as `data:image/…` — never a URL the canvas would go and fetch. Same check on file import, since a `.squig.json` is a stranger's document too.

## Meeting "Copy the selection as a PNG" (#22)

That landed on main while this was open, and the two features shared a switch case:

- **⌘⇧C keeps the keystroke, ⌘C gives it up.** The picture is ours to intercept; the objects ride the browser's event.
- **The PNG export now writes pictures out.** It renders a node from its prims, and a picture has none — so ⌘⇧C was producing an empty frame where the screenshot should be. Verified in the browser that a data-URI `<image>` inside the standalone SVG rasterizes and leaves the canvas untainted, so `toBlob` still works.
- **Copy and Cut from the palette and the menu reach the system clipboard too.** There is no copy event to hang those on — the palette's own input has the focus by then — so they go through the async clipboard, with squig's private one filled either way.
- **A picture that won't decode says so** in the flash #22 added for exactly this kind of invisible result.

## Verified in the app

Real keystrokes in a real browser: ⌘C → ⌘V round-trips layers through the system clipboard and lands them top-left at the pointer; ⇧⌘V puts them back where they came from; a pasted PNG becomes a framed image node and survives a reload; a pasted paragraph comes back as three sensible lines; "Paste here" in the context menu works, falling back to squig's own clipboard when the browser won't hand the real one over (it can hang, so that read has a timeout). Copy and paste inside a form field are untouched. After the merge, the copy/paste round trip was re-checked against the merged build.

`pnpm test` — 29 new clipboard checks alongside the existing 68.

## Not in scope

Drag-and-drop of image files onto the canvas. Adjacent, and people will try it — happy to follow up.

One thing worth knowing: `rasterize` loads the export SVG as a data URI, and pictures make that string much bigger than it used to be. Well inside what browsers take at this budget, and an oversized one fails loudly through the existing "couldn't make that PNG" path rather than silently — but a blob URL there would remove the ceiling entirely if it ever bites.