### PR TITLE
Swap the align-centre icons so they point the way they move things

### DIFF
--- a/components/chrome/align-row.tsx
+++ b/components/chrome/align-row.tsx
@@ -25,10 +25,10 @@ type Edge = "left" | "hcenter" | "right" | "top" | "vcenter" | "bottom"
 
 const ALIGN: { edge: Edge; label: string; icon: PhosphorIcon }[] = [
   { edge: "left", label: "Align left", icon: AlignLeftSimpleIcon },
-  { edge: "hcenter", label: "Align horizontal centres", icon: AlignCenterVerticalSimpleIcon },
+  { edge: "hcenter", label: "Align horizontal centres", icon: AlignCenterHorizontalSimpleIcon },
   { edge: "right", label: "Align right", icon: AlignRightSimpleIcon },
   { edge: "top", label: "Align top", icon: AlignTopSimpleIcon },
-  { edge: "vcenter", label: "Align vertical centres", icon: AlignCenterHorizontalSimpleIcon },
+  { edge: "vcenter", label: "Align vertical centres", icon: AlignCenterVerticalSimpleIcon },
   { edge: "bottom", label: "Align bottom", icon: AlignBottomSimpleIcon },
 ]
 

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -143,10 +143,10 @@ export function CanvasContextMenu() {
         ? ([
             { separator: true },
             { label: "Align left", icon: AlignLeftSimpleIcon, run: () => st().alignSelected("left") },
-            { label: "Align centres", icon: AlignCenterVerticalSimpleIcon, run: () => st().alignSelected("hcenter") },
+            { label: "Align centres", icon: AlignCenterHorizontalSimpleIcon, run: () => st().alignSelected("hcenter") },
             { label: "Align right", icon: AlignRightSimpleIcon, run: () => st().alignSelected("right") },
             { label: "Align top", icon: AlignTopSimpleIcon, run: () => st().alignSelected("top") },
-            { label: "Align middles", icon: AlignCenterHorizontalSimpleIcon, run: () => st().alignSelected("vcenter") },
+            { label: "Align middles", icon: AlignCenterVerticalSimpleIcon, run: () => st().alignSelected("vcenter") },
             { label: "Align bottom", icon: AlignBottomSimpleIcon, run: () => st().alignSelected("bottom") },
           ] as Entry[])
         : []),


### PR DESCRIPTION
The two centring buttons were wearing each other's icons.

`hcenter` moves shapes along **x** — its glyph should be the one with the *vertical* guide line (`AlignCenterHorizontalSimple`: wide box, vertical axis through it). `vcenter` moves along **y** and wants the *horizontal* guide (`AlignCenterVerticalSimple`). They were assigned the other way round.

Fixed in two places that share the mapping:
- `components/chrome/align-row.tsx` — the inspector's align cluster
- `components/chrome/context-menu.tsx` — "Align centres" / "Align middles"

The four edge icons (left/right/top/bottom) and both distribute icons were already correct.

Verified in the running app: drew a rect and an ellipse, selected both, and the second button — now showing the vertical-guide glyph — put them on a shared vertical axis. `pnpm lint` clean, `pnpm test` passes (144 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)