### PR TITLE
Invite people to the source from the file menu

### DIFF
--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -13,7 +13,7 @@
 import { useRef } from "react"
 import { useSquig } from "@/lib/store"
 import { exportDoc, importDoc } from "@/lib/file-io"
-import { CaretDownIcon } from "@phosphor-icons/react"
+import { ArrowUpRightIcon, CaretDownIcon } from "@phosphor-icons/react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -108,6 +108,22 @@ export function TopCorner() {
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onClick={() => st().clearCanvas()}>
             Clear canvas
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {/* squig is open source — the one row in here that leaves the app */}
+          <DropdownMenuItem
+            render={
+              <a
+                href="https://github.com/pablostanley/squig"
+                target="_blank"
+                rel="noreferrer noopener"
+              />
+            }
+          >
+            Contribute on GitHub
+            <DropdownMenuShortcut className="pl-4">
+              <ArrowUpRightIcon className="size-3.5" />
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
squig is open source now, so the file menu ends with a link to the repo.

- New last row: **Contribute on GitHub** → https://github.com/pablostanley/squig
- Rendered as a real `<a target="_blank">` so middle-click and ⌘-click work
- Sits after its own separator, below Clear canvas, with an arrow-up-right in
  the shortcut slot — the only row in the menu that leaves the app

Verified in the running app: menu opens, the row reads as a link with the
right href.

🤖 Generated with [Claude Code](https://claude.com/claude-code)