### PR TITLE
Press Return to start typing in the selected layer

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -26,7 +26,7 @@ import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type H
 import { pickAt, pickInRect } from "@/lib/canvas/hit-test"
 import { canvasOwnsKeyboard } from "@/lib/canvas/keyboard-owner"
 import { useClipboard } from "@/lib/canvas/use-clipboard"
-import { editTarget } from "@/lib/canvas/edit-target"
+import { editTarget, hasEditableText } from "@/lib/canvas/edit-target"
 import { textBlockHeight } from "@/lib/sketch/text-layout"
 import { unionBounds, type Bounds } from "@/lib/selection"
 import { NodeSketch, SketchPrims } from "./sketch"
@@ -943,11 +943,7 @@ export function Canvas() {
       }
       // double-clicking inside a multi-selection narrows to what you clicked
       if (s.selection.length !== 1 || s.selection[0] !== hitId) s.setSelection([hitId])
-      if (n.type === "text") s.setEditing(hitId)
-      if (n.type === "component") {
-        const def = getDef(n.kind)
-        if (def?.controls.some((c) => c.type === "text")) s.setEditing(hitId)
-      }
+      if (hasEditableText(n)) s.setEditing(hitId)
     },
     [st, pick]
   )
@@ -1274,6 +1270,17 @@ export function Canvas() {
             containerRef.current?.blur()
           }
           break
+        case "Enter": {
+          // Return steps into the words of whatever is selected — the same
+          // edit a double-click opens, without having to aim at the glyphs.
+          // Only on a lone node: with several selected there's no "the" text.
+          if (e.shiftKey || s.selection.length !== 1) break
+          const n = s.nodes[s.selection[0]]
+          if (!n || !hasEditableText(n)) break
+          e.preventDefault()
+          s.setEditing(n.id)
+          break
+        }
         case "Tab": {
           // Tab is how you move between controls. Only claim it when the
           // canvas itself has focus — otherwise a click on the rail traps the

--- a/components/canvas/text-edit-overlay.tsx
+++ b/components/canvas/text-edit-overlay.tsx
@@ -8,6 +8,7 @@
 // alignment, growing around the same edge the renderer anchors to. No box, no
 // panel, no field: a caret in the drawing, and the words you're changing.
 //
+// A double-click opens this, and so does Return on a selected layer.
 // Enter (or ⌘Enter on a multi-line text node) and clicking away both commit.
 // Escape cancels, which is what Escape means everywhere else in squig.
 // ---------------------------------------------------------------------------

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -8,7 +8,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { copySelection, pasteFromSystem } from "@/lib/clipboard"
 import { useSquig } from "@/lib/store"
 import { screenToWorld } from "@/lib/types"
-import { getDef } from "@/lib/library/registry"
+import { hasEditableText } from "@/lib/canvas/edit-target"
 import { kbd } from "@/lib/shortcuts"
 import { copyAsPngWithNotice } from "@/lib/export-image"
 import {
@@ -128,8 +128,8 @@ export function CanvasContextMenu() {
       ...(hasText
         ? [{ label: "Link text…", hint: kbd("mod+k"), icon: LinkSimpleIcon, run: () => st().setLinkOpen(true) } as Entry]
         : []),
-      ...(one?.type === "text" || (one?.type === "component" && getDef(one.kind)?.controls.some((c) => c.type === "text"))
-        ? [{ label: "Edit text", hint: "double-click", icon: TextTIcon, run: () => st().setEditing(one.id) } as Entry]
+      ...(one && hasEditableText(one)
+        ? [{ label: "Edit text", hint: kbd("enter"), icon: TextTIcon, run: () => st().setEditing(one.id) } as Entry]
         : []),
       { separator: true },
       { label: "Bring to front", hint: kbd("far+]"), icon: ArrowLineUpIcon, run: () => st().bringToFront(targets) },

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -55,6 +55,15 @@ export function textControlKey(node: ComponentNode): string | null {
   return getDef(node.kind)?.controls.find((c) => c.type === "text")?.key ?? null
 }
 
+/**
+ * Has this node any words to edit? The cheap answer — same verdict `editTarget`
+ * reaches, without rendering anything to find out, so a keystroke can ask.
+ */
+export function hasEditableText(node: SquigNode): boolean {
+  if (node.type === "text") return true
+  return node.type === "component" && textControlKey(node) !== null
+}
+
 function currentValue(node: ComponentNode, key: string): string {
   const def = getDef(node.kind)
   const value = node.props[key] ?? def?.defaults[key]

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -131,7 +131,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ["mod+i"], label: "Italic" },
       { keys: ["mod+u"], label: "Underline" },
       { keys: ["mod+k"], label: "Link selected text" },
-      { keys: ["double-click"], label: "Edit text" },
+      { keys: ["enter", "double-click"], label: "Edit text" },
     ],
   },
   {


### PR DESCRIPTION
Select a text layer, press Return, and the caret lands in it — same editor a double-click opens, without having to aim at the glyphs. Type or delete straight away; Escape or a click outside finishes.

- Return only fires on a lone selection (with several picked there's no "the" text), and never with Shift held.
- Works on component labels too, matching what double-click already did.
- `hasEditableText` moves into `lib/canvas/edit-target` so the keystroke, the double-click and the context-menu item can't drift apart. The context menu and the ? sheet now advertise Return alongside double-click.

Verified in the running app: Return opens the editor with the run selected and no stray newline; typing replaces it; ⌘Return, Escape (draft discarded, layer intact) and click-away all commit or cancel as before; Return on a rectangle or a multi-selection does nothing. Types, lint and the 97 unit checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)