### PR TITLE
Give the last three inks names as cute as the first three

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -74,7 +74,7 @@ export const THEMES = {
     select: "#E8622F",
   },
   plum: {
-    label: "Plum",
+    label: "Ditto purple",
     bg: "#FCF9FC",
     paper: "#FFFFFF",
     ink: "#71268A",
@@ -86,7 +86,7 @@ export const THEMES = {
     select: "#D9A441",
   },
   marigold: {
-    label: "Marigold",
+    label: "Safelight amber",
     bg: "#FDFAF2",
     paper: "#FFFFFF",
     ink: "#B26A0F",
@@ -98,7 +98,7 @@ export const THEMES = {
     select: "#2438FF",
   },
   graphite: {
-    label: "Graphite",
+    label: "Carbon black",
     bg: "#FCFCFA",
     paper: "#FFFFFF",
     ink: "#2D2A26",


### PR DESCRIPTION
`Plum`, `Marigold` and `Graphite` named the color and stopped there, while `Internet blue`, `Riso red` and `Terminal green` each name a place the color comes from. Halfway down the palette list the naming changed authors.

These three pick up the same thread — media you actually make marks with:

| was | now | why |
| --- | --- | --- |
| Plum | **Ditto purple** | the spirit duplicator's aniline dye |
| Marigold | **Safelight amber** | the darkroom |
| Graphite | **Carbon black** | carbon paper |

Only the `label` fields change. The theme keys (`plum`, `marigold`, `graphite`) are saved inside every document, so renaming those would repaint drawings people already made.

Checked: `pnpm test` green (97 checks), and all six labels verified in the running app — they fit the palette menu and the collapsed trigger without truncating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)