### PR TITLE
Text layers that wrap: side handles set the measure, corners scale the type

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -18,8 +18,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useSquig } from "@/lib/store"
-import type { SquigNode } from "@/lib/types"
+import type { SquigNode, TextNode } from "@/lib/types"
 import { screenToWorld } from "@/lib/types"
+import { autoSizeTextBox, setTextWidth } from "@/lib/canvas/text-reflow"
 import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type SnapRect } from "@/lib/canvas/snap-engine"
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type Handle } from "@/lib/canvas/transform"
@@ -149,6 +150,16 @@ export function Canvas() {
   })
   const modsRef = useRef<Mods>(NO_MODS)
   const lastPointRef = useRef<{ clientX: number; clientY: number } | null>(null)
+  /**
+   * Double-press bookkeeping for the side handles. A DOM dblclick can't carry
+   * this: the first press starts (and empties out) a resize gesture, which
+   * remounts every handle, so the browser sees two different targets and
+   * delivers the dblclick to the canvas underneath — which would edit the
+   * layer, or worse, plant a new one. So the second press is caught in
+   * startResize, before it becomes a gesture at all.
+   */
+  const lastHandlePress = useRef<{ handle: Handle; t: number } | null>(null)
+  const swallowDblClickUntil = useRef(0)
   const autoPanRef = useRef<number | null>(null)
   const autoPanTickRef = useRef<() => void>(() => {})
   const hoverRafRef = useRef<number | null>(null)
@@ -421,10 +432,17 @@ export function Canvas() {
         const dx = wx - g.wx
         const dy = wy - g.wy
 
-        const raw = resizeBounds(g.origBounds, g.handle, dx, dy, { aspect: mods.shift, fromCenter: mods.alt })
+        // one text layer alone resizes like a text layer, not like a box: the
+        // side handles set the measure the words wrap to, and the corners
+        // scale the type — always in proportion, because a corner-stretched
+        // glyph isn't a thing a pen does
+        const soloText = g.origNodes.length === 1 && g.origNodes[0].type === "text" ? (g.origNodes[0] as TextNode) : null
+        const lockAspect = mods.shift || (!!soloText && g.handle.length === 2)
+
+        const raw = resizeBounds(g.origBounds, g.handle, dx, dy, { aspect: lockAspect, fromCenter: mods.alt })
         let next = raw
 
-        if (!mods.toggle && !mods.shift) {
+        if (!mods.toggle && !lockAspect) {
           // measure the snap on the unsnapped box, then fold the correction
           // back through the same resize so the result stays self-consistent
           const rectS = makeSnapRect("__bbox__", raw.x * v.zoom + v.x, raw.y * v.zoom + v.y, raw.w * v.zoom, raw.h * v.zoom)
@@ -437,6 +455,21 @@ export function Canvas() {
         } else {
           // snapping an edge would break the ratio, so aspect lock wins
           setGuides([])
+        }
+
+        if (soloText && (g.handle === "e" || g.handle === "w")) {
+          // wrap-width drag. The clamp can refuse the last few pixels of a
+          // squeeze, so the box is re-anchored on whichever edge the gesture
+          // holds still — otherwise the far edge walks as the clamp bites.
+          const patch = setTextWidth(soloText, next.w)
+          const w = patch.w as number
+          const x = mods.alt
+            ? next.x + next.w / 2 - w / 2
+            : g.handle === "w"
+              ? next.x + next.w - w
+              : next.x
+          s.updateNodes({ [soloText.id]: { ...patch, x } as Partial<SquigNode> })
+          return
         }
 
         s.updateNodes(scaleNodes(g.origNodes, g.origBounds, next))
@@ -667,6 +700,10 @@ export function Canvas() {
       s.setTool("select")
     }
 
+    // a press that actually dragged is a resize, not the first half of a
+    // double-click — don't let the next press on that handle read as one
+    if (g.kind === "resize" && g.exceeded) lastHandlePress.current = null
+
     // a click with no drag inside a bigger selection narrows to what was
     // clicked — already resolved to a group or a single piece at press time
     if (g.kind === "move" && !g.exceeded && g.collapseTo) {
@@ -787,6 +824,15 @@ export function Canvas() {
     [onPointerMove, finishGesture, cancelGesture, updateGesture]
   )
 
+  /** Double-clicking a side handle un-fixes the width — the box hugs again. */
+  const resetTextWidth = useCallback(() => {
+    const s = st()
+    const n = s.selection.length === 1 ? s.nodes[s.selection[0]] : null
+    if (!n || n.type !== "text" || !n.fixedW) return
+    s.checkpoint()
+    s.updateNode(n.id, autoSizeTextBox(n) as Partial<SquigNode>)
+  }, [st])
+
   const startResize = useCallback(
     (handle: Handle, e: React.PointerEvent) => {
       e.stopPropagation()
@@ -795,6 +841,23 @@ export function Canvas() {
       const sel = s.selection.map((id) => s.nodes[id]).filter(Boolean) as SquigNode[]
       const b = unionBounds(sel)
       if (!b) return
+
+      // double-clicking a side handle of a fixed-width text layer un-fixes it
+      const prev = lastHandlePress.current
+      lastHandlePress.current = { handle, t: e.timeStamp }
+      if (
+        prev &&
+        prev.handle === handle &&
+        e.timeStamp - prev.t < 400 &&
+        (handle === "e" || handle === "w") &&
+        sel.length === 1 &&
+        sel[0].type === "text" &&
+        sel[0].fixedW
+      ) {
+        swallowDblClickUntil.current = e.timeStamp + 600
+        resetTextWidth()
+        return
+      }
       modsRef.current = readMods(e)
       const [wx, wy] = toWorld(e)
       beginGesture(
@@ -815,7 +878,7 @@ export function Canvas() {
         e
       )
     },
-    [st, beginGesture, toWorld]
+    [st, beginGesture, toWorld, resetTextWidth]
   )
 
   const onPointerDown = useCallback(
@@ -940,9 +1003,34 @@ export function Canvas() {
 
   const onDoubleClick = useCallback(
     (e: React.MouseEvent) => {
+      // the tail of a handle double-press — see startResize
+      if (e.timeStamp < swallowDblClickUntil.current) {
+        swallowDblClickUntil.current = 0
+        return
+      }
       const s = st()
       const hitId = pick(e)
-      if (!hitId) return
+      if (!hitId) {
+        // double-clicking bare canvas starts typing there, the way tldraw
+        // does — a dismissed empty draft deletes itself, so a stray
+        // double-click costs nothing
+        if (s.tool !== "select" || s.placing) return
+        const [wx, wy] = toWorld(e)
+        const fontSize = 18
+        const h = textBlockHeight(1, fontSize)
+        const id = s.addNode({
+          type: "text",
+          text: "",
+          fontSize,
+          x: wx,
+          // the click lands in the middle of the line it just started
+          y: wy - h / 2,
+          w: 120,
+          h,
+        } as Omit<SquigNode, "id" | "seed">)
+        s.setEditing(id)
+        return
+      }
       const n = s.nodes[hitId]
       if (!n) return
       // first double-click steps into a group; the next one edits what's inside
@@ -954,7 +1042,7 @@ export function Canvas() {
       if (s.selection.length !== 1 || s.selection[0] !== hitId) s.setSelection([hitId])
       if (hasEditableText(n)) s.setEditing(hitId)
     },
-    [st, pick]
+    [st, pick, toWorld]
   )
 
   const onContextMenu = useCallback(
@@ -1567,13 +1655,21 @@ function SelectionOverlay({
   // while a marquee is sweeping, the hit set is the message — a union box and
   // handles around a set that changes every frame is just flicker
   const marqueeing = gestureKind === "marquee"
-  const showHandles = !gestureKind && w > 12 && h > 12
+  // handles stay up through a resize: they track the box the way tldraw's do,
+  // and unmounting them between the two presses of a double-click would hand
+  // the second press to the canvas underneath
+  const showHandles = (!gestureKind || gestureKind === "resize") && w > 12 && h > 12
   const showWide = w >= HANDLE_ROOM
   const showTall = h >= HANDLE_ROOM
 
+  // a lone text layer has no top or bottom to drag: its height is derived from
+  // the wrapped lines, so the handles that would set it are corners (scale the
+  // type) and sides (set the measure) — same six tldraw offers
+  const soloText = selectedNodes.length === 1 && selectedNodes[0].type === "text"
+
   const visible = (hd: Handle) => {
-    if (hd === "n" || hd === "s") return showWide
-    if (hd === "e" || hd === "w") return showTall
+    if (hd === "n" || hd === "s") return !soloText && showWide
+    if (hd === "e" || hd === "w") return soloText || showTall
     return true
   }
 
@@ -1607,9 +1703,15 @@ function SelectionOverlay({
             // a tight box, and a mis-grab costs more on a corner than a side.
             // Ordering does it — a z-index here would also lift the handles
             // over the panels that come after the canvas.
+            //
+            // A lone text layer is the one exception, reversed: its box is a
+            // line of type, short enough that the corner pads swallow the
+            // middle of either edge — exactly where you aim to set the wrap
+            // width. There the sides sit on top, and the corners keep the
+            // outward slop past the box that only they cover.
             HANDLES.filter(visible)
               .slice()
-              .sort((a, b) => a.length - b.length)
+              .sort((a, b) => (soloText ? b.length - a.length : a.length - b.length))
               .map((hd) => {
                 const box = handleHitBox(hd, w, h, padX, padY)
                 return (

--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -323,7 +323,7 @@ export const NodeSketch = memo(function NodeSketch({
       case "text":
         // w and align place the anchor, so a resize or a realignment is a
         // different set of marks even when the words haven't changed
-        return `t:${node.text}:${node.fontSize}:${node.w}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
+        return `t:${node.text}:${node.fontSize}:${node.w}:${node.fixedW ? 1 : 0}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
       case "image":
         // the src doesn't shape a single mark — only the frame's box does
         return `i:${node.w}:${node.h}:${flip}`

--- a/components/canvas/text-edit-overlay.tsx
+++ b/components/canvas/text-edit-overlay.tsx
@@ -18,12 +18,19 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useSquig } from "@/lib/store"
 import type { ComponentNode, SquigNode, TextNode } from "@/lib/types"
 import type { EditTarget } from "@/lib/canvas/edit-target"
-import { fontMetrics, measureLinesWidth } from "@/lib/canvas/text-metrics"
+import { fontMetrics, measureLinesWidth, wrapText } from "@/lib/canvas/text-metrics"
 import { fitTextBox } from "@/lib/canvas/text-reflow"
 import { TEXT_LINE_HEIGHT, anchorFactor } from "@/lib/sketch/text-layout"
 
-/** Room for a caret at either end of the run, in screen px. */
-const CARET_PAD = 2
+/**
+ * How far past the words the editor still answers to the pointer, in screen
+ * px. Padding rather than margin, so a click landing there goes to the
+ * textarea — which puts the caret at the nearest spot in the text instead of
+ * committing and dropping you out of the edit. Clicking just past the end of
+ * a line to type from there is the single most common caret gesture, and it
+ * has to keep you in.
+ */
+const CARET_PAD = 8
 
 export function TextEditOverlay({ node, target }: { node: SquigNode; target: EditTarget }) {
   const v = useSquig((s) => s.viewport)
@@ -110,35 +117,44 @@ export function TextEditOverlay({ node, target }: { node: SquigNode; target: Edi
    * is slack for ascenders, descenders and a caret at either end; the top-left
    * walks back by exactly that much, so none of it shifts anything.
    */
+  // a fixed-width text layer edits inside its own box: the textarea holds the
+  // box's width so the browser wraps the draft at the same measure the
+  // renderer will, and only the height follows the typing
+  const fixed = isText && !!(node as TextNode).fixedW
+
   const box = useMemo(() => {
     const size = target.fontSize * v.zoom
     const style = { size, bold: target.bold, italic: target.italic }
-    const lines = value.split("\n")
     const lineHeight = size * TEXT_LINE_HEIGHT
     const { ascent, descent } = fontMetrics(style)
 
     // an empty run still needs somewhere to show its placeholder
-    const run = measureLinesWidth(value ? lines : [placeholder], style)
+    const lineCount = fixed
+      ? wrapText(value, node.w * v.zoom, style).length
+      : value.split("\n").length
+    const run = fixed
+      ? node.w * v.zoom
+      : measureLinesWidth(value ? value.split("\n") : [placeholder], style)
     const padY = size * 0.35
     const anchorX = (node.x + target.x) * v.zoom + v.x
     const baselineY = (node.y + target.baseline) * v.zoom + v.y
 
     return {
-      left: anchorX - CARET_PAD - anchorFactor(target.align) * run,
+      left: fixed ? node.x * v.zoom + v.x - CARET_PAD : anchorX - CARET_PAD - anchorFactor(target.align) * run,
       top: baselineY - ((lineHeight - (ascent + descent)) / 2 + ascent) - padY,
       width: run + CARET_PAD * 2,
-      height: lines.length * lineHeight + padY * 2,
+      height: lineCount * lineHeight + padY * 2,
       padding: `${padY}px ${CARET_PAD}px`,
       fontSize: size,
       lineHeight: `${lineHeight}px`,
     }
-  }, [node.x, node.y, target, value, v, placeholder])
+  }, [node.x, node.y, node.w, target, value, v, placeholder, fixed])
 
   return (
     <textarea
       ref={taRef}
       value={value}
-      wrap="off"
+      wrap={fixed ? "soft" : "off"}
       spellCheck={false}
       onChange={(e) => setValue(target.multiline ? e.target.value : e.target.value.replace(/\n/g, ""))}
       onBlur={() => {
@@ -177,7 +193,10 @@ export function TextEditOverlay({ node, target }: { node: SquigNode; target: Edi
         fontStyle: target.italic ? "italic" : undefined,
         textDecoration: target.underline ? "underline" : undefined,
         textAlign: target.align,
-        whiteSpace: "pre",
+        whiteSpace: fixed ? "pre-wrap" : "pre",
+        // long words break where the canvas breaks them — mid-word, only when
+        // the word alone is wider than the box; see wrapText
+        overflowWrap: fixed ? "break-word" : undefined,
         color: target.color,
         caretColor: "var(--sq-ink)",
         // the one tell that this run is live: a wash the width of the words,

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -20,7 +20,7 @@ import { normalizeFill } from "@/lib/types"
 import { getDef } from "@/lib/library/registry"
 import { selectionSummary, shared, sharedControls, sharedNumber, unionBounds } from "@/lib/selection"
 import { scaleNodes, MIN_SIZE } from "@/lib/canvas/transform"
-import { fitTextBox } from "@/lib/canvas/text-reflow"
+import { fitTextBox, setTextWidth } from "@/lib/canvas/text-reflow"
 import { VariantControl } from "./variant-controls"
 import { MixedNumberField, MixedSwitch, MixedTextField } from "./mixed-fields"
 import { AlignRow } from "./align-row"
@@ -535,6 +535,10 @@ function isOutlined(n: SquigNode): boolean {
  * subtly different ones.
  */
 function resizeTo(n: SquigNode, w: number, h: number): Partial<SquigNode> {
+  // typing a width into a text layer sets the measure its words wrap to — the
+  // same thing dragging a side handle does — rather than stretching the box
+  // around the type
+  if (n.type === "text" && w !== n.w) return setTextWidth(n, w) as Partial<SquigNode>
   const from = unionBounds([n])!
   return scaleNodes([n], from, { x: n.x, y: n.y, w, h })[n.id]
 }

--- a/components/chrome/text-controls.tsx
+++ b/components/chrome/text-controls.tsx
@@ -39,9 +39,10 @@ export const TEXT_STYLES = [
 ] as const
 
 /**
- * Three, not four: squig text doesn't wrap, so there is no justify to be had —
- * a line ends where you pressed Return. What these do decide is which edge the
- * run is pinned to, which is the edge that holds still while you type.
+ * Three, not four: a napkin has no reason to justify its lines. What these do
+ * decide is which edge the run is pinned to — the edge that holds still while
+ * you type on an auto-sized layer, and how the wrapped lines sit inside a
+ * fixed-width one.
  */
 const ALIGNMENTS: { value: TextAlign; label: string; icon: PhosphorIcon }[] = [
   { value: "left", label: "Align left", icon: TextAlignLeftIcon },

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import { INK, type Prim } from "@/lib/sketch/kit"
+import { wrapText } from "@/lib/canvas/text-metrics"
 import { nodePrims } from "@/lib/sketch/node-prims"
 import { textAnchorX, textBaseline } from "@/lib/sketch/text-layout"
 import { getDef } from "@/lib/library/registry"
@@ -102,7 +103,9 @@ function locateLabel(node: ComponentNode, key: string): { prim: TextPrim; index:
  * baseline and the lines read in typing order.
  */
 function textNodeTarget(node: TextNode): EditTarget {
-  const lines = node.text.split("\n")
+  const lines = node.fixedW
+    ? wrapText(node.text, node.w, { size: node.fontSize, bold: node.bold, italic: node.italic })
+    : node.text.split("\n")
   const align: TextAlign = node.align ?? "left"
   const flipped: TextAlign = node.flipX ? (align === "left" ? "right" : align === "right" ? "left" : "center") : align
 

--- a/lib/canvas/text-metrics.ts
+++ b/lib/canvas/text-metrics.ts
@@ -68,6 +68,53 @@ export function measureLinesWidth(lines: string[], style: TypeStyle): number {
 }
 
 /**
+ * Break one paragraph to a width, the way a browser does: greedily at spaces,
+ * and through the middle of a word only when the word alone is too wide for
+ * the line (`overflow-wrap: break-word`, which is what the inline editor sets,
+ * behaves the same way — so the canvas and the textarea break in the same
+ * places).
+ */
+function wrapParagraph(text: string, maxW: number, style: TypeStyle): string[] {
+  if (measureTextWidth(text, style) <= maxW) return [text]
+  const out: string[] = []
+  let line = ""
+
+  const breakLongWord = (word: string): string => {
+    let rest = word
+    while (measureTextWidth(rest, style) > maxW && rest.length > 1) {
+      // largest head that still fits — but always at least one character, or a
+      // box narrower than one glyph would loop forever
+      let i = rest.length - 1
+      while (i > 1 && measureTextWidth(rest.slice(0, i), style) > maxW) i--
+      out.push(rest.slice(0, i))
+      rest = rest.slice(i)
+    }
+    return rest
+  }
+
+  for (const word of text.split(" ")) {
+    const test = line ? `${line} ${word}` : word
+    if (measureTextWidth(test, style) <= maxW) {
+      line = test
+      continue
+    }
+    if (line) out.push(line)
+    line = measureTextWidth(word, style) > maxW ? breakLongWord(word) : word
+  }
+  out.push(line)
+  return out
+}
+
+/**
+ * A text run's lines at a fixed box width. Hard returns always break; soft
+ * breaks are recomputed from the width, which is the whole point of a
+ * fixed-width text layer.
+ */
+export function wrapText(text: string, maxW: number, style: TypeStyle): string[] {
+  return (text || " ").split("\n").flatMap((p) => wrapParagraph(p, maxW, style))
+}
+
+/**
  * The face's own ascent and descent at this size — the em box a browser
  * centres inside a line box before it puts the baseline down.
  */

--- a/lib/canvas/text-reflow.ts
+++ b/lib/canvas/text-reflow.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { anchorFactor, textBlockHeight } from "@/lib/sketch/text-layout"
-import { measureLinesWidth } from "./text-metrics"
+import { measureLinesWidth, wrapText } from "./text-metrics"
 import type { TextNode } from "@/lib/types"
 
 /** Narrow enough to hug an "i", wide enough to still be worth clicking. */
@@ -14,17 +14,23 @@ const SLACK = 2
 /**
  * Fit the box to the words.
  *
- * The box grows and shrinks around whichever edge the alignment pins, so
- * centred text stays centred where it was and right-aligned text keeps its
- * right edge instead of sliding off it. Vertically it always grows downward —
- * the first baseline is the one thing that never moves while you type.
+ * An auto-sized layer's box grows and shrinks around whichever edge the
+ * alignment pins, so centred text stays centred where it was and right-aligned
+ * text keeps its right edge instead of sliding off it. A fixed-width layer
+ * holds its box still — the words wrap to it, and only the height answers to
+ * the text. Vertically both always grow downward: the first baseline is the
+ * one thing that never moves while you type.
  *
  * A mirrored node pins the opposite edge: flipping swaps which end of the box
  * the run hangs off (see mirrorPrims), so the anchor has to swap with it.
  */
 export function fitTextBox(n: TextNode, text: string, fontSize = n.fontSize): Partial<TextNode> {
+  const style = { size: fontSize, bold: n.bold, italic: n.italic }
+  if (n.fixedW) {
+    return { text, fontSize, h: textBlockHeight(wrapText(text, n.w, style).length, fontSize) }
+  }
   const lines = (text || " ").split("\n")
-  const measured = measureLinesWidth(lines, { size: fontSize, bold: n.bold, italic: n.italic })
+  const measured = measureLinesWidth(lines, style)
   const w = Math.max(MIN_WIDTH, measured + SLACK)
   const pinned = n.flipX ? 1 - anchorFactor(n.align) : anchorFactor(n.align)
   return {
@@ -34,4 +40,30 @@ export function fitTextBox(n: TextNode, text: string, fontSize = n.fontSize): Pa
     w,
     h: textBlockHeight(lines.length, fontSize),
   }
+}
+
+/**
+ * The narrowest a wrap width may be dragged: never below a click target, and
+ * never below one em — a glyph wider than its own box would spill past the
+ * selection ring, and the char-breaker needs room for at least one glyph per
+ * line to make progress.
+ */
+export function minTextWidth(n: TextNode): number {
+  return Math.max(MIN_WIDTH, n.fontSize)
+}
+
+/**
+ * What dragging a side handle does to a text layer: the width becomes the
+ * measure, the words re-break to it, and the height follows the line count.
+ * From here on the layer is fixed-width — `autoSizeTextBox` is the way back.
+ */
+export function setTextWidth(n: TextNode, w: number): Partial<TextNode> {
+  const cw = Math.max(minTextWidth(n), w)
+  const lines = wrapText(n.text, cw, { size: n.fontSize, bold: n.bold, italic: n.italic })
+  return { fixedW: true, w: cw, h: textBlockHeight(lines.length, n.fontSize) }
+}
+
+/** Back to hugging the words — what double-clicking a side handle means. */
+export function autoSizeTextBox(n: TextNode): Partial<TextNode> {
+  return { ...fitTextBox({ ...n, fixedW: false }, n.text), fixedW: false }
 }

--- a/lib/canvas/transform.ts
+++ b/lib/canvas/transform.ts
@@ -8,6 +8,8 @@
 
 import type { SquigNode } from "../types"
 import type { Bounds } from "../selection"
+import { textBlockHeight } from "../sketch/text-layout"
+import { wrapText } from "./text-metrics"
 
 export const HANDLES = ["nw", "n", "ne", "e", "se", "s", "sw", "w"] as const
 export type Handle = (typeof HANDLES)[number]
@@ -165,7 +167,14 @@ export function scaleNodes(
       // the renderer lays every baseline out in multiples of the type size, so
       // the type has to follow the vertical scale or the box and the words
       // come apart — see lib/sketch/text-layout
-      patch.fontSize = Math.max(4, n.fontSize * sy)
+      const fontSize = Math.max(4, n.fontSize * sy)
+      patch.fontSize = fontSize
+      // a fixed-width layer scaled off-ratio re-breaks its lines, so the box
+      // height has to come from the new wrap, not from the old height scaled
+      if (n.fixedW && Math.abs(sx - sy) > EPS) {
+        const lines = wrapText(n.text, n.w * sx, { size: fontSize, bold: n.bold, italic: n.italic })
+        patch.h = textBlockHeight(lines.length, fontSize)
+      }
     }
 
     patches[n.id] = patch as Partial<SquigNode>

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -8,6 +8,7 @@
 
 import { HAND, mirrorPrims, type Prim, type PrimOpts } from "./kit"
 import { textAnchorX, textBaseline } from "./text-layout"
+import { wrapText } from "@/lib/canvas/text-metrics"
 import { normalizeFill, type FillTone, type Outlined, type SquigNode, type StrokeWeight } from "@/lib/types"
 import { renderComponent } from "@/lib/library/registry"
 
@@ -93,7 +94,12 @@ export function basePrims(node: SquigNode): Prim[] {
     }
     case "text": {
       const anchor = textAnchorX(node.align, node.w)
-      return node.text.split("\n").map((lineText, i): Prim => ({
+      // an auto-sized layer's lines are its hard returns; a fixed-width layer
+      // re-breaks them to the measure the side handles set
+      const lines = node.fixedW
+        ? wrapText(node.text, node.w, { size: node.fontSize, bold: node.bold, italic: node.italic })
+        : node.text.split("\n")
+      return lines.map((lineText, i): Prim => ({
         t: "text",
         x: anchor,
         y: textBaseline(i, node.fontSize),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,9 +82,10 @@ export interface DrawNode extends BaseNode, Outlined {
 }
 
 /**
- * Squig text doesn't wrap — a line ends where you pressed Return — so there is
- * no justify to be had. The three that remain are real: they decide which edge
- * of the box the run is pinned to, which is what holds still while you type.
+ * No justify — a napkin has no reason to stretch its lines. The three that
+ * remain are real: on an auto-sized layer they decide which edge of the box
+ * the run is pinned to (what holds still while you type), and on a fixed-width
+ * layer they lay the wrapped lines out inside it.
  */
 export type TextAlign = "left" | "center" | "right"
 
@@ -92,6 +93,14 @@ export interface TextNode extends BaseNode {
   type: "text"
   text: string
   fontSize: number
+  /**
+   * A text layer starts life auto-sized: the box hugs the words, a line ends
+   * where you pressed Return. Dragging a side handle sets this — from then on
+   * `w` is the measure the words wrap to and `h` follows the wrapped line
+   * count. Corner handles scale the type either way. Double-clicking a side
+   * handle clears it. Absent on every document written before this existed.
+   */
+  fixedW?: boolean
   /** left when absent — most text is */
   align?: TextAlign
   bold?: boolean

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts"
+    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-text.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/test-text.ts
+++ b/scripts/test-text.ts
@@ -1,0 +1,166 @@
+// ---------------------------------------------------------------------------
+// Text wrap and reflow checks.
+//
+//   node --experimental-strip-types scripts/test-text.ts
+//
+// Off the browser there is no canvas to measure with, so every width here
+// comes from the deterministic fallback in text-metrics: each character is
+// 0.46 em wide. The numbers below are chosen around that ratio.
+// ---------------------------------------------------------------------------
+
+import { wrapText, measureTextWidth } from "../lib/canvas/text-metrics.ts"
+import { fitTextBox, setTextWidth, autoSizeTextBox, minTextWidth } from "../lib/canvas/text-reflow.ts"
+import { textBlockHeight } from "../lib/sketch/text-layout.ts"
+import { scaleNodes } from "../lib/canvas/transform.ts"
+import { unionBox, type TextNode } from "../lib/types.ts"
+
+let passed = 0
+const failures: string[] = []
+
+function check(name: string, cond: boolean, detail = "") {
+  if (cond) passed++
+  else failures.push(`${name}${detail ? ` — ${detail}` : ""}`)
+}
+
+function close(a: number, b: number, eps = 1e-6) {
+  return Math.abs(a - b) <= eps
+}
+
+const STYLE = { size: 10 } // fallback char width: 4.6
+
+const text = (over: Partial<TextNode>): TextNode => ({
+  id: "t1",
+  type: "text",
+  text: "hello world",
+  fontSize: 10,
+  x: 0,
+  y: 0,
+  w: 100,
+  h: textBlockHeight(1, 10),
+  seed: 1,
+  ...over,
+})
+
+// -- wrapText ---------------------------------------------------------------
+
+check("wide enough — one line", wrapText("hello world", 100, STYLE).length === 1)
+
+{
+  // "hello" is 23px; "hello world" is 50.6 — a 30px measure breaks at the space
+  const lines = wrapText("hello world", 30, STYLE)
+  check("breaks at the space", lines.length === 2, lines.join("|"))
+  check("break consumes the space", lines[0] === "hello" && lines[1] === "world", lines.join("|"))
+}
+
+{
+  const lines = wrapText("hi\nthere", 1000, STYLE)
+  check("hard returns always break", lines.length === 2, lines.join("|"))
+}
+
+{
+  const lines = wrapText("one\n\ntwo", 1000, STYLE)
+  check("blank lines survive", lines.length === 3 && lines[1] === "", lines.join("|"))
+}
+
+{
+  // "abcdefghij" is 46px — wider than a 20px measure on its own, so it has to
+  // break mid-word, and every piece has to fit
+  const lines = wrapText("abcdefghij", 20, STYLE)
+  check("long word breaks mid-word", lines.length > 1, lines.join("|"))
+  check(
+    "every broken piece fits",
+    lines.every((l) => measureTextWidth(l, STYLE) <= 20),
+    lines.join("|")
+  )
+  check("no glyph lost breaking", lines.join("") === "abcdefghij", lines.join("|"))
+}
+
+{
+  // a measure narrower than one glyph must still make progress
+  const lines = wrapText("abc", 1, STYLE)
+  check("degenerate measure terminates", lines.length === 3, lines.join("|"))
+}
+
+check("empty text still has a line", wrapText("", 100, STYLE).length === 1)
+
+// -- fitTextBox -------------------------------------------------------------
+
+{
+  // auto-sized: the box hugs the words
+  const n = text({})
+  const fit = fitTextBox(n, "hello world")
+  check("auto fit hugs the run", close(fit.w!, measureTextWidth("hello world", STYLE) + 2))
+  check("auto fit single-line height", close(fit.h!, textBlockHeight(1, 10)))
+}
+
+{
+  // fixed-width: the box holds, the height answers to the wrap
+  const n = text({ fixedW: true, w: 30 })
+  const fit = fitTextBox(n, "hello world")
+  check("fixed fit keeps the measure", fit.w === undefined && fit.x === undefined)
+  check("fixed fit height follows the wrap", close(fit.h!, textBlockHeight(2, 10)))
+}
+
+{
+  // centred auto text grows around its centre
+  const n = text({ align: "center", x: 50, w: 20 })
+  const fit = fitTextBox(n, "hello world")
+  check("centred fit stays centred", close(n.x + n.w / 2, fit.x! + fit.w! / 2))
+}
+
+// -- setTextWidth / autoSizeTextBox ----------------------------------------
+
+{
+  const n = text({})
+  const patch = setTextWidth(n, 30)
+  check("side drag fixes the width", patch.fixedW === true && patch.w === 30)
+  check("side drag reflows the height", close(patch.h!, textBlockHeight(2, 10)))
+}
+
+{
+  const n = text({ fontSize: 40 })
+  const patch = setTextWidth(n, 1)
+  check("width clamps at one em", patch.w === Math.max(24, 40), String(patch.w))
+  check("minTextWidth agrees", minTextWidth(n) === 40)
+}
+
+{
+  const n = text({ fixedW: true, w: 30, h: textBlockHeight(2, 10) })
+  const patch = autoSizeTextBox(n)
+  check("reset un-fixes the width", patch.fixedW === false)
+  check("reset hugs the run again", close(patch.w!, measureTextWidth("hello world", STYLE) + 2))
+  check("reset back to one line", close(patch.h!, textBlockHeight(1, 10)))
+}
+
+// -- scaleNodes on fixed-width text ----------------------------------------
+
+{
+  // uniform scale: wrap points are scale-invariant, height scales with the box
+  const n = text({ fixedW: true, w: 30, h: textBlockHeight(2, 10) })
+  const from = { x: 0, y: 0, w: 30, h: n.h }
+  const patch = scaleNodes([n], from, { x: 0, y: 0, w: 60, h: n.h * 2 })[n.id] as Partial<TextNode>
+  check("uniform scale doubles the type", close(patch.fontSize!, 20))
+  check("uniform scale keeps two lines", close(patch.h!, textBlockHeight(2, 20)), String(patch.h))
+}
+
+{
+  // widening only: the words re-break, the height comes from the new wrap
+  const n = text({ fixedW: true, w: 30, h: textBlockHeight(2, 10) })
+  const from = { x: 0, y: 0, w: 30, h: n.h }
+  const patch = scaleNodes([n], from, { x: 0, y: 0, w: 100, h: n.h })[n.id] as Partial<TextNode>
+  check("off-ratio scale keeps the type", close(patch.fontSize!, 10))
+  check("off-ratio scale reflows to one line", close(patch.h!, textBlockHeight(1, 10)), String(patch.h))
+}
+
+// unionBox import keeps this file honest about types.ts still exporting it —
+// and a box of one node is that node
+check("unionBox sanity", unionBox([text({})])!.maxX === 100)
+
+// -- report -----------------------------------------------------------------
+
+if (failures.length) {
+  console.error(`✗ ${failures.length} failed, ${passed} passed`)
+  for (const f of failures) console.error(`  ✗ ${f}`)
+  process.exit(1)
+}
+console.log(`✓ text: all ${passed} checks passed`)


### PR DESCRIPTION
Text layers now behave the way tldraw and Figma taught everyone's hands to expect.

## The headline

- **Side handles set the wrap width.** Dragging e/w on a text layer fixes its width; the words re-break to that measure and the box height follows the wrapped line count, live through the drag. The opposite edge stays pinned (alt drags from center).
- **Corner handles scale the type**, always in proportion — a corner-stretched glyph isn't a thing a pen does.
- **A lone text layer shows six handles**: corners + sides. No top/bottom, because height is derived from the wrap.
- **Double-clicking a side handle un-fixes the width** — the box hugs the words again, growing around the edge the alignment pins (centered text stays centered).

## Editing UX fixes

- Clicking inside the words while editing **moves the caret** instead of committing and dropping you out. The editor's hit area reaches 8px past the run, so clicking just past the end of a line — the most common caret gesture — stays in.
- **Double-clicking bare canvas starts typing there** (tldraw's move). A dismissed empty draft deletes itself, so a stray double-click costs nothing.
- Editing a fixed-width layer happens in a **box-wide textarea that wraps at the same points the renderer will** (same greedy breaker, same `break-word` behavior for long words) and grows downward as you type.
- On a short text box the corner pads used to swallow the middle of the edge — exactly where you aim to set the width. **Sides now win that overlap for text**, and handles stay mounted through a resize so handle double-clicks can land.
- Inspector: typing a **W** does what the side handle does; **font size changes on a fixed layer keep the measure and reflow the height**; alignment lays the wrapped lines inside the held box.

## How

One new optional field, `TextNode.fixedW` (absent on every existing document — old files are untouched). The wrap itself is a single greedy breaker in `lib/canvas/text-metrics.ts`, shared by the renderer, the inline editor, the PNG export and the resize maths, so they can never disagree about where a line ends.

## Verification

- `pnpm test` — 132 checks including 27 new ones in `scripts/test-text.ts` (wrap edge cases, fit/reset math, off-ratio scaling); lint and build clean.
- Exercised end to end in the running app: create by double-click, wrap by side drag both directions, corner scale, live wrap while typing, caret clicks mid-edit, handle double-click reset, undo, center alignment, and a component label edit to confirm the shared overlay still lands on the button's baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)