### PR TITLE
Let a click inside an unfilled shape select it

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -23,7 +23,7 @@ import { screenToWorld } from "@/lib/types"
 import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type SnapRect } from "@/lib/canvas/snap-engine"
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type Handle } from "@/lib/canvas/transform"
-import { pickAt, pickInRect } from "@/lib/canvas/hit-test"
+import { pickAt, pickInRect, pickSoftAt } from "@/lib/canvas/hit-test"
 import { canvasOwnsKeyboard } from "@/lib/canvas/keyboard-owner"
 import { useClipboard } from "@/lib/canvas/use-clipboard"
 import { editTarget, hasEditableText } from "@/lib/canvas/edit-target"
@@ -107,6 +107,11 @@ type Gesture =
       pointerId: number
       exceeded: boolean
       base: string[]
+      /** the hollow shape whose middle the press landed in, if any. A press
+       *  there reads two ways — a click means "select this shape", a drag
+       *  means "marquee, it just happened to start inside" — so the candidate
+       *  rides along and the release picks the reading. */
+      softHitId: string | null
     }
   | { kind: "draw"; points: [number, number][]; sx: number; sy: number; pointerId: number; exceeded: boolean }
   | {
@@ -176,7 +181,9 @@ export function Canvas() {
   const [guides, setGuides] = useState<GuideLine[]>([])
   const [cursor, setCursor] = useState<[number, number] | null>(null)
   const [livePoints, setLivePoints] = useState<[number, number][] | null>(null)
-  const [hoverId, setHoverId] = useState<string | null>(null)
+  /** soft: the pointer is over a hollow shape's middle — a click would select
+   *  it but a drag would marquee, so the outline shows without a move cursor */
+  const [hover, setHover] = useState<{ id: string; soft: boolean } | null>(null)
   const [altHeld, setAltHeld] = useState(false)
   const [gestureKind, setGestureKind] = useState<Gesture["kind"] | null>(null)
 
@@ -205,7 +212,12 @@ export function Canvas() {
     (e: { clientX: number; clientY: number }): string | null => {
       const s = st()
       const [wx, wy] = toWorld(e)
-      return pickAt(s.nodes, s.order, wx, wy, s.viewport.zoom)
+      // ink and fills first; failing that, the hollow shape the point is
+      // inside of — double-click, right-click and hover all read a point the
+      // way a completed click does
+      return (
+        pickAt(s.nodes, s.order, wx, wy, s.viewport.zoom) ?? pickSoftAt(s.nodes, s.order, wx, wy)
+      )
     },
     [st, toWorld]
   )
@@ -299,6 +311,10 @@ export function Canvas() {
       }
 
       if (g.kind === "marquee") {
+        // while a hollow-shape candidate is in play the press hasn't chosen a
+        // meaning yet, so the selection holds still: a click will take the
+        // shape on release, and a real drag lands in the branch below
+        if (!g.exceeded && g.softHitId) return
         const box: Bounds = {
           x: Math.min(g.wx, wx),
           y: Math.min(g.wy, wy),
@@ -673,6 +689,25 @@ export function Canvas() {
       s.setSelection(g.collapseTo)
     }
 
+    // the press sat inside a hollow shape and never became a drag: it was a
+    // click on that shape all along, with the same grammar a hard click gets —
+    // groups expand, ⌘ digs into them, Shift/⌘ add or toggle off
+    if (g.kind === "marquee" && !g.exceeded && g.softHitId && s.nodes[g.softHitId]) {
+      const mods = modsRef.current
+      const deep = mods.toggle && !!s.nodes[g.softHitId]?.groupIds?.length
+      const hitSet = deep ? [g.softHitId] : s.expandSelection([g.softHitId])
+      if (!deep && (mods.shift || mods.toggle)) {
+        const sel = s.selection
+        s.setSelection(
+          hitSet.every((id) => sel.includes(id))
+            ? sel.filter((i) => !hitSet.includes(i))
+            : [...new Set([...sel, ...hitSet])]
+        )
+      } else {
+        s.setSelection(hitSet)
+      }
+    }
+
     // an ⌥-drag copy hands ⌘D the distance it travelled, so the next one
     // lands the same way again. cloneIds and sourceIds share an index.
     if (g.kind === "move" && g.cloneIds) {
@@ -932,8 +967,11 @@ export function Canvas() {
         return
       }
 
-      // empty canvas — marquee, with the current selection as its base
-      beginGesture({ kind: "marquee", ...common, wx, wy, base: s.selection }, e)
+      // no ink under the press — marquee, with the current selection as its
+      // base. If the press sits inside a hollow shape, that shape rides along
+      // as the thing a mere click would mean.
+      const softHitId = pickSoftAt(s.nodes, s.order, wx, wy)
+      beginGesture({ kind: "marquee", ...common, wx, wy, base: s.selection, softHitId }, e)
     },
     [st, tool, isSpacebarHeld, toWorld, beginGesture, dropComponent]
   )
@@ -983,7 +1021,7 @@ export function Canvas() {
       // the ghost is driven at the window level instead — see below
       if (s.placing) return
       if (gestureRef.current || s.tool !== "select" || isSpacebarHeld || s.editingId) {
-        if (hoverId) setHoverId(null)
+        if (hover) setHover(null)
         return
       }
       if (hoverRafRef.current !== null) return
@@ -992,13 +1030,17 @@ export function Canvas() {
         hoverRafRef.current = null
         // the same predicate the click uses — an affordance drawn from
         // different geometry than the hit test is just a lie
-        setHoverId(pick({ clientX, clientY }))
+        const cur = st()
+        const [wx, wy] = toWorld({ clientX, clientY })
+        const hard = pickAt(cur.nodes, cur.order, wx, wy, cur.viewport.zoom)
+        const id = hard ?? pickSoftAt(cur.nodes, cur.order, wx, wy)
+        setHover(id ? { id, soft: !hard } : null)
       })
     },
-    [st, toWorld, hoverId, isSpacebarHeld, pick]
+    [st, toWorld, hover, isSpacebarHeld]
   )
 
-  const onPointerLeave = useCallback(() => setHoverId(null), [])
+  const onPointerLeave = useCallback(() => setHover(null), [])
 
   /**
    * The placement ghost tracks the pointer on `window`, not on the canvas, so a
@@ -1366,15 +1408,17 @@ export function Canvas() {
     [selection, nodes]
   )
   const placingDef = placing ? getDef(placing) : null
-  const hoverNode = hoverId && !selection.includes(hoverId) ? nodes[hoverId] : null
+  const hoverNode = hover && !selection.includes(hover.id) ? nodes[hover.id] : null
 
+  // a soft hover keeps the default cursor: a click there selects, but a drag
+  // marquees, and a move cursor would promise a drag this press won't do
   const cursorStyle = isSpacebarHeld && !gestureKind
     ? "grab"
     : placing || tool === "shape" || tool === "arrow" || tool === "draw" || tool === "text"
       ? "crosshair"
       : gestureKind === "move"
         ? (altHeld ? "copy" : "move")
-        : hoverId && tool === "select"
+        : hover && !hover.soft && tool === "select"
           ? (altHeld ? "copy" : "move")
           : "default"
 

--- a/lib/canvas/hit-test.ts
+++ b/lib/canvas/hit-test.ts
@@ -216,6 +216,58 @@ export function hitsRect(n: SquigNode, r: Bounds, zoom: number): boolean {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Is the point inside a hollow node's see-through middle?
+ *
+ * The middle stays transparent to `hitsPoint` so that presses inside a big
+ * empty box can still become a marquee — but a *click* that lands there and
+ * never turns into a drag was almost certainly aimed at the shape. This is
+ * the test for that second reading: consulted only after `hitsPoint` has
+ * missed everything, so borders and filled shapes have already had their say.
+ *
+ * Arrows don't take part. A diagonal arrow's box is mostly empty air over
+ * whatever it happens to cross, and treating all of it as a target would make
+ * connectors swallow clicks meant for the space between things.
+ */
+export function hitsInterior(n: SquigNode, x: number, y: number): boolean {
+  const hollowShape = n.type === "shape" && normalizeFill(n.fill) === "none"
+  if (!hollowShape && n.type !== "draw") return false
+  if (!inBox(x, y, boxOf(n), 0)) return false
+  if (n.type === "shape" && n.shape === "ellipse") {
+    // inside the oval means inside the disc — the corners of its box stay
+    // empty, same as they do for the hard test
+    const rx = n.w / 2
+    const ry = n.h / 2
+    if (rx <= 0 || ry <= 0) return false
+    const nx = (x - (n.x + rx)) / rx
+    const ny = (y - (n.y + ry)) / ry
+    return Math.hypot(nx, ny) <= 1
+  }
+  // rects and doodles answer by their whole box
+  return true
+}
+
+/**
+ * Topmost hollow node whose interior holds the point, or null.
+ *
+ * The click-only fallback behind `pickAt`: call it when the hard pick came up
+ * empty and the press turned out to be a click rather than a drag. Because it
+ * only runs after a full miss, anything filled has already won, and walking
+ * front-to-back settles overlapping hollow shapes by z-order.
+ */
+export function pickSoftAt(
+  nodes: Record<string, SquigNode>,
+  order: readonly string[],
+  x: number,
+  y: number
+): string | null {
+  for (let i = order.length - 1; i >= 0; i--) {
+    const n = nodes[order[i]]
+    if (n && hitsInterior(n, x, y)) return order[i]
+  }
+  return null
+}
+
 /** Topmost node under a world point, or null. Walks front-to-back. */
 export function pickAt(
   nodes: Record<string, SquigNode>,

--- a/scripts/test-geometry.ts
+++ b/scripts/test-geometry.ts
@@ -8,7 +8,7 @@
 // ---------------------------------------------------------------------------
 
 import { resizeBounds, scaleNodes, MIN_SIZE, type Handle } from "../lib/canvas/transform.ts"
-import { hitsPoint, hitsRect, pickAt, pickInRect, pickTolerance } from "../lib/canvas/hit-test.ts"
+import { hitsInterior, hitsPoint, hitsRect, pickAt, pickInRect, pickSoftAt, pickTolerance } from "../lib/canvas/hit-test.ts"
 import { repeatStep } from "../lib/canvas/duplicate.ts"
 import type { SquigNode } from "../lib/types.ts"
 
@@ -289,6 +289,53 @@ const apply = (ns: SquigNode[], patches: Record<string, Partial<SquigNode>>): Sq
   check("a near-horizontal arrow is grabbable a few px off its line", hitsPoint(flat, 150, 4, 1))
   check("but not from far away", !hitsPoint(flat, 150, 40, 1))
   check("tolerance for lines ignores their thickness", pickTolerance(1, flat) === pickTolerance(1))
+}
+
+// -- soft picking: what a mere click in a hollow middle means ----------------
+
+{
+  const hollow = rect("hollow", 0, 0, 400, 300)
+  const solid = rect("solid", 0, 0, 400, 300, true)
+
+  check("a hollow rect's middle is a soft target", hitsInterior(hollow, 200, 150))
+  check("but nothing outside its box is", !hitsInterior(hollow, 500, 150))
+  check("a filled rect is never a soft target — the hard pick already owns it", !hitsInterior(solid, 200, 150))
+
+  const ring = ellipse("ring", 0, 0, 200, 200)
+  check("a hollow ellipse's disc is a soft target", hitsInterior(ring, 100, 100))
+  check("the empty corner of its box is not", !hitsInterior(ring, 8, 8))
+
+  const doodle: SquigNode = {
+    id: "doodle", type: "draw", x: 0, y: 0, w: 100, h: 100,
+    points: [[0, 100], [50, 0], [100, 100]], seed: 1,
+  }
+  check("a doodle's box is a soft target", hitsInterior(doodle, 50, 90))
+  check("an arrow's box never is", !hitsInterior(arrow("a", 0, 0, 200, 200), 190, 10))
+}
+
+{
+  // two hollow rects sharing a middle: the one on top takes the click
+  const nodes: Record<string, SquigNode> = {
+    below: rect("below", 0, 0, 300, 300),
+    above: rect("above", 50, 50, 300, 300),
+  }
+  const order = ["below", "above"]
+  check("overlapping soft picks resolve to the topmost node", pickSoftAt(nodes, order, 150, 150) === "above")
+  check("outside the top one falls through to the one below", pickSoftAt(nodes, order, 20, 20) === "below")
+  check("empty space soft-picks nothing", pickSoftAt(nodes, order, 500, 500) === null)
+}
+
+{
+  // a border always beats a hollow middle, even a middle stacked above it:
+  // the hard pick answers first and the soft pick is never consulted
+  const nodes: Record<string, SquigNode> = {
+    small: rect("small", 0, 0, 100, 100),
+    big: rect("big", -50, -50, 200, 200),
+  }
+  // big sits on top of small in z, and its hollow middle covers all of small
+  const order = ["small", "big"]
+  check("a border below beats a hollow middle above", pickAt(nodes, order, 0, 50, 1) === "small")
+  check("where no ink answers, the topmost middle takes it", pickSoftAt(nodes, order, 50, 50) === "big")
 }
 
 // -- the step ⌘D repeats ----------------------------------------------------


### PR DESCRIPTION
Unfilled shapes were only grabbable by their outline, which made them slippery: a click anywhere in the middle fell through to the marquee. Now that press reads two ways, and the release picks the meaning.

## What changed

- **Click in a hollow middle → select the shape.** A press inside an unfilled rect, oval (its disc, not its box corners) or freehand doodle that never becomes a drag selects it, with the same click grammar as ink: groups expand, ⌘ digs in, Shift/⌘ adds or toggles off.
- **Drag from a hollow middle → marquee**, exactly as before. The selection holds still until the press picks a meaning, so nothing flickers.
- **Priority is unchanged where it matters:** a border always wins (even a border *below* a hollow middle in z), a filled shape under the point beats every hollow middle stacked above it, and overlapping hollow middles resolve to the topmost. Arrows don't take part — a connector's box is mostly empty air over other things.
- **Hover tells the truth:** the outline shows over a hollow middle because a click would select it, but the cursor stays default there — a move cursor would promise a drag this press won't do. Double-click and right-click read the point the same way.

## How

`pickSoftAt` in `lib/canvas/hit-test.ts` is a click-only fallback consulted after `pickAt` misses everything, so all the hard-hit priority rules come for free. The marquee gesture carries the soft candidate and the release decides.

## Verified

- `pnpm test` — 117 checks, including 12 new soft-pick cases
- `tsc`, `eslint`, `next build` all clean
- In the running app: click-selects / drag-marquees / border-moves on a hollow rect; filled child wins under two hollow middles; topmost hollow wins where only middles overlap; a border below beats a middle above; marquee inside a hollow frame grabs only what it crosses; oval disc vs box corner; doodle by its box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)