### PR TITLE
Point the README's try-it link at squig.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A wireframing tool for people who think by drawing.
 
-**[Open squig →](https://squig-theta.vercel.app)**
+**[Try it live at squig.sh →](https://squig.sh)**
 
 ![A squig canvas: a landing page wireframe drawn in blue ink — nav, hero, feature row, footer — with the tool's rail on the left and the page inspector on the right](docs/hero.jpg)
 


### PR DESCRIPTION
The link at the top of the README pointed at the raw Vercel URL (`squig-theta.vercel.app`). squig.sh is live (verified 200), so this uses the real domain and states plainly that it's a live demo.

Also updated the repo's About → Website field to `https://squig.sh` (was the Vercel URL) — that's a repo setting, not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)