### PR TITLE
Escape keeps your words when you stop editing text

### DIFF
--- a/components/canvas/text-edit-overlay.tsx
+++ b/components/canvas/text-edit-overlay.tsx
@@ -9,8 +9,8 @@
 // panel, no field: a caret in the drawing, and the words you're changing.
 //
 // A double-click opens this, and so does Return on a selected layer.
-// Enter (or ⌘Enter on a multi-line text node) and clicking away both commit.
-// Escape cancels, which is what Escape means everywhere else in squig.
+// Enter (or ⌘Enter on a multi-line text node), Escape and clicking away all
+// commit — leaving the editor never throws typed words away.
 // ---------------------------------------------------------------------------
 
 import { useEffect, useMemo, useRef, useState } from "react"
@@ -62,13 +62,6 @@ export function TextEditOverlay({ node, target }: { node: SquigNode; target: Edi
         props: { ...(node as ComponentNode).props, [target.propKey]: value },
       } as Partial<SquigNode>)
     }
-    s.setEditing(null)
-  }
-
-  /** Escape throws the draft away. A brand-new empty node goes with it. */
-  const cancel = () => {
-    const s = st()
-    if (isText && !(node as TextNode).text.trim()) s.removeNodes([node.id])
     s.setEditing(null)
   }
 
@@ -158,8 +151,10 @@ export function TextEditOverlay({ node, target }: { node: SquigNode; target: Edi
       onKeyDown={(e) => {
         e.stopPropagation()
         if (e.key === "Escape") {
+          // stop editing, keep the words — Escape here means "I'm done",
+          // not "undo what I typed"
           e.preventDefault()
-          cancel()
+          commit()
           return
         }
         if (e.key === "Enter" && (e.metaKey || !target.multiline)) {


### PR DESCRIPTION
Pressing Escape in the inline text editor used to throw the draft away. Now it commits, exactly like Enter or clicking away — Escape means "I'm done typing", not "undo everything I typed".

The one cancel-ish behavior that survives: placing a text layer and Escaping without typing still removes the empty node, so no invisible layers pile up.

Verified in the running app:
- new layer: T → click → type → Esc → text stays as a layer
- existing layer: double-click → retype → Esc → edit stays
- empty node: T → click → Esc → node discarded

Lint, tests, and build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)