### PR TITLE
Crop a picture: eight handles, a sliding mat, nothing thrown away

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -18,8 +18,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useSquig } from "@/lib/store"
-import type { SquigNode, TextNode } from "@/lib/types"
+import type { ImageNode, SquigNode, TextNode } from "@/lib/types"
 import { screenToWorld } from "@/lib/types"
+import { clampWindow, cropAnchor, cropPatch, imageSheet, panSheet } from "@/lib/canvas/crop"
 import { autoSizeTextBox, setTextWidth } from "@/lib/canvas/text-reflow"
 import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type SnapRect } from "@/lib/canvas/snap-engine"
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
@@ -30,7 +31,7 @@ import { useClipboard } from "@/lib/canvas/use-clipboard"
 import { editTarget, hasEditableText } from "@/lib/canvas/edit-target"
 import { textBlockHeight } from "@/lib/sketch/text-layout"
 import { unionBounds, type Bounds } from "@/lib/selection"
-import { NodeSketch, SketchPrims } from "./sketch"
+import { NodeSketch, SketchPrims, imagePlacement, mirrorBox } from "./sketch"
 import { getDef, renderComponent } from "@/lib/library/registry"
 import { exportDoc } from "@/lib/file-io"
 import { copyAsPngWithNotice } from "@/lib/export-image"
@@ -140,6 +141,45 @@ type Gesture =
       origBounds: Bounds
       dirty: boolean
     }
+  | {
+      kind: "crop"
+      /** a handle moves the window; "pan" slides the picture under it */
+      handle: Handle | "pan"
+      wx: number
+      wy: number
+      sx: number
+      sy: number
+      pointerId: number
+      exceeded: boolean
+      id: string
+      /** the box at gesture start */
+      origWin: Bounds
+      /** where the whole picture lay at gesture start — see lib/canvas/crop */
+      origSheet: Bounds
+      dirty: boolean
+    }
+
+const inRect = (b: Bounds, x: number, y: number) => x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h
+
+/**
+ * The picture the crop mode is on, or null.
+ *
+ * Crop mode runs on one picture and only while that picture is the entire
+ * selection, so reaching for anything else is what ends it. Deriving that here
+ * rather than trusting the flag alone means no code path that changes the
+ * selection — ⌘A, Tab, invert, select-same-kind, a marquee — has to remember
+ * to turn the mode off, and none of them can leave a crop window floating over
+ * a set of nodes it doesn't belong to.
+ */
+function croppingImage(
+  nodes: Record<string, SquigNode>,
+  selection: string[],
+  croppingId: string | null
+): ImageNode | null {
+  if (!croppingId || selection.length !== 1 || selection[0] !== croppingId) return null
+  const n = nodes[croppingId]
+  return n?.type === "image" ? n : null
+}
 
 const canAutoPan = (g: Gesture | null) =>
   !!g && (g.kind === "marquee" || g.kind === "move" || g.kind === "resize" || g.kind === "create")
@@ -181,6 +221,7 @@ export function Canvas() {
   const placing = useSquig((s) => s.placing)
   const placingDrag = useSquig((s) => s.placingDrag)
   const editingId = useSquig((s) => s.editingId)
+  const croppingId = useSquig((s) => s.croppingId)
 
   // where the words being edited actually sit — the editor stands there, and
   // the renderer leaves that one run out so they don't print on top of it
@@ -492,6 +533,34 @@ export function Canvas() {
         return
       }
 
+      if (g.kind === "crop") {
+        if (!g.dirty) {
+          if (!g.exceeded) return
+          s.checkpoint()
+          g.dirty = true
+        }
+        const dx = wx - g.wx
+        const dy = wy - g.wy
+
+        // Sliding the picture: the window is pinned and the sheet moves under
+        // it, stopping when the picture's own edge would come inside the box.
+        if (g.handle === "pan") {
+          s.updateNodes({ [g.id]: cropPatch(g.origWin, panSheet(g.origSheet, g.origWin, dx, dy)) as Partial<SquigNode> })
+          return
+        }
+
+        // Dragging a handle: the sheet is pinned and the window moves over it,
+        // so the pixels you're keeping hold still at the size they already are
+        // — the mat slides, the photo doesn't. No snapping to other nodes here:
+        // the only edges that mean anything are the picture's own, and those
+        // are the clamp.
+        const aspect = mods.shift
+        const raw = resizeBounds(g.origWin, g.handle, dx, dy, { aspect, fromCenter: mods.alt })
+        const win = clampWindow(raw, g.origSheet, aspect ? cropAnchor(g.handle, g.origWin, mods.alt) : undefined)
+        s.updateNodes({ [g.id]: cropPatch(win, g.origSheet) as Partial<SquigNode> })
+        return
+      }
+
       if (g.kind === "draw") {
         g.points.push([wx, wy])
         setLivePoints([...g.points])
@@ -766,7 +835,8 @@ export function Canvas() {
 
     if (g.kind === "marquee") {
       s.setSelection(g.base)
-    } else if ((g.kind === "move" || g.kind === "resize") && g.dirty) {
+    } else if ((g.kind === "move" || g.kind === "resize" || g.kind === "crop") && g.dirty) {
+      // Escape undoes this drag, not the whole crop — you stay in the mode
       s.revertToCheckpoint()
     } else if (g.kind === "create") {
       if (g.id) s.revertToCheckpoint()
@@ -916,6 +986,37 @@ export function Canvas() {
     [st, beginGesture, toWorld, resetTextWidth]
   )
 
+  /** A press on one of the eight crop handles. */
+  const startCrop = useCallback(
+    (handle: Handle, e: React.PointerEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      const s = st()
+      const n = croppingImage(s.nodes, s.selection, s.croppingId)
+      if (!n) return
+      modsRef.current = readMods(e)
+      const [wx, wy] = toWorld(e)
+      beginGesture(
+        {
+          kind: "crop",
+          handle,
+          wx,
+          wy,
+          sx: e.clientX,
+          sy: e.clientY,
+          pointerId: e.pointerId,
+          exceeded: false,
+          id: n.id,
+          origWin: { x: n.x, y: n.y, w: n.w, h: n.h },
+          origSheet: imageSheet(n),
+          dirty: false,
+        },
+        e
+      )
+    },
+    [st, beginGesture, toWorld]
+  )
+
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
       // secondary buttons and stray extra touches never start a gesture
@@ -944,6 +1045,34 @@ export function Canvas() {
         return
       }
       if (e.button !== 0) return
+
+      // -- crop mode --------------------------------------------------------
+      // While it's on it owns the canvas: the eight handles are their own
+      // targets (startCrop), a press anywhere over the picture slides it, and
+      // a press off the picture is how you leave.
+      if (s.croppingId) {
+        const n = croppingImage(s.nodes, s.selection, s.croppingId)
+        if (n && inRect(imageSheet(n), wx, wy)) {
+          beginGesture(
+            {
+              kind: "crop",
+              ...common,
+              wx,
+              wy,
+              id: n.id,
+              handle: "pan",
+              origWin: { x: n.x, y: n.y, w: n.w, h: n.h },
+              origSheet: imageSheet(n),
+              dirty: false,
+            },
+            e
+          )
+          return
+        }
+        // the same bargain the text editor strikes: the click that dismisses
+        // the mode also lands where it was aimed, instead of costing two
+        s.setCropping(null)
+      }
 
       // placing a component from the library
       if (s.placing) {
@@ -1080,7 +1209,10 @@ export function Canvas() {
       }
       // double-clicking inside a multi-selection narrows to what you clicked
       if (s.selection.length !== 1 || s.selection[0] !== hitId) s.setSelection([hitId])
-      if (hasEditableText(n)) s.setEditing(hitId)
+      // a picture has no words to step into, so the same press steps into its
+      // crop instead — the one edit a picture has
+      if (n.type === "image") s.setCropping(hitId)
+      else if (hasEditableText(n)) s.setEditing(hitId)
     },
     [st, pick, toWorld]
   )
@@ -1402,6 +1534,8 @@ export function Canvas() {
           if (s.shortcutsOpen) s.setShortcutsOpen(false)
           else if (s.linkOpen) s.setLinkOpen(false)
           else if (s.editingId) s.setEditing(null)
+          // leaving keeps the crop, the way leaving an edit keeps the words
+          else if (croppingImage(s.nodes, s.selection, s.croppingId)) s.setCropping(null)
           else if (s.contextMenu) s.setContextMenu(null)
           else if (s.placing) s.setPlacing(null)
           else if (s.panel) s.setPanel(null)
@@ -1415,9 +1549,22 @@ export function Canvas() {
           // Return steps into the words of whatever is selected — the same
           // edit a double-click opens, without having to aim at the glyphs.
           // Only on a lone node: with several selected there's no "the" text.
-          if (e.shiftKey || s.selection.length !== 1) break
+          if (e.shiftKey) break
+          // in crop mode Return is the commit, so it steps back out again
+          if (croppingImage(s.nodes, s.selection, s.croppingId)) {
+            e.preventDefault()
+            s.setCropping(null)
+            break
+          }
+          if (s.selection.length !== 1) break
           const n = s.nodes[s.selection[0]]
-          if (!n || !hasEditableText(n)) break
+          if (!n) break
+          if (n.type === "image") {
+            e.preventDefault()
+            s.setCropping(n.id)
+            break
+          }
+          if (!hasEditableText(n)) break
           e.preventDefault()
           s.setEditing(n.id)
           break
@@ -1498,7 +1645,11 @@ export function Canvas() {
     [selection, nodes]
   )
   const placingDef = placing ? getDef(placing) : null
-  const hoverNode = hover && !selection.includes(hover.id) ? nodes[hover.id] : null
+  // the picture being cropped comes out of the document order and is redrawn
+  // on top, under its own dimmed ghost — the mode is a spotlight, and a node
+  // that happened to be stacked above it shouldn't sit in the middle of it
+  const cropNode = croppingImage(nodes, selection, croppingId)
+  const hoverNode = hover && !selection.includes(hover.id) && !cropNode ? nodes[hover.id] : null
 
   // a soft hover keeps the default cursor: a click there selects, but a drag
   // marquees, and a move cursor would promise a drag this press won't do
@@ -1508,9 +1659,15 @@ export function Canvas() {
       ? "crosshair"
       : gestureKind === "move"
         ? (altHeld ? "copy" : "move")
-        : hover && !hover.soft && tool === "select"
-          ? (altHeld ? "copy" : "move")
-          : "default"
+        // a crop drag captures the pointer, so the cursor comes from here once
+        // it leaves the handle it started on
+        : gestureKind === "crop"
+          ? "move"
+          : cropNode
+            ? "default"
+            : hover && !hover.soft && tool === "select"
+              ? (altHeld ? "copy" : "move")
+              : "default"
 
   return (
     <div
@@ -1534,13 +1691,14 @@ export function Canvas() {
         <g transform={`translate(${v.x} ${v.y}) scale(${v.zoom})`}>
           {order.map((id) => {
             const n = nodes[id]
-            if (!n) return null
+            if (!n || id === cropNode?.id) return null
             return (
               <g key={id} transform={`translate(${n.x} ${n.y})`}>
                 <NodeSketch node={n} hiddenText={id === editingId ? editing?.hidden : undefined} />
               </g>
             )
           })}
+          {cropNode && <CropStage node={cropNode} />}
           {livePoints && livePoints.length > 1 && (
             <polyline
               points={livePoints.map((p) => p.join(",")).join(" ")}
@@ -1579,14 +1737,20 @@ export function Canvas() {
         />
       )}
 
-      {/* selection rings + handles (screen space) */}
-      <SelectionOverlay
-        selectedNodes={selectedNodes}
-        viewport={v}
-        onStartResize={startResize}
-        editing={!!editingId}
-        gestureKind={gestureKind}
-      />
+      {/* selection rings + handles (screen space) — the crop window replaces
+          them outright while it's up: two boxes with two meanings, one of them
+          stale, is the worst of both */}
+      {cropNode ? (
+        <CropOverlay node={cropNode} viewport={v} onStartCrop={startCrop} />
+      ) : (
+        <SelectionOverlay
+          selectedNodes={selectedNodes}
+          viewport={v}
+          onStartResize={startResize}
+          editing={!!editingId}
+          gestureKind={gestureKind}
+        />
+      )}
 
       {/* smart guides */}
       {guides.length > 0 && (
@@ -1620,11 +1784,137 @@ export function Canvas() {
       {editingNode && editing && <TextEditOverlay key={editingNode.id} node={editingNode} target={editing} />}
 
       {/* context row */}
-      <ContextRow selectedNodes={selectedNodes} viewport={v} busy={!!gestureKind} />
+      <ContextRow selectedNodes={selectedNodes} viewport={v} busy={!!gestureKind || !!cropNode} />
 
       {/* empty-canvas nudge */}
       {order.length === 0 && !placing && <EmptyCanvas />}
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+/** How much of the picture still shows where the crop has cut it away. */
+const GHOST_OPACITY = 0.28
+
+/**
+ * A picture in crop mode: the whole of it, faint, with the part that survives
+ * the crop printed over the top at full strength.
+ *
+ * The ghost is the node's own render minus the clip — same placement, same
+ * mirror, one `<svg>` fewer — so the two can't drift apart no matter what the
+ * crop or the flips are doing.
+ */
+function CropStage({ node }: { node: ImageNode }) {
+  const p = imagePlacement(node)
+  return (
+    <g transform={`translate(${node.x} ${node.y})`}>
+      <g transform={mirrorBox(node.w, node.h, node.flipX, node.flipY)} opacity={GHOST_OPACITY}>
+        <image href={node.src} x={p.x} y={p.y} width={p.w} height={p.h} preserveAspectRatio="none" />
+      </g>
+      <NodeSketch node={node} />
+    </g>
+  )
+}
+
+/**
+ * The crop window — eight handles on the box, over a picture that keeps going
+ * past them.
+ *
+ * It stands in for the selection ring while the mode is on, so it draws the
+ * same white dot on the same blue, at the same sizes: this is still "the thing
+ * you have hold of", just a different thing. The rest of the picture gets a
+ * dashed outline, which is the only honest way to say how much room a drag
+ * still has left.
+ */
+function CropOverlay({
+  node,
+  viewport,
+  onStartCrop,
+}: {
+  node: ImageNode
+  viewport: { x: number; y: number; zoom: number }
+  onStartCrop: (h: Handle, e: React.PointerEvent) => void
+}) {
+  const v = viewport
+  const sheet = imageSheet(node)
+  const left = node.x * v.zoom + v.x
+  const top = node.y * v.zoom + v.y
+  const w = node.w * v.zoom
+  const h = node.h * v.zoom
+
+  const showWide = w >= HANDLE_ROOM
+  const showTall = h >= HANDLE_ROOM
+  const visible = (hd: Handle) => (hd === "n" || hd === "s" ? showWide : hd === "e" || hd === "w" ? showTall : true)
+  const padX = grabPad(w, showWide)
+  const padY = grabPad(h, showTall)
+
+  return (
+    <>
+      {/* the whole picture: how far a drag can still go, and the surface that
+          slides under the window — it takes the press and lets it bubble to
+          the canvas, which is where the pan gesture actually starts */}
+      <div
+        className="pointer-events-auto absolute"
+        style={{
+          left: sheet.x * v.zoom + v.x,
+          top: sheet.y * v.zoom + v.y,
+          width: sheet.w * v.zoom,
+          height: sheet.h * v.zoom,
+          border: "1px dashed color-mix(in srgb, var(--sq-select) 45%, transparent)",
+          cursor: "move",
+        }}
+      />
+
+      <div className="pointer-events-none absolute" style={{ left, top, width: w, height: h }}>
+        <div className="absolute inset-0" style={{ border: "2px solid var(--sq-select)" }} />
+        {/* thirds — the one guide a crop is actually composed against */}
+        {showWide && showTall && (
+          <>
+            {[1, 2].map((i) => (
+              <div
+                key={`v${i}`}
+                className="absolute top-0 bottom-0"
+                style={{ left: `${(i * 100) / 3}%`, borderLeft: "1px solid color-mix(in srgb, var(--sq-select) 30%, transparent)" }}
+              />
+            ))}
+            {[1, 2].map((i) => (
+              <div
+                key={`h${i}`}
+                className="absolute right-0 left-0"
+                style={{ top: `${(i * 100) / 3}%`, borderTop: "1px solid color-mix(in srgb, var(--sq-select) 30%, transparent)" }}
+              />
+            ))}
+          </>
+        )}
+        {/* corners last, for the same reason SelectionOverlay does it */}
+        {HANDLES.filter(visible)
+          .slice()
+          .sort((a, b) => a.length - b.length)
+          .map((hd) => {
+            const box = handleHitBox(hd, w, h, padX, padY)
+            return (
+              <div
+                key={hd}
+                className="pointer-events-auto absolute"
+                style={{ left: box.left, top: box.top, width: box.width, height: box.height, cursor: HANDLE_CURSORS[hd] }}
+                onPointerDown={(e) => onStartCrop(hd, e)}
+              >
+                <div
+                  className="pointer-events-none absolute rounded-[3px] bg-white"
+                  style={{
+                    left: box.dotLeft,
+                    top: box.dotTop,
+                    width: HANDLE_DOT,
+                    height: HANDLE_DOT,
+                    border: "2px solid var(--sq-select)",
+                  }}
+                />
+              </div>
+            )
+          })}
+      </div>
+    </>
   )
 }
 

--- a/components/canvas/sketch.tsx
+++ b/components/canvas/sketch.tsx
@@ -16,7 +16,7 @@ import type { RoughGenerator } from "roughjs/bin/generator"
 import { HAND, INK, SHADE, type InkColor, type Prim, type PrimOpts } from "@/lib/sketch/kit"
 import { useIconCatalogVersion } from "@/lib/sketch/use-icon-catalog"
 import { nodePrims } from "@/lib/sketch/node-prims"
-import type { SquigNode } from "@/lib/types"
+import { cropOf, type ImageNode, type SquigNode } from "@/lib/types"
 
 const gen: RoughGenerator = rough.generator()
 
@@ -348,24 +348,60 @@ export const NodeSketch = memo(function NodeSketch({
 
   return (
     <>
-      {node.type === "image" && (
-        <image
-          href={node.src}
-          x={0}
-          y={0}
-          width={node.w}
-          height={node.h}
-          // the box is the truth about how big this is — a resize that squashes
-          // it should squash the picture, the way dragging any other node does
-          preserveAspectRatio="none"
-          // a flip is a property of the node, so the pixels turn with the frame
-          transform={mirrorBox(node.w, node.h, node.flipX, node.flipY)}
-        />
-      )}
+      {node.type === "image" && <ImagePixels node={node} />}
       <SketchPrims prims={prims} seed={node.seed} hiddenText={hiddenText} />
     </>
   )
 })
+
+/**
+ * The picture itself, cropped to its box.
+ *
+ * A nested `<svg>` is the clip: it opens a viewport of exactly the node's box
+ * and hides everything the inner `<image>` puts outside it, with no `clipPath`
+ * and so no document-unique id to mint, collide, or forget to update when a
+ * node is duplicated. The picture is laid out larger than the box and slid
+ * under it — see `imagePlacement`.
+ */
+function ImagePixels({ node }: { node: ImageNode }) {
+  const p = imagePlacement(node)
+  return (
+    <svg x={0} y={0} width={node.w} height={node.h} overflow="hidden">
+      {/* a flip is a property of the node, so the pixels turn with the frame —
+          about the box, which means what you see mirrors, not what's hidden */}
+      <g transform={mirrorBox(node.w, node.h, node.flipX, node.flipY)}>
+        <image
+          href={node.src}
+          x={p.x}
+          y={p.y}
+          width={p.w}
+          height={p.h}
+          // the box is the truth about how big this is — a resize that squashes
+          // it should squash the picture, the way dragging any other node does
+          preserveAspectRatio="none"
+        />
+      </g>
+    </svg>
+  )
+}
+
+/**
+ * Where the whole picture goes, in the node's own coordinates, so that the
+ * cropped part of it lands exactly on the box.
+ *
+ * With no crop that's (0, 0, w, h) — the picture fills its box, which is what
+ * every picture did before crops existed. With one it's bigger and offset up
+ * and left, and the nested `<svg>` above trims the overhang.
+ *
+ * Exported because the PNG export has to place the same pixels the same way,
+ * into a file rather than onto the canvas.
+ */
+export function imagePlacement(node: ImageNode): { x: number; y: number; w: number; h: number } {
+  const c = cropOf(node)
+  const w = node.w / c.w
+  const h = node.h / c.h
+  return { x: -c.x * w, y: -c.y * h, w, h }
+}
 
 /**
  * Mirror a picture about its own box — the same flip mirrorPrims gives the

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -18,7 +18,10 @@ import { exportDoc, importDoc } from "@/lib/file-io"
 import { copyAsPngWithNotice } from "@/lib/export-image"
 import { relativeTime } from "@/lib/files"
 import { kbd } from "@/lib/shortcuts"
+import { isCropped } from "@/lib/canvas/crop"
 import {
+  ArrowCounterClockwiseIcon,
+  CropIcon,
   MagnifyingGlassIcon,
   CursorIcon,
   SquareIcon,
@@ -120,6 +123,12 @@ function Palette() {
   const hasComponent = selection.some((id) => nodes[id]?.type === "component")
   const hasText = selection.some((id) => nodes[id]?.type === "text")
   const hasGroup = selection.some((id) => nodes[id]?.groupIds?.length)
+  // cropping is a mode you step into, so it needs exactly one picture to step into
+  const loneImage = selection.length === 1 && nodes[selection[0]]?.type === "image" ? selection[0] : null
+  const hasCrop = selection.some((id) => {
+    const n = nodes[id]
+    return n?.type === "image" && isCropped(n)
+  })
 
   const actions = useMemo<Action[]>(
     () => [
@@ -155,6 +164,8 @@ function Palette() {
       { id: "back", label: "Send to back", hint: kbd("far+["), section: "Arrange", icon: StackIcon, disabled: !hasSel, run: () => st().sendToBack(st().selection) },
       { id: "flip-h", label: "Flip horizontal", hint: kbd("shift+h"), section: "Arrange", keywords: "mirror reverse", icon: FlipHorizontalIcon, disabled: !hasSel, run: () => st().flipSelected("x") },
       { id: "flip-v", label: "Flip vertical", hint: kbd("shift+v"), section: "Arrange", keywords: "mirror reverse", icon: FlipVerticalIcon, disabled: !hasSel, run: () => st().flipSelected("y") },
+      { id: "crop", label: "Crop image", hint: kbd("enter"), section: "Arrange", keywords: "photo picture trim frame mask", icon: CropIcon, disabled: !loneImage, run: () => loneImage && st().setCropping(loneImage) },
+      { id: "uncrop", label: "Reset crop", section: "Arrange", keywords: "photo picture uncrop restore full", icon: ArrowCounterClockwiseIcon, disabled: !hasCrop, run: () => st().resetCrop() },
       { id: "align-l", label: "Align left", section: "Arrange", icon: CornersOutIcon, disabled: selection.length < 2, run: () => st().alignSelected("left") },
       { id: "align-hc", label: "Align centres horizontally", section: "Arrange", icon: CornersOutIcon, disabled: selection.length < 2, run: () => st().alignSelected("hcenter") },
       { id: "align-r", label: "Align right", section: "Arrange", icon: CornersOutIcon, disabled: selection.length < 2, run: () => st().alignSelected("right") },
@@ -195,7 +206,7 @@ function Palette() {
           run: () => st().openFile(f.id),
         })),
     ],
-    [st, hasSel, hasComponent, hasText, hasGroup, selection.length, files, docId]
+    [st, hasSel, hasComponent, hasText, hasGroup, loneImage, hasCrop, selection.length, files, docId]
   )
 
   const rows = useMemo<Row[]>(() => {

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -9,6 +9,7 @@ import { copySelection, pasteFromSystem } from "@/lib/clipboard"
 import { useSquig } from "@/lib/store"
 import { screenToWorld } from "@/lib/types"
 import { hasEditableText } from "@/lib/canvas/edit-target"
+import { isCropped } from "@/lib/canvas/crop"
 import { kbd } from "@/lib/shortcuts"
 import { copyAsPngWithNotice } from "@/lib/export-image"
 import {
@@ -31,6 +32,7 @@ import {
   ClipboardTextIcon,
   CopyIcon,
   CopySimpleIcon,
+  CropIcon,
   EyeSlashIcon,
   FlipHorizontalIcon,
   FlipVerticalIcon,
@@ -130,6 +132,14 @@ export function CanvasContextMenu() {
         : []),
       ...(one && hasEditableText(one)
         ? [{ label: "Edit text", hint: kbd("enter"), icon: TextTIcon, run: () => st().setEditing(one.id) } as Entry]
+        : []),
+      ...(one?.type === "image"
+        ? ([
+            { label: "Crop image", hint: kbd("enter"), icon: CropIcon, run: () => st().setCropping(one.id) },
+            ...(isCropped(one)
+              ? [{ label: "Reset crop", icon: ArrowCounterClockwiseIcon, run: () => st().resetCrop([one.id]) }]
+              : []),
+          ] as Entry[])
         : []),
       { separator: true },
       { label: "Bring to front", hint: kbd("far+]"), icon: ArrowLineUpIcon, run: () => st().bringToFront(targets) },

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -15,8 +15,9 @@
 // ---------------------------------------------------------------------------
 
 import { useSquig } from "@/lib/store"
-import type { ArrowNode, ComponentNode, FillTone, InkTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
+import type { ArrowNode, ComponentNode, FillTone, ImageNode, InkTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
 import { normalizeFill, normalizeInk } from "@/lib/types"
+import { isCropped } from "@/lib/canvas/crop"
 import { getDef } from "@/lib/library/registry"
 import { selectionSummary, shared, sharedControls, sharedNumber, unionBounds } from "@/lib/selection"
 import { scaleNodes, MIN_SIZE } from "@/lib/canvas/transform"
@@ -31,7 +32,9 @@ import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
+  ArrowCounterClockwiseIcon,
   ArrowsOutIcon,
+  CropIcon,
   FlipHorizontalIcon,
   FlipVerticalIcon,
   LinkBreakIcon,
@@ -312,6 +315,7 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
   const shapes = selected.filter((n): n is ShapeNode => n.type === "shape")
   const arrows = selected.filter((n): n is ArrowNode => n.type === "arrow")
   const texts = selected.filter((n): n is TextNode => n.type === "text")
+  const images = selected.filter((n): n is ImageNode => n.type === "image")
   // components draw their own strokes from authored prims — a pen weight set
   // here would have nothing to apply to without rewriting the whole library
   const outlined = selected.filter((n) => n.type === "shape" || n.type === "draw" || n.type === "arrow")
@@ -453,6 +457,38 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
               }
             />
           </Row>
+        </PanelSection>
+      )}
+
+      {/* --- contextual: picture ---------------------------------------- */}
+      {images.length > 0 && (
+        <PanelSection id="picture" title="Picture" count={partial(images.length)}>
+          {/* Crop is a mode, not a value, so the panel's job is only to say it
+              exists and let you back out of it — the window itself is dragged
+              on the canvas. Stepping in needs one picture; giving the pixels
+              back works on however many are selected. */}
+          <StackRow label="Crop">
+            <div className="flex gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={images.length !== 1 || images.length !== selected.length}
+                className="h-ctl flex-1 rounded-chrome-sm text-label"
+                onClick={() => st().setCropping(images[0].id)}
+              >
+                <CropIcon className="size-3" /> Crop
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!images.some(isCropped)}
+                className="h-ctl flex-1 rounded-chrome-sm text-label"
+                onClick={() => st().resetCrop(images.map((n) => n.id))}
+              >
+                <ArrowCounterClockwiseIcon className="size-3" /> Reset
+              </Button>
+            </div>
+          </StackRow>
         </PanelSection>
       )}
 

--- a/lib/canvas/crop.ts
+++ b/lib/canvas/crop.ts
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------
+// Crop maths — pure.
+//
+// One picture, two rectangles. The *window* is the node's own box: the part of
+// the picture that prints. The *sheet* is where the whole picture would lie in
+// world space if none of it were hidden — larger than the window whenever
+// there's a crop, exactly the window when there isn't.
+//
+// Every crop gesture holds one of the two still and moves the other:
+//
+//   · dragging a handle moves the window's edges over a pinned sheet, which is
+//     what makes cropping feel like sliding a mat over a photo rather than
+//     resizing the photo — the pixels you keep don't move or change size
+//   · dragging inside slides the sheet under a pinned window
+//
+// Either way the answer is the same arithmetic at the end: where the window
+// now sits on the sheet, written down as a 0..1 crop. The node's `crop` is
+// never accumulated from deltas, so a drag out and back is lossless.
+// ---------------------------------------------------------------------------
+
+import type { Bounds } from "../selection"
+import { cropOf, normalizeCrop, type ImageCrop, type ImageNode } from "../types"
+import { MIN_SIZE, type Handle } from "./transform"
+
+const EPS = 1e-6
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi)
+
+/**
+ * Where the whole picture lies in world space — the sheet the window sits on.
+ *
+ * An uncropped picture returns its own box, so every caller below works the
+ * same on a picture that has never been cropped as on one that has.
+ */
+export function imageSheet(n: ImageNode): Bounds {
+  const c = cropOf(n)
+  const w = n.w / c.w
+  const h = n.h / c.h
+  return { x: n.x - c.x * w, y: n.y - c.y * h, w, h }
+}
+
+/** Where a window sits on a sheet, as the 0..1 crop the node stores. */
+export function windowToCrop(win: Bounds, sheet: Bounds): ImageCrop {
+  const sw = sheet.w > EPS ? sheet.w : 1
+  const sh = sheet.h > EPS ? sheet.h : 1
+  return {
+    x: (win.x - sheet.x) / sw,
+    y: (win.y - sheet.y) / sh,
+    w: win.w / sw,
+    h: win.h / sh,
+  }
+}
+
+/**
+ * The patch a gesture writes: the box it landed on, and the crop that box
+ * means. `crop` is undefined when the window has been opened back out to the
+ * whole sheet — see normalizeCrop on why that isn't {0,0,1,1}.
+ */
+export function cropPatch(win: Bounds, sheet: Bounds): Partial<ImageNode> {
+  return { x: win.x, y: win.y, w: win.w, h: win.h, crop: normalizeCrop(windowToCrop(win, sheet)) }
+}
+
+/**
+ * The point a resize holds still — the one the window grows and shrinks about.
+ *
+ * This mirrors what `resizeBounds` pins, because the clamp below scales the
+ * box about this point and has to leave the dragged edge's opposite exactly
+ * where resizeBounds put it. A side handle under aspect lock grows about the
+ * centre on the perpendicular axis, so that axis anchors at the centre.
+ */
+export function cropAnchor(handle: Handle, orig: Bounds, fromCenter: boolean): [number, number] {
+  const cx = orig.x + orig.w / 2
+  const cy = orig.y + orig.h / 2
+  if (fromCenter) return [cx, cy]
+  const x = handle.includes("w") ? orig.x + orig.w : handle.includes("e") ? orig.x : cx
+  const y = handle.includes("n") ? orig.y + orig.h : handle.includes("s") ? orig.y : cy
+  return [x, y]
+}
+
+/** One axis, clamped into [lo, hi] and never squeezed below MIN_SIZE. */
+function clampSpan(a: number, b: number, lo: number, hi: number): [number, number] {
+  let start = Math.max(a, lo)
+  let end = Math.min(b, hi)
+  if (end - start < MIN_SIZE) {
+    // grow back out of whichever end has room; a sheet narrower than MIN_SIZE
+    // can't happen — the window it came from was at least that wide
+    if (start <= lo) end = Math.min(hi, start + MIN_SIZE)
+    else start = Math.max(lo, end - MIN_SIZE)
+  }
+  return [start, end]
+}
+
+/**
+ * Pull a window back inside its sheet.
+ *
+ * Without `anchor` each edge is clamped where it stands, which is what a free
+ * drag wants: run past the top of the picture and the top edge stops, the
+ * others carry on. With `anchor` — Shift, aspect locked — clamping one edge
+ * would quietly break the ratio the user is holding, so the whole box scales
+ * down about the point the gesture is pinning instead. It shrinks to the
+ * biggest box of that ratio that still fits, and keeps the pinned edge.
+ */
+export function clampWindow(box: Bounds, sheet: Bounds, anchor?: [number, number]): Bounds {
+  const left = sheet.x
+  const right = sheet.x + sheet.w
+  const top = sheet.y
+  const bottom = sheet.y + sheet.h
+
+  if (!anchor) {
+    const [x0, x1] = clampSpan(box.x, box.x + box.w, left, right)
+    const [y0, y1] = clampSpan(box.y, box.y + box.h, top, bottom)
+    return { x: x0, y: y0, w: x1 - x0, h: y1 - y0 }
+  }
+
+  const [ax, ay] = anchor
+  let s = 1
+  // reach: how far the box wants to go from the anchor on this side, against
+  // how far it may. Both are measured outward from the anchor, so both are
+  // non-negative for an anchor inside the sheet — which it always is, having
+  // come from a window that was already there.
+  const fit = (want: number, room: number) => {
+    if (want > EPS && room < want) s = Math.min(s, Math.max(0, room) / want)
+  }
+  fit(ax - box.x, ax - left)
+  fit(box.x + box.w - ax, right - ax)
+  fit(ay - box.y, ay - top)
+  fit(box.y + box.h - ay, bottom - ay)
+
+  if (s >= 1) return box
+  const scaled = {
+    x: ax - (ax - box.x) * s,
+    y: ay - (ay - box.y) * s,
+    w: box.w * s,
+    h: box.h * s,
+  }
+  // the ratio has already been honoured; a box scaled to nothing still has to
+  // be grabbable, so the floor wins over it at the very end
+  return clampWindow(scaled, sheet)
+}
+
+/**
+ * Slide the picture under a fixed window.
+ *
+ * The clamp is what stops the drag at the edge of the picture: the sheet may
+ * not be pulled so far that bare canvas shows inside the window.
+ */
+export function panSheet(sheet: Bounds, win: Bounds, dx: number, dy: number): Bounds {
+  return {
+    ...sheet,
+    x: clamp(sheet.x + dx, win.x + win.w - sheet.w, win.x),
+    y: clamp(sheet.y + dy, win.y + win.h - sheet.h, win.y),
+  }
+}
+
+/** Is any of this picture hidden? */
+export function isCropped(n: ImageNode): boolean {
+  return n.crop !== undefined
+}
+
+/**
+ * Give the hidden pixels back, growing the box to the sheet the crop was cut
+ * from — the picture stays exactly the size it looks, and the parts that were
+ * outside the window reappear around it.
+ */
+export function uncropPatch(n: ImageNode): Partial<ImageNode> {
+  const sheet = imageSheet(n)
+  return { x: sheet.x, y: sheet.y, w: sheet.w, h: sheet.h, crop: undefined }
+}

--- a/lib/clipboard-payload.ts
+++ b/lib/clipboard-payload.ts
@@ -16,6 +16,7 @@
 // ---------------------------------------------------------------------------
 
 import type { SquigNode, TextNode } from "./types"
+import { normalizeCrop } from "./types"
 
 const PAYLOAD_VERSION = 1
 /** the attribute the HTML carrier hides the payload in */
@@ -131,6 +132,8 @@ export function validNode(v: unknown): SquigNode | null {
       // the only scheme this app ever writes, and the only one it will read:
       // a pasted document has no business pointing the canvas at a URL
       if (!str(n.src) || !/^data:image\//i.test(n.src)) return null
+      // four numbers that divide the box — one NaN renders at infinity
+      n.crop = normalizeCrop(n.crop)
       break
   }
 

--- a/lib/export-image.ts
+++ b/lib/export-image.ts
@@ -18,7 +18,7 @@
 // Miss either one and the PNG comes back black-on-nothing in Times New Roman.
 // ---------------------------------------------------------------------------
 
-import { mirrorBox, mirrorGlyphs, primsToPaths } from "@/components/canvas/sketch"
+import { imagePlacement, mirrorBox, mirrorGlyphs, primsToPaths } from "@/components/canvas/sketch"
 import { iconPathsReady, loadIconWeight, normalizeIconWeight } from "./sketch/icon-catalog"
 import { INK, resolveIconName } from "./sketch/kit"
 import { nodePrims } from "./sketch/node-prims"
@@ -87,9 +87,15 @@ function nodeMarkup(node: SquigNode, resolve: (paint: string) => string, font: s
   // rasterised — an external src would do neither.
   if (node.type === "image") {
     const mirror = mirrorBox(node.w, node.h, node.flipX, node.flipY)
+    const p = imagePlacement(node)
+    // the nested <svg> is the crop, exactly as the canvas draws it — a viewport
+    // the size of the box, trimming a picture laid out larger than it
     out.push(
-      `<image href="${esc(node.src)}" x="0" y="0" width="${node.w}" height="${node.h}"` +
-        ` preserveAspectRatio="none"${mirror ? ` transform="${esc(mirror)}"` : ""}/>`
+      `<svg x="0" y="0" width="${node.w}" height="${node.h}" overflow="hidden">` +
+        `<g${mirror ? ` transform="${esc(mirror)}"` : ""}>` +
+        `<image href="${esc(node.src)}" x="${p.x}" y="${p.y}" width="${p.w}" height="${p.h}"` +
+        ` preserveAspectRatio="none"/>` +
+        `</g></svg>`
     )
   }
 

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -136,6 +136,16 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
+    title: "Pictures",
+    rows: [
+      { keys: ["enter", "double-click"], label: "Crop a picture" },
+      { keys: ["drag"], label: "Slide the picture under the crop" },
+      { keys: ["shift+drag"], label: "Crop to the same shape" },
+      { keys: ["alt+drag"], label: "Crop both sides at once" },
+      { keys: ["enter", "esc"], label: "Done cropping" },
+    ],
+  },
+  {
     title: "View",
     rows: [
       { keys: ["mod+plus"], label: "Zoom in" },

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -2,8 +2,9 @@
 
 import { create } from "zustand"
 import { nanoid } from "nanoid"
-import type { ComponentNode, SquigNode, TextAlign, TextNode, Tool, Viewport, ShapeKind } from "./types"
-import { normalizeFill, screenToWorld, unionBox } from "./types"
+import type { ComponentNode, ImageNode, SquigNode, TextAlign, TextNode, Tool, Viewport, ShapeKind } from "./types"
+import { normalizeCrop, normalizeFill, screenToWorld, unionBox } from "./types"
+import { isCropped, uncropPatch } from "./canvas/crop"
 import { repeatStep, type DupTrail } from "./canvas/duplicate"
 import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
@@ -73,6 +74,8 @@ interface SquigState {
    *  rather than on the next click */
   placingDrag: boolean
   editingId: string | null
+  /** the picture whose crop window is being dragged — see lib/canvas/crop */
+  croppingId: string | null
   contextRow: boolean
   /* --- the look, kept flat so a control can subscribe to just its own knob.
      It belongs to the open document: every setter writes it back to the file,
@@ -116,6 +119,10 @@ interface SquigState {
   setPanel: (p: PanelKind) => void
   setPlacing: (kind: string | null, opts?: { drag?: boolean }) => void
   setEditing: (id: string | null) => void
+  /** step into (or out of) a picture's crop window */
+  setCropping: (id: string | null) => void
+  /** give a picture back every pixel it's hiding */
+  resetCrop: (ids?: string[]) => void
   setContextRow: (on: boolean) => void
   setTheme: (t: ThemeName) => void
   setFont: (f: FontMode) => void
@@ -246,7 +253,12 @@ function sanitize(
     if (node.type === "shape") node.fill = normalizeFill(node.fill)
     // an imported file is a stranger's document: a picture in it carries its
     // own pixels or it doesn't render at all — never a URL we'd go and fetch
-    if (node.type === "image" && !/^data:image\//i.test(node.src ?? "")) continue
+    if (node.type === "image") {
+      if (!/^data:image\//i.test(node.src ?? "")) continue
+      // a crop is four numbers that divide the box; one bad one would render
+      // the picture at infinity and take the file with it
+      node.crop = normalizeCrop(node.crop)
+    }
     clean[id] = node
   }
   const seen = new Set<string>()
@@ -412,6 +424,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   placing: null,
   placingDrag: false,
   editingId: null,
+  croppingId: null,
   contextRow: false,
   ...DEFAULT_LOOK,
   hydrated: false,
@@ -433,11 +446,39 @@ export const useSquig = create<SquigState>((set, get) => ({
     set({ fileName: n })
     scheduleSave(get)
   },
-  setTool: (t) => set({ tool: t, placing: null, placingDrag: false, panel: null }),
+  setTool: (t) => set({ tool: t, placing: null, placingDrag: false, panel: null, croppingId: null }),
   setShapeKind: (s) => set({ shapeKind: s }),
   setPanel: (p) => set((st) => ({ panel: st.panel === p ? null : p, placing: null, placingDrag: false })),
-  setPlacing: (kind, opts) => set({ placing: kind, placingDrag: kind !== null && opts?.drag === true }),
-  setEditing: (id) => set({ editingId: id }),
+  // reaching for something to place is a new intent, and the crop window would
+  // otherwise swallow the click that drops it
+  setPlacing: (kind, opts) =>
+    set({ placing: kind, placingDrag: kind !== null && opts?.drag === true, ...(kind ? { croppingId: null } : {}) }),
+  setEditing: (id) => set({ editingId: id, croppingId: id ? null : get().croppingId }),
+
+  setCropping: (id) => {
+    // only a picture has a crop window to step into, and only one at a time —
+    // the mode owns the whole selection while it's on, which is also how it
+    // ends: see croppingImage in components/canvas/canvas
+    if (!id) {
+      set({ croppingId: null })
+      return
+    }
+    if (get().nodes[id]?.type !== "image") return
+    set({ croppingId: id, editingId: null, selection: [id] })
+  },
+
+  resetCrop: (ids) => {
+    const s = get()
+    const targets = (ids ?? s.selection)
+      .map((id) => s.nodes[id])
+      .filter((n): n is ImageNode => n?.type === "image" && isCropped(n))
+    if (!targets.length) return
+    s.updateNodes(
+      Object.fromEntries(targets.map((n) => [n.id, uncropPatch(n) as Partial<SquigNode>])),
+      { checkpoint: true }
+    )
+  },
+
   setContextRow: (on) => {
     set({ contextRow: on })
     scheduleSave(get)
@@ -470,7 +511,11 @@ export const useSquig = create<SquigState>((set, get) => ({
       // bail when nothing actually changed, so a marquee crossing nothing new
       // doesn't re-render the canvas on every pointermove
       if (next.length === s.selection.length && next.every((id, i) => s.selection[i] === id)) return s
-      return { selection: next }
+      // the crop window belongs to one picture and to nothing else: reaching
+      // for anything at all — another node, a second one, empty canvas — is
+      // how you leave, and leaving keeps the crop you'd dragged so far
+      const cropping = s.croppingId && next.length === 1 && next[0] === s.croppingId ? s.croppingId : null
+      return { selection: next, croppingId: cropping }
     })
   },
   setCommandOpen: (open) =>
@@ -584,6 +629,7 @@ export const useSquig = create<SquigState>((set, get) => ({
         selection: s.selection.filter((i) => !ids.includes(i)),
         // editing a node that just went away would wedge the canvas
         editingId: s.editingId && ids.includes(s.editingId) ? null : s.editingId,
+        croppingId: s.croppingId && ids.includes(s.croppingId) ? null : s.croppingId,
       }
     })
     scheduleSave(get)
@@ -657,6 +703,9 @@ export const useSquig = create<SquigState>((set, get) => ({
         order: prev.order,
         selection: prev.selection.filter((id) => prev.nodes[id]),
         editingId: null,
+        // unlike the text editor, the crop overlay is a pure read of the node,
+        // so ⌘Z can walk back through a crop without leaving the mode
+        croppingId: s.croppingId && prev.nodes[s.croppingId] ? s.croppingId : null,
       }
     })
     scheduleSave(get)
@@ -675,6 +724,7 @@ export const useSquig = create<SquigState>((set, get) => ({
         order: next.order,
         selection: next.order.filter((id) => restored.includes(id)),
         editingId: null,
+        croppingId: s.croppingId && next.nodes[s.croppingId] ? s.croppingId : null,
       }
     })
     scheduleSave(get)
@@ -708,7 +758,7 @@ export const useSquig = create<SquigState>((set, get) => ({
 
   clearCanvas: () => {
     get().checkpoint()
-    set({ nodes: {}, order: [], selection: [], editingId: null })
+    set({ nodes: {}, order: [], selection: [], editingId: null, croppingId: null })
     scheduleSave(get)
   },
 
@@ -985,7 +1035,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   },
 
   selectAll: () => set((s) => ({ selection: [...s.order] })),
-  selectNone: () => set({ selection: [] }),
+  selectNone: () => set({ selection: [], croppingId: null }),
 
   invertSelection: () => {
     set((s) => ({ selection: s.order.filter((id) => !s.selection.includes(id)) }))
@@ -1058,6 +1108,7 @@ export const useSquig = create<SquigState>((set, get) => ({
       nodes: {},
       order: [],
       selection: [],
+      croppingId: null,
       viewport: { x: 0, y: 0, zoom: 1 },
       renamingFile: false,
       linkOpen: false,
@@ -1083,6 +1134,7 @@ export const useSquig = create<SquigState>((set, get) => ({
       nodes: clean.nodes,
       order: clean.order,
       selection: [],
+      croppingId: null,
       viewport: { x: 0, y: 0, zoom: 1 },
       renamingFile: false,
       linkOpen: false,
@@ -1113,6 +1165,7 @@ export const useSquig = create<SquigState>((set, get) => ({
       nodes: {},
       order: [],
       selection: [],
+      croppingId: null,
       past: [],
       future: [],
     })
@@ -1146,6 +1199,7 @@ export const useSquig = create<SquigState>((set, get) => ({
         nodes: clean.nodes,
         order: clean.order,
         selection: [],
+        croppingId: null,
         renamingFile: false,
         linkOpen: false,
         past: [],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -153,6 +153,61 @@ export interface ImageNode extends BaseNode {
   naturalH: number
   /** the file it came from, when the clipboard said */
   name?: string
+  /**
+   * Which part of the picture the box shows. Absent means all of it, which is
+   * how every picture arrives and how most of them stay.
+   */
+  crop?: ImageCrop
+}
+
+/**
+ * A crop window in the picture's own coordinates — 0..1 on both axes, never
+ * pixels. Normalised is what lets the crop survive everything that happens to
+ * the box afterwards: a resize, a scaled selection, a source re-encoded at a
+ * different size. The box shows this rectangle of the picture stretched to
+ * fill it, which is the same deal an uncropped picture has always had.
+ *
+ * Nothing is thrown away. The pixels outside the window are still in the
+ * document, so re-cropping can hand any of them back.
+ */
+export interface ImageCrop {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** The whole picture — what a node with no `crop` is showing. */
+export const FULL_CROP: ImageCrop = { x: 0, y: 0, w: 1, h: 1 }
+
+/** Smallest slice of a picture a crop may narrow to, per axis. */
+const MIN_CROP = 0.005
+
+/**
+ * A crop we're willing to render, or undefined for "no crop at all".
+ *
+ * One NaN through here lands in the document, gets autosaved, and takes the
+ * picture with it on every reload — the same reason `sanitize` exists in the
+ * store. A window that says "all of it" comes back undefined rather than
+ * {0,0,1,1}: the absent field is the canonical spelling of an uncropped
+ * picture, and two spellings of one state is a bug waiting for a `===`.
+ */
+export function normalizeCrop(v: unknown): ImageCrop | undefined {
+  if (!v || typeof v !== "object") return undefined
+  const c = v as ImageCrop
+  const fin = (n: unknown): n is number => typeof n === "number" && Number.isFinite(n)
+  if (!fin(c.x) || !fin(c.y) || !fin(c.w) || !fin(c.h)) return undefined
+  const w = Math.min(1, Math.max(MIN_CROP, c.w))
+  const h = Math.min(1, Math.max(MIN_CROP, c.h))
+  const x = Math.min(1 - w, Math.max(0, c.x))
+  const y = Math.min(1 - h, Math.max(0, c.y))
+  if (x === 0 && y === 0 && w === 1 && h === 1) return undefined
+  return { x, y, w, h }
+}
+
+/** The window a picture is showing, with the absent-means-all case spelled out. */
+export function cropOf(n: ImageNode): ImageCrop {
+  return n.crop ?? FULL_CROP
 }
 
 export type SquigNode = ComponentNode | ShapeNode | DrawNode | TextNode | ArrowNode | ImageNode

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-text.ts"
+    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-text.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-crop.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/test-crop.ts
+++ b/scripts/test-crop.ts
@@ -1,0 +1,263 @@
+// ---------------------------------------------------------------------------
+// Crop maths — the window, the sheet, and the arithmetic between them.
+//
+//   node --experimental-strip-types scripts/test-crop.ts
+//
+// lib/canvas/crop imports only types and MIN_SIZE, so this runs standalone
+// with no bundler and no test framework.
+// ---------------------------------------------------------------------------
+
+import {
+  clampWindow,
+  cropAnchor,
+  cropPatch,
+  imageSheet,
+  isCropped,
+  panSheet,
+  uncropPatch,
+  windowToCrop,
+} from "../lib/canvas/crop.ts"
+import { resizeBounds, MIN_SIZE } from "../lib/canvas/transform.ts"
+import { normalizeCrop, type ImageCrop, type ImageNode } from "../lib/types.ts"
+import type { Bounds } from "../lib/selection.ts"
+
+let passed = 0
+const failures: string[] = []
+
+function check(name: string, cond: boolean, detail = "") {
+  if (cond) passed++
+  else failures.push(`${name}${detail ? ` — ${detail}` : ""}`)
+}
+
+const close = (a: number, b: number, eps = 1e-6) => Math.abs(a - b) <= eps
+
+function boxIs(name: string, got: Bounds, want: Bounds, eps = 1e-6) {
+  const ok =
+    close(got.x, want.x, eps) && close(got.y, want.y, eps) && close(got.w, want.w, eps) && close(got.h, want.h, eps)
+  check(
+    name,
+    ok,
+    ok ? "" : `got ${JSON.stringify(round(got))}, want ${JSON.stringify(round(want))}`
+  )
+}
+
+const round = (b: Bounds) => ({
+  x: +b.x.toFixed(3),
+  y: +b.y.toFixed(3),
+  w: +b.w.toFixed(3),
+  h: +b.h.toFixed(3),
+})
+
+// -- fixtures ---------------------------------------------------------------
+
+function pic(over: Partial<ImageNode> = {}): ImageNode {
+  return {
+    id: "img",
+    type: "image",
+    x: 100,
+    y: 100,
+    w: 200,
+    h: 100,
+    seed: 1,
+    src: "data:image/png;base64,xx",
+    naturalW: 400,
+    naturalH: 200,
+    ...over,
+  }
+}
+
+// -- the sheet --------------------------------------------------------------
+
+{
+  // an uncropped picture is its own sheet — every caller has to work the same
+  // on a picture that has never been cropped as on one that has
+  boxIs("uncropped: the sheet is the box", imageSheet(pic()), { x: 100, y: 100, w: 200, h: 100 })
+
+  // showing the middle half of each axis means the whole picture is twice the
+  // box in each direction, hung a quarter of itself up and to the left
+  const half = pic({ crop: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } })
+  boxIs("cropped: the sheet is the picture at the size it looks", imageSheet(half), {
+    x: 100 - 0.25 * 400,
+    y: 100 - 0.25 * 200,
+    w: 400,
+    h: 200,
+  })
+
+  // and the round trip is lossless — this is the invariant every gesture rests
+  // on, because none of them accumulate deltas
+  const back = windowToCrop({ x: half.x, y: half.y, w: half.w, h: half.h }, imageSheet(half))
+  check(
+    "window → crop → sheet round-trips",
+    close(back.x, 0.25) && close(back.y, 0.25) && close(back.w, 0.5) && close(back.h, 0.5),
+    JSON.stringify(back)
+  )
+}
+
+// -- normalizeCrop ----------------------------------------------------------
+
+{
+  check("a full window isn't a crop at all", normalizeCrop({ x: 0, y: 0, w: 1, h: 1 }) === undefined)
+  check("NaN never reaches the document", normalizeCrop({ x: NaN, y: 0, w: 1, h: 1 }) === undefined)
+  check("nor does Infinity", normalizeCrop({ x: 0, y: 0, w: Infinity, h: 1 }) === undefined)
+  check("nor does a missing crop", normalizeCrop(undefined) === undefined)
+
+  const wide = normalizeCrop({ x: -0.5, y: 0.5, w: 2, h: 0.8 }) as ImageCrop
+  check(
+    "a crop that runs off the picture is pulled back onto it",
+    wide.x === 0 && wide.w === 1 && close(wide.y, 0.2) && close(wide.h, 0.8),
+    JSON.stringify(wide)
+  )
+
+  const sliver = normalizeCrop({ x: 0.9, y: 0, w: 0, h: 1 }) as ImageCrop
+  check("a zero-width crop floors instead of dividing by zero", sliver.w > 0 && sliver.x + sliver.w <= 1)
+}
+
+// -- dragging a handle ------------------------------------------------------
+
+{
+  const n = pic()
+  const sheet = imageSheet(n)
+  const win = { x: n.x, y: n.y, w: n.w, h: n.h }
+
+  // pull the east edge 50 to the left: the box narrows, and the crop says so.
+  // The pixels that stay put don't move or change size — that's the whole
+  // point of pinning the sheet.
+  const east = clampWindow(resizeBounds(win, "e", -50, 0), sheet)
+  boxIs("east handle narrows the window", east, { x: 100, y: 100, w: 150, h: 100 })
+  const patch = cropPatch(east, sheet)
+  check(
+    "…and the crop drops the right quarter",
+    close(patch.crop!.x, 0) && close(patch.crop!.w, 0.75) && close(patch.crop!.h, 1),
+    JSON.stringify(patch.crop)
+  )
+
+  // the west edge moves the box's origin as well as its size
+  const west = clampWindow(resizeBounds(win, "w", 40, 0), sheet)
+  boxIs("west handle moves the origin too", west, { x: 140, y: 100, w: 160, h: 100 })
+  check("…and the crop starts further into the picture", close(cropPatch(west, sheet).crop!.x, 0.2))
+
+  // dragging outward on an uncropped picture has nowhere to go: the sheet is
+  // the box, so the window can't grow past it
+  const past = clampWindow(resizeBounds(win, "e", 500, 0), sheet)
+  boxIs("an uncropped window can't be opened out any further", past, win)
+  check("…and that's still 'no crop'", cropPatch(past, sheet).crop === undefined)
+}
+
+// -- opening a crop back out ------------------------------------------------
+
+{
+  const n = pic({ crop: { x: 0.25, y: 0, w: 0.5, h: 1 } })
+  const sheet = imageSheet(n)
+  const win = { x: n.x, y: n.y, w: n.w, h: n.h }
+
+  // the hidden pixels are still there: drag east and they come back, up to the
+  // picture's own edge and not one pixel past it
+  const out = clampWindow(resizeBounds(win, "e", 1000, 0), sheet)
+  check("a crop hands its pixels back when you drag out", close(out.x + out.w, sheet.x + sheet.w))
+  check("…and stops at the edge of the picture", out.x + out.w <= sheet.x + sheet.w + 1e-9)
+
+  // reset gives back everything at the size the picture is already drawn
+  const reset = uncropPatch(n)
+  boxIs("reset restores the whole sheet", reset as Bounds, sheet)
+  check("…and clears the crop", reset.crop === undefined)
+  check("isCropped reads the field, not the numbers", isCropped(n) && !isCropped(pic()))
+}
+
+// -- aspect lock ------------------------------------------------------------
+
+{
+  const n = pic({ crop: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } })
+  const sheet = imageSheet(n) // 400 × 200 at (0, 50)
+  const win = { x: n.x, y: n.y, w: n.w, h: n.h } // 200 × 100 at (100, 100)
+  const ratio = win.w / win.h
+
+  // Shift on a corner: drag far enough that a free resize would run off the
+  // picture, and check the clamp gives up size rather than shape
+  const anchor = cropAnchor("se", win, false)
+  check("the se anchor is the nw corner", anchor[0] === win.x && anchor[1] === win.y)
+
+  const big = clampWindow(resizeBounds(win, "se", 1000, 1000, { aspect: true }), sheet, anchor)
+  check("aspect lock survives the clamp", close(big.w / big.h, ratio, 1e-6), `${big.w} × ${big.h}`)
+  check("…and the pinned corner holds", close(big.x, win.x) && close(big.y, win.y))
+  check(
+    "…and the box still fits inside the picture",
+    big.x >= sheet.x - 1e-9 &&
+      big.y >= sheet.y - 1e-9 &&
+      big.x + big.w <= sheet.x + sheet.w + 1e-9 &&
+      big.y + big.h <= sheet.y + sheet.h + 1e-9
+  )
+  // 100px of vertical room below the anchor against 300 horizontal: the short
+  // axis is what runs out first, so height maxes and width follows the ratio
+  check("…and it grew to the limit of the tighter axis", close(big.y + big.h, sheet.y + sheet.h))
+
+  // from the centre, both directions are pinned to the middle
+  const mid = cropAnchor("se", win, true)
+  check("alt anchors at the centre", mid[0] === win.x + win.w / 2 && mid[1] === win.y + win.h / 2)
+  const sym = clampWindow(resizeBounds(win, "se", 1000, 1000, { aspect: true, fromCenter: true }), sheet, mid)
+  check("symmetric aspect lock keeps its ratio", close(sym.w / sym.h, ratio, 1e-6))
+  check(
+    "…and stays centred where it started",
+    close(sym.x + sym.w / 2, mid[0]) && close(sym.y + sym.h / 2, mid[1])
+  )
+}
+
+// -- sliding the picture ----------------------------------------------------
+
+{
+  const n = pic({ crop: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } })
+  const sheet = imageSheet(n)
+  const win = { x: n.x, y: n.y, w: n.w, h: n.h }
+
+  const moved = panSheet(sheet, win, 30, -10)
+  boxIs("a small slide moves the picture, not the box", moved, {
+    x: sheet.x + 30,
+    y: sheet.y - 10,
+    w: sheet.w,
+    h: sheet.h,
+  })
+  const p = cropPatch(win, moved)
+  check("the box holds still", p.x === win.x && p.y === win.y && p.w === win.w && p.h === win.h)
+  check("…and the crop follows the picture the other way", p.crop!.x < 0.25 && p.crop!.y > 0.25)
+
+  // shove it far enough and the picture's own edge arrives; bare canvas must
+  // never show inside the window
+  const shoved = panSheet(sheet, win, 100_000, 100_000)
+  check("a slide stops at the picture's edge", close(shoved.x, win.x) && close(shoved.y, win.y))
+  const back = panSheet(sheet, win, -100_000, -100_000)
+  check(
+    "…and at the other edge too",
+    close(back.x + back.w, win.x + win.w) && close(back.y + back.h, win.y + win.h)
+  )
+  const crop = cropPatch(win, shoved).crop!
+  check("a slide to the corner reads as a corner crop", close(crop.x, 0) && close(crop.y, 0))
+
+  // an uncropped picture has no slack at all, so a slide is a no-op rather
+  // than a way to drag the picture off its own box
+  const stuck = pic()
+  const stuckWin = { x: stuck.x, y: stuck.y, w: stuck.w, h: stuck.h }
+  boxIs("an uncropped picture doesn't slide", panSheet(imageSheet(stuck), stuckWin, 40, 40), stuckWin)
+}
+
+// -- the floor --------------------------------------------------------------
+
+{
+  const n = pic()
+  const sheet = imageSheet(n)
+  const win = { x: n.x, y: n.y, w: n.w, h: n.h }
+  // squeeze from both sides at once, past the point of no return
+  const tiny = clampWindow(resizeBounds(win, "se", -1000, -1000), sheet)
+  check("a window can't be squeezed below the handle floor", tiny.w >= MIN_SIZE && tiny.h >= MIN_SIZE)
+  check("…and stays on the picture", tiny.x >= sheet.x - 1e-9 && tiny.y >= sheet.y - 1e-9)
+
+  const crop = cropPatch(tiny, sheet).crop!
+  check("…and its crop is still a real rectangle", crop.w > 0 && crop.h > 0 && crop.x + crop.w <= 1 + 1e-9)
+}
+
+// ---------------------------------------------------------------------------
+
+if (failures.length) {
+  console.error(`\n✗ ${failures.length} failed, ${passed} passed\n`)
+  for (const f of failures) console.error("  ✗ " + f)
+  process.exit(1)
+}
+console.log(`✓ ${passed} crop checks passed`)


### PR DESCRIPTION
Double-click a picture — or select it and hit Return — and you step into its crop window: eight handles on the box, the rest of the photo showing faintly around it, thirds guides across the middle. Return, Escape, or a click anywhere else commits, the way leaving a text edit keeps the words. Also reachable from the right-click menu, the command palette, and a new Picture section in the inspector.

**Nothing is destroyed.** The node carries a 0..1 `crop` rectangle and keeps every pixel it had, so re-cropping hands any of them back and Reset gives you the whole picture at the size it already looks. Normalised rather than pixels, so the crop survives a resize, a scaled selection, or a source re-encoded at a different size.

## How it works

`lib/canvas/crop` is two rectangles: the **window** (the node's box) and the **sheet** (where the whole photo would lie in world space).

- **Dragging a handle** pins the sheet and moves the window — which is what makes it feel like sliding a mat over a photo rather than resizing the photo: the pixels you keep don't move or change size.
- **Dragging inside** pins the window and slides the sheet.

Either way the crop is recomputed from the gesture-start snapshot rather than accumulated from deltas, so dragging out and back is lossless. Shift locks the ratio *through* the clamp — scaling about the point the gesture pins, instead of clamping one edge and quietly breaking the shape the user is holding. Alt works from the centre.

Rendering is a nested `<svg>`, which clips to the box with no document-unique id to mint, collide, or forget when a node is duplicated. The PNG export emits the same markup.

Crop mode is *derived* from "this picture is the whole selection" rather than trusted from the flag alone, so every way of changing the selection ends it — ⌘A, Tab, invert, a marquee — and none of them had to learn about cropping.

## Testing

- `scripts/test-crop.ts` — 38 new checks on the crop maths: sheet/window round-trips, handle drags, aspect lock through the clamp, panning to the picture's edge, the size floor, and `normalizeCrop` rejecting NaN/Infinity before it can reach a saved document. Full suite is 182 checks, all green; build and lint clean.
- Verified in the running app against a numbered colour grid: entering crop, narrowing the window (kept pixels held still), sliding the picture under it, committing with Return, persistence across reload, Reset restoring the full sheet in place, normal resize of a cropped image, and ⌘A ending the mode.
- Aspect lock was driven with synthetic events carrying `shiftKey`, because the browser-automation harness never delivers modifiers — 234×89 → 178×68 held the ratio with the NW corner pinned.
- The export path was checked by rasterising its exact markup through the same data-URI-to-`Image` route it uses and sampling pixels, confirming the nested-`<svg>` clip survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)