### PR TITLE
Rename the last three inks: Purple drizzle, Dirty blond, Hipster black

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -74,7 +74,7 @@ export const THEMES = {
     select: "#E8622F",
   },
   plum: {
-    label: "Ditto purple",
+    label: "Purple drizzle",
     bg: "#FCF9FC",
     paper: "#FFFFFF",
     ink: "#71268A",
@@ -86,7 +86,7 @@ export const THEMES = {
     select: "#D9A441",
   },
   marigold: {
-    label: "Safelight amber",
+    label: "Dirty blond",
     bg: "#FDFAF2",
     paper: "#FFFFFF",
     ink: "#B26A0F",
@@ -98,7 +98,7 @@ export const THEMES = {
     select: "#2438FF",
   },
   graphite: {
-    label: "Carbon black",
+    label: "Hipster black",
     bg: "#FCFCFA",
     paper: "#FFFFFF",
     ink: "#2D2A26",


### PR DESCRIPTION
Pablo's names, replacing the ones from #29.

| was | now |
| --- | --- |
| Ditto purple | **Purple drizzle** |
| Safelight amber | **Dirty blond** |
| Carbon black | **Hipster black** |

The old set matched the format of `Internet blue` / `Riso red` / `Terminal green` but asked you to know what a spirit duplicator is. These land without the footnote.

Sentence case, to match the rest of the list.

Labels only — theme keys (`plum`, `marigold`, `graphite`) are saved inside every document and stay put.

Checked: `pnpm test` green (97 checks), and all six verified in the running app — no truncation in the palette menu or the collapsed trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)