### PR TITLE
Three inks: text and outlines can turn down to muted or faint

### DIFF
--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -59,7 +59,9 @@ function fillPaint(o: PrimOpts): string {
  * border above it, it is the same pen pressed lighter. So `stroke` no longer
  * picks a colour; it picks how hard the pen presses, and the tone names it
  * inherited now read as weights. Anything that needs to recede further than
- * a hairline should be carrying a shaded fill instead of a paler line.
+ * a hairline should be carrying a shaded fill instead of a paler line. The one
+ * exception is the user's own hand: a canvas node can ask for a paler tone
+ * through `PrimOpts.tone`, which the library never sets.
  */
 const PEN: Record<InkColor, number> = {
   ink: 1,
@@ -75,7 +77,7 @@ function primOptions(p: Prim, seed: number): Options {
     seed,
     roughness: o?.roughness ?? HAND.roughness,
     bowing: HAND.bowing,
-    stroke: INK.ink,
+    stroke: INK[o?.tone ?? "ink"],
     // an explicit strokeWidth is already a considered weight — leave it alone
     strokeWidth: o?.strokeWidth ?? (HAND.strokeWidth * PEN[o?.stroke ?? "ink"]),
     fill: undefined,
@@ -309,8 +311,14 @@ export const NodeSketch = memo(function NodeSketch({
 }) {
   const shapeKey = useMemo(() => {
     const flip = `${node.flipX ? 1 : 0}${node.flipY ? 1 : 0}`
-    // outline settings change the generated geometry, so they belong in the key
-    const pen = "stroke" in node ? `${node.stroke ?? ""}:${node.dashed ? 1 : 0}` : ""
+    // outline settings change the marks — the geometry, or the ink they print
+    // in — so they belong in the key. Guarded by type, not by key presence: a
+    // fresh shape has none of these keys yet, and the first patch only adds
+    // the one it sets, so an `in` check would miss the change entirely.
+    const pen =
+      node.type === "shape" || node.type === "draw" || node.type === "arrow"
+        ? `${node.stroke ?? ""}:${node.dashed ? 1 : 0}:${node.ink ?? ""}`
+        : ""
     switch (node.type) {
       case "component":
         return `c:${node.kind}:${node.w}:${node.h}:${flip}:${JSON.stringify(node.props)}`
@@ -323,7 +331,7 @@ export const NodeSketch = memo(function NodeSketch({
       case "text":
         // w and align place the anchor, so a resize or a realignment is a
         // different set of marks even when the words haven't changed
-        return `t:${node.text}:${node.fontSize}:${node.w}:${node.fixedW ? 1 : 0}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}`
+        return `t:${node.text}:${node.fontSize}:${node.w}:${node.fixedW ? 1 : 0}:${node.align ?? ""}:${flip}:${node.bold ? 1 : 0}${node.italic ? 1 : 0}${node.underline || node.link ? 1 : 0}:${node.ink ?? ""}`
       case "image":
         // the src doesn't shape a single mark — only the frame's box does
         return `i:${node.w}:${node.h}:${flip}`

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -15,8 +15,8 @@
 // ---------------------------------------------------------------------------
 
 import { useSquig } from "@/lib/store"
-import type { ArrowNode, ComponentNode, FillTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
-import { normalizeFill } from "@/lib/types"
+import type { ArrowNode, ComponentNode, FillTone, InkTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
+import { normalizeFill, normalizeInk } from "@/lib/types"
 import { getDef } from "@/lib/library/registry"
 import { selectionSummary, shared, sharedControls, sharedNumber, unionBounds } from "@/lib/selection"
 import { scaleNodes, MIN_SIZE } from "@/lib/canvas/transform"
@@ -114,6 +114,34 @@ const STROKE_OPTIONS: readonly SegmentOption<StrokeWeight>[] = [
   { value: "light", label: "Light pen", content: <PenChip height={1} /> },
   { value: "regular", label: "Regular pen", content: <PenChip height={1.75} /> },
   { value: "heavy", label: "Heavy pen", content: <PenChip height={3} /> },
+]
+
+/** "A" set in one tone — the ink previewed on the thing it will colour. */
+function InkLetter({ color }: { color: string }) {
+  return (
+    <span className="text-[13px] leading-none font-semibold" style={{ color }}>
+      A
+    </span>
+  )
+}
+
+/** A drop of one tone — the outline inks are dots, the fills stay square chips. */
+function InkDot({ color }: { color: string }) {
+  return <span className="block size-3 rounded-full" style={{ background: color }} />
+}
+
+/** The ink ladder as letters — for text, the tone is shown on an actual glyph. */
+const TEXT_INK_OPTIONS: readonly SegmentOption<InkTone>[] = [
+  { value: "ink", label: "Ink", content: <InkLetter color="var(--sq-ink)" /> },
+  { value: "muted", label: "Muted", content: <InkLetter color="var(--sq-muted)" /> },
+  { value: "faint", label: "Faint", content: <InkLetter color="var(--sq-faint)" /> },
+]
+
+/** The same ladder as pen dots — what an outline dipped in each tone prints like. */
+const LINE_INK_OPTIONS: readonly SegmentOption<InkTone>[] = [
+  { value: "ink", label: "Ink", content: <InkDot color="var(--sq-ink)" /> },
+  { value: "muted", label: "Muted", content: <InkDot color="var(--sq-muted)" /> },
+  { value: "faint", label: "Faint", content: <InkDot color="var(--sq-faint)" /> },
 ]
 
 // ---------------------------------------------------------------------------
@@ -384,6 +412,17 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
             <TextStyleToggles texts={texts} />
           </Row>
 
+          <Row label="Ink">
+            <Segmented
+              ariaLabel="Text ink"
+              options={TEXT_INK_OPTIONS}
+              shared={shared(texts.map((n) => normalizeInk(n.ink)))}
+              onChange={(tone) =>
+                patch((n) => (n.type === "text" ? ({ ink: tone === "ink" ? undefined : tone } as Partial<SquigNode>) : null))
+              }
+            />
+          </Row>
+
           {/* A link is a value, not a mode — so it gets a field showing where
               the text actually points. Empty means it points nowhere, and
               clearing the field is how you unlink. ⌘K still opens the floating
@@ -440,6 +479,14 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
               options={STROKE_OPTIONS}
               shared={shared(outlined.map((n) => ("stroke" in n ? (n.stroke ?? "regular") : "regular")))}
               onChange={(weight) => patch((n) => (isOutlined(n) ? ({ stroke: weight } as Partial<SquigNode>) : null))}
+            />
+          </Row>
+          <Row label="Ink">
+            <Segmented
+              ariaLabel="Outline ink"
+              options={LINE_INK_OPTIONS}
+              shared={shared(outlined.map((n) => normalizeInk("ink" in n ? n.ink : undefined)))}
+              onChange={(tone) => patch((n) => (isOutlined(n) ? ({ ink: tone === "ink" ? undefined : tone } as Partial<SquigNode>) : null))}
             />
           </Row>
           <Row spread label="Dashed">

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -15,6 +15,7 @@ import { wrapText } from "@/lib/canvas/text-metrics"
 import { nodePrims } from "@/lib/sketch/node-prims"
 import { textAnchorX, textBaseline } from "@/lib/sketch/text-layout"
 import { getDef } from "@/lib/library/registry"
+import { normalizeInk } from "@/lib/types"
 import type { ComponentNode, SquigNode, TextAlign, TextNode } from "@/lib/types"
 
 type TextPrim = Extract<Prim, { t: "text" }>
@@ -123,7 +124,7 @@ function textNodeTarget(node: TextNode): EditTarget {
     bold: !!node.bold,
     italic: !!node.italic,
     underline: !!node.underline || !!node.link,
-    color: INK.ink,
+    color: INK[normalizeInk(node.ink)],
     multiline: true,
     hidden: "all",
   }

--- a/lib/library/break-apart.ts
+++ b/lib/library/break-apart.ts
@@ -107,6 +107,9 @@ export function breakApart(node: ComponentNode): SquigNode[] {
           y: node.y + p.y - p.size,
           w, h: textBlockHeight(1, p.size),
           text: p.text, fontSize: p.size, align: p.align,
+          // a label authored in a quieter ink keeps it — the component's tonal
+          // hierarchy is most of what it was saying, same as its fills
+          ink: p.color === "muted" || p.color === "faint" ? p.color : undefined,
           bold: p.bold, italic: p.italic, underline: p.underline,
           seed: seed(),
         })

--- a/lib/sketch/kit.ts
+++ b/lib/sketch/kit.ts
@@ -48,9 +48,17 @@ export interface PrimOpts {
    * Pen pressure, not colour — every line in a squig prints in the one ink.
    * "ink" is a full stroke, "muted" an ordinary one, "faint" a hairline.
    * If something needs to recede further than a hairline, give it a shaded
-   * fill; don't reach for a paler line, because there isn't one.
+   * fill; don't reach for a paler line. (A canvas node the *user* pales is
+   * different — that's `tone`.)
    */
   stroke?: InkColor
+  /**
+   * The ink the mark actually prints in — the user-facing three-step ladder.
+   * Library defs never set this (their `stroke` picks pressure, and every
+   * authored line prints in the one ink); it exists for canvas nodes whose
+   * outline the user has deliberately turned down to muted or faint.
+   */
+  tone?: InkColor
   strokeWidth?: number
   /**
    * "shade" is the tinted fill — a flat step off the paper, never a pattern.

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -9,7 +9,7 @@
 import { HAND, mirrorPrims, type Prim, type PrimOpts } from "./kit"
 import { textAnchorX, textBaseline } from "./text-layout"
 import { wrapText } from "@/lib/canvas/text-metrics"
-import { normalizeFill, type FillTone, type Outlined, type SquigNode, type StrokeWeight } from "@/lib/types"
+import { normalizeFill, normalizeInk, type FillTone, type Outlined, type SquigNode, type StrokeWeight } from "@/lib/types"
 import { renderComponent } from "@/lib/library/registry"
 
 /**
@@ -44,6 +44,9 @@ function outline(node: Outlined, baseWidth: number, o?: PrimOpts): PrimOpts {
   return {
     ...o,
     strokeWidth: baseWidth * PEN_SCALE[node.stroke ?? "regular"],
+    // pressure and tone are two different knobs: how hard the pen presses, and
+    // which of the three inks it was dipped in
+    tone: normalizeInk(node.ink),
     dashed: node.dashed,
   }
 }
@@ -106,6 +109,7 @@ export function basePrims(node: SquigNode): Prim[] {
         text: lineText,
         size: node.fontSize,
         align: node.align,
+        color: normalizeInk(node.ink),
         bold: node.bold,
         italic: node.italic,
         // a link is a link because it's underlined — no blue in a wireframe

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,19 @@ export type ShapeKind = "rect" | "ellipse"
 export type FillTone = "none" | "paper" | "light" | "strong"
 
 /**
+ * Which step of the ink ladder a node prints in. One ink, three strengths:
+ * full ink, the muted secondary, and the faint hairline tone — the same three
+ * the theme already mixes for component labels. Absent means full ink, which
+ * is what every document written before this existed meant.
+ */
+export type InkTone = "ink" | "muted" | "faint"
+
+/** Documents come from disk and localStorage — read anything, keep the ladder. */
+export function normalizeInk(v: unknown): InkTone {
+  return v === "muted" || v === "faint" ? v : "ink"
+}
+
+/**
  * Pen pressure for a drawn line. One pen, pressed harder or softer — squig has
  * no second stroke colour, so weight is the whole outline vocabulary.
  */
@@ -27,6 +40,8 @@ export type StrokeWeight = "light" | "regular" | "heavy"
 /** Outline settings shared by every hand-drawn node. */
 export interface Outlined {
   stroke?: StrokeWeight
+  /** the tone the line prints in — full ink when absent */
+  ink?: InkTone
   dashed?: boolean
 }
 
@@ -103,6 +118,8 @@ export interface TextNode extends BaseNode {
   fixedW?: boolean
   /** left when absent — most text is */
   align?: TextAlign
+  /** the tone the words print in — full ink when absent */
+  ink?: InkTone
   bold?: boolean
   italic?: boolean
   underline?: boolean


### PR DESCRIPTION
The theme has always mixed three strengths of its one ink — full, muted, faint — but user nodes could only print in the first. This exposes the ladder:

- **Text layers** get an **Ink** row in the inspector (three "A" chips set in the live palette's actual tones).
- **Outlined nodes** — shapes, scribbles, arrows — get an **Ink** row in the Outline section (tone dots), sitting between Pen and Dashed.
- Absent means full ink, so every existing document reads and renders exactly as before, and choosing full ink writes nothing into the file.

Design notes:
- The tone is a new prim option (`PrimOpts.tone`), deliberately separate from `stroke`: in library defs `stroke` picks pen *pressure*, and authored components keep printing every line in the one ink. The "one pen" rule survives; the user's own hand gets the dial.
- Labels a def authors in muted/faint keep their tone when the component is broken apart.
- The inline text editor types in the same tone the run prints in.
- Export needed no changes — the resolver already maps every `--sq-*` var — verified end to end.

Also fixes a latent repaint bug found during review: `NodeSketch`'s memo key guarded outline settings behind a runtime `"stroke" in node` check, but a fresh shape has no such key and a patch only adds the field it sets — so toggling **dashed** on a never-restroked shape changed the document without repainting. The guard is now by node type (verified: dashed now repaints instantly on a fresh rect).

Verified in the running app: tone chips render from the live palette; canvas repaints on every tone change; muted/faint survive save/reload (`ink` persists in the file), undo, theme switching (tones follow the new palette), break-apart, mixed selections (dashed track), and PNG export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)