### PR TITLE
Give a squashed picture its shape back

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -947,20 +947,29 @@ export function Canvas() {
       const b = unionBounds(sel)
       if (!b) return
 
-      // double-clicking a side handle of a fixed-width text layer un-fixes it
+      // the second press on the same handle, soon enough after the first
       const prev = lastHandlePress.current
       lastHandlePress.current = { handle, t: e.timeStamp }
-      if (
-        prev &&
-        prev.handle === handle &&
-        e.timeStamp - prev.t < 400 &&
-        (handle === "e" || handle === "w") &&
-        sel.length === 1 &&
-        sel[0].type === "text" &&
-        sel[0].fixedW
-      ) {
+      const doubled = !!prev && prev.handle === handle && e.timeStamp - prev.t < 400
+      const lone = sel.length === 1 ? sel[0] : null
+
+      // double-clicking a side handle of a fixed-width text layer un-fixes it
+      if (doubled && (handle === "e" || handle === "w") && lone?.type === "text" && lone.fixedW) {
         swallowDblClickUntil.current = e.timeStamp + 600
         resetTextWidth()
+        return
+      }
+
+      // and double-clicking a corner handle of a picture puts it back on the
+      // ratio its own pixels have. Corners rather than sides because a corner
+      // is already the handle you reach for when you want the shape kept, so
+      // it's the one to ask for the shape back — and the sides are spoken for
+      // above. The swallow happens even when the maths turns out to be a
+      // no-op: the press was a handle double-press either way, and letting it
+      // through would step into the crop window instead.
+      if (doubled && handle.length === 2 && lone?.type === "image") {
+        swallowDblClickUntil.current = e.timeStamp + 600
+        s.restoreAspect([lone.id])
         return
       }
       modsRef.current = readMods(e)

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -17,7 +17,7 @@
 import { useSquig } from "@/lib/store"
 import type { ArrowNode, ComponentNode, FillTone, ImageNode, InkTone, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
 import { normalizeFill, normalizeInk } from "@/lib/types"
-import { isCropped } from "@/lib/canvas/crop"
+import { isCropped, trueShapePatch } from "@/lib/canvas/crop"
 import { getDef } from "@/lib/library/registry"
 import { selectionSummary, shared, sharedControls, sharedNumber, unionBounds } from "@/lib/selection"
 import { scaleNodes, MIN_SIZE } from "@/lib/canvas/transform"
@@ -37,6 +37,7 @@ import {
   CropIcon,
   FlipHorizontalIcon,
   FlipVerticalIcon,
+  FrameCornersIcon,
   LinkBreakIcon,
   SelectionAllIcon,
   TrashIcon,
@@ -488,6 +489,23 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
                 <ArrowCounterClockwiseIcon className="size-3" /> Reset
               </Button>
             </div>
+          </StackRow>
+
+          {/* A box dragged off its ratio and a box with pixels hidden are two
+              different mistakes, so this gets its own row rather than a third
+              button under Crop. It runs over every picture selected — each one
+              knows its own ratio — and the ones already true sit it out, which
+              is also why the button greys out when there's nothing to fix. */}
+          <StackRow label="Proportions">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!images.some((n) => !!trueShapePatch(n))}
+              className="h-ctl w-full rounded-chrome-sm text-label"
+              onClick={() => st().restoreAspect(images.map((n) => n.id))}
+            >
+              <FrameCornersIcon className="size-3" /> Unsquash
+            </Button>
           </StackRow>
         </PanelSection>
       )}

--- a/lib/canvas/crop.ts
+++ b/lib/canvas/crop.ts
@@ -166,3 +166,69 @@ export function uncropPatch(n: ImageNode): Partial<ImageNode> {
   const sheet = imageSheet(n)
   return { x: sheet.x, y: sheet.y, w: sheet.w, h: sheet.h, crop: undefined }
 }
+
+/**
+ * The ratio the picture actually shows: its own pixels, narrowed by the crop.
+ *
+ * The crop is the whole reason this isn't `naturalW / naturalH`. A photo cut
+ * down to a tall sliver is a tall picture now, whatever shape the file it came
+ * from was, and handing it the file's ratio back would be a second squash
+ * wearing a fix's coat.
+ *
+ * Null when the numbers can't answer — a picture that decoded to nothing, or
+ * one from a document written before natural size was recorded. Callers do
+ * nothing rather than divide by it.
+ */
+export function visibleAspect(n: ImageNode): number | null {
+  const c = cropOf(n)
+  const w = n.naturalW * c.w
+  const h = n.naturalH * c.h
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= EPS || h <= EPS) return null
+  return w / h
+}
+
+/** Closer than this and nobody could see the difference, so there isn't one. */
+const HAIR = 0.5
+
+/**
+ * Give a picture its shape back — the same box, unbent.
+ *
+ * Two choices worth writing down, because both had a plausible other answer.
+ *
+ * The *area* is what's held, not the width. Keeping the width is a line
+ * shorter, but a picture someone had dragged out into a long letterbox would
+ * come back nearly as tall as it is wide and tower over whatever was arranged
+ * around it. Holding the area means the picture stays about as prominent on
+ * the page as it was: its shape changes, its weight doesn't.
+ *
+ * The *centre* holds still, not the top-left. The gesture that lands here most
+ * often is a double-click on a corner handle, and pinning the opposite corner
+ * would send the corner under the cursor the entire distance — the picture
+ * would read as having fled the pointer. Pinning the centre halves that on
+ * both axes, is the same answer whichever of the four corners was clicked, and
+ * leaves a row of pictures sitting roughly where the eye left them.
+ *
+ * Null means there is nothing to do: the box is already true, or the numbers
+ * won't say what true is. Callers skip the checkpoint on null, so this can't
+ * leave an undo step that undoes nothing — the same deal a tap with the pen
+ * gets in finishGesture.
+ */
+export function trueShapePatch(n: ImageNode): Partial<ImageNode> | null {
+  const ratio = visibleAspect(n)
+  if (ratio === null) return null
+  if (!Number.isFinite(n.w) || !Number.isFinite(n.h) || n.w <= EPS || n.h <= EPS) return null
+
+  const area = n.w * n.h
+  let w = Math.sqrt(area * ratio)
+  let h = Math.sqrt(area / ratio)
+  // a wild ratio on a small box can push one axis under the handle floor;
+  // growing both by one factor keeps the shape we just worked out
+  const grow = Math.max(1, MIN_SIZE / w, MIN_SIZE / h)
+  w *= grow
+  h *= grow
+
+  if (Math.abs(w - n.w) < HAIR && Math.abs(h - n.h) < HAIR) return null
+  // the crop rides along untouched: it's normalised, so the same window of the
+  // picture fills the new box, and the sheet resizes with it
+  return { x: n.x + (n.w - w) / 2, y: n.y + (n.h - h) / 2, w, h }
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -4,7 +4,7 @@ import { create } from "zustand"
 import { nanoid } from "nanoid"
 import type { ComponentNode, ImageNode, SquigNode, TextAlign, TextNode, Tool, Viewport, ShapeKind } from "./types"
 import { normalizeCrop, normalizeFill, screenToWorld, unionBox } from "./types"
-import { isCropped, uncropPatch } from "./canvas/crop"
+import { isCropped, trueShapePatch, uncropPatch } from "./canvas/crop"
 import { repeatStep, type DupTrail } from "./canvas/duplicate"
 import { getDef } from "./library/registry"
 import { breakApart } from "./library/break-apart"
@@ -123,6 +123,8 @@ interface SquigState {
   setCropping: (id: string | null) => void
   /** give a picture back every pixel it's hiding */
   resetCrop: (ids?: string[]) => void
+  /** put a squashed picture back on the ratio its pixels actually have */
+  restoreAspect: (ids?: string[]) => void
   setContextRow: (on: boolean) => void
   setTheme: (t: ThemeName) => void
   setFont: (f: FontMode) => void
@@ -477,6 +479,22 @@ export const useSquig = create<SquigState>((set, get) => ({
       Object.fromEntries(targets.map((n) => [n.id, uncropPatch(n) as Partial<SquigNode>])),
       { checkpoint: true }
     )
+  },
+
+  restoreAspect: (ids) => {
+    const s = get()
+    const patches: Record<string, Partial<SquigNode>> = {}
+    for (const id of ids ?? s.selection) {
+      const n = s.nodes[id]
+      if (n?.type !== "image") continue
+      // a picture already on its ratio hands back null, and so drops out of
+      // the batch — a selection of twelve where one is squashed moves that one
+      const p = trueShapePatch(n)
+      if (p) patches[id] = p as Partial<SquigNode>
+    }
+    // nothing was out of shape: no checkpoint, no undo step that undoes nothing
+    if (!Object.keys(patches).length) return
+    s.updateNodes(patches, { checkpoint: true })
   },
 
   setContextRow: (on) => {

--- a/scripts/test-crop.ts
+++ b/scripts/test-crop.ts
@@ -14,7 +14,9 @@ import {
   imageSheet,
   isCropped,
   panSheet,
+  trueShapePatch,
   uncropPatch,
+  visibleAspect,
   windowToCrop,
 } from "../lib/canvas/crop.ts"
 import { resizeBounds, MIN_SIZE } from "../lib/canvas/transform.ts"
@@ -251,6 +253,77 @@ function pic(over: Partial<ImageNode> = {}): ImageNode {
 
   const crop = cropPatch(tiny, sheet).crop!
   check("…and its crop is still a real rectangle", crop.w > 0 && crop.h > 0 && crop.x + crop.w <= 1 + 1e-9)
+}
+
+// -- giving a picture its shape back ---------------------------------------
+
+{
+  // the fixture is 400 × 200 pixels shown in a 200 × 100 box: already true
+  check("an untouched picture is already true", trueShapePatch(pic()) === null)
+  check("…and its ratio is the pixels' own", close(visibleAspect(pic())!, 2))
+
+  // squashed into a square: area 200 × 200 = 40000 held at 2:1 gives 283 × 141
+  const squashed = pic({ w: 200, h: 200 })
+  const fixed = trueShapePatch(squashed)!
+  check("a squashed picture comes back at the pixels' ratio", close(fixed.w! / fixed.h!, 2, 1e-9))
+  check("…holding the area it took up", close(fixed.w! * fixed.h!, 200 * 200, 1e-6))
+  check(
+    "…about its centre, so it doesn't jump away from the corner you clicked",
+    close(fixed.x! + fixed.w! / 2, 200) && close(fixed.y! + fixed.h! / 2, 200),
+    JSON.stringify(round(fixed as Bounds))
+  )
+  // and it says so out loud: neither axis simply kept its old value
+  check("…and neither axis was simply kept", fixed.w! > 200 && fixed.h! < 200)
+
+  // stretched the other way — a tall box on a wide picture — comes back wide
+  const tall = trueShapePatch(pic({ w: 60, h: 300 }))!
+  check("a stretched picture comes back the other way", tall.w! > tall.h! && close(tall.w! / tall.h!, 2, 1e-9))
+}
+
+{
+  // A crop is what makes this more than naturalW / naturalH. The picture is
+  // 400 × 200; showing a tenth of its width and all of its height leaves
+  // 40 × 200 of pixels — a tall sliver, whatever shape the file was.
+  const sliver = pic({ crop: { x: 0.3, y: 0, w: 0.1, h: 1 }, w: 200, h: 200 })
+  check("a crop changes what 'true' means", close(visibleAspect(sliver)!, 0.2))
+  const back = trueShapePatch(sliver)!
+  check("…so a tall crop comes back tall", close(back.w! / back.h!, 0.2, 1e-9), `${back.w} × ${back.h}`)
+  check("…still holding the area", close(back.w! * back.h!, 200 * 200, 1e-6))
+  check("…and leaving the crop alone", back.crop === undefined && !("crop" in back))
+
+  // the same picture cropped the other way is a wide one
+  const strip = pic({ crop: { x: 0, y: 0.4, w: 1, h: 0.1 }, w: 200, h: 200 })
+  check("a wide crop comes back wide", close(visibleAspect(strip)!, 20))
+
+  // a crop that isn't square on a picture that isn't square: 400 × 0.5 = 200
+  // wide by 200 × 0.25 = 50 tall, so 4:1 — neither the crop's ratio (2:1) nor
+  // the picture's (2:1) on their own would get here
+  const both = pic({ crop: { x: 0.1, y: 0.1, w: 0.5, h: 0.25 } })
+  check("…and both ratios multiply, rather than one winning", close(visibleAspect(both)!, 4))
+
+  // a box already at the cropped ratio has nothing to do
+  check("a picture already true to its crop is left alone", trueShapePatch(pic({ crop: { x: 0, y: 0, w: 0.5, h: 1 }, w: 100, h: 100 })) === null)
+}
+
+{
+  // NaN in the geometry gets autosaved and takes the file with it, so every
+  // way the numbers can fail has to end in "do nothing" rather than in maths
+  check("a picture with no pixels can't say what true is", visibleAspect(pic({ naturalH: 0 })) === null)
+  check("…and isn't touched", trueShapePatch(pic({ naturalW: 0, w: 200, h: 200 })) === null)
+  check("…nor is one whose natural size never got written down", trueShapePatch(pic({ naturalW: undefined as unknown as number })) === null)
+  check("a box with no height is left alone too", trueShapePatch(pic({ h: 0 })) === null)
+
+  const out = trueShapePatch(pic({ w: 200, h: 200 }))!
+  check(
+    "and what does come out is all finite",
+    [out.x!, out.y!, out.w!, out.h!].every((v) => Number.isFinite(v))
+  )
+
+  // an extreme ratio on a small box would put one axis under the handle floor;
+  // both grow together so the shape survives the floor
+  const wisp = trueShapePatch(pic({ naturalW: 4000, naturalH: 4, w: 20, h: 20 }))!
+  check("a wisp of a picture still clears the handle floor", wisp.h! >= MIN_SIZE - 1e-9, `${wisp.w} × ${wisp.h}`)
+  check("…and keeps its ratio anyway", close(wisp.w! / wisp.h!, 1000, 1e-6))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`ImageNode` has always written down `naturalW` and `naturalH`, and nothing has ever read them. Drag a picture off its ratio and there was no way back. This closes that.

## Two ways in, one piece of maths

- **Double-click a corner handle** of a lone picture. It rhymes with double-clicking a *side* handle of a fixed-width text layer to un-fix it, and extends the same double-press bookkeeping in `startResize` — including the swallow that stops the trailing `dblclick` from stepping into the crop window.
- **Picture → Proportions → Unsquash** in the inspector, which works across a whole selection of pictures. The button greys out when nothing in the selection is off its ratio.

Both call one new store action, `restoreAspect`, over `trueShapePatch` in `lib/canvas/crop.ts`.

## Crop changes what "true" means

The ratio restored is the visible one:

```
(naturalW * crop.w) / (naturalH * crop.h)
```

A picture cropped to a tall sliver comes back tall — handing it the file's ratio would be a second squash wearing a fix's coat. The crop rides along untouched: it's normalised, so the same window of the picture stretches to fill the new box, and the sheet resizes with it.

## The decisions

- **The area is held, not the width.** Keeping the width is a line shorter, but a picture dragged out into a long letterbox would come back nearly as tall as it is wide and tower over whatever was arranged around it. Holding the area means the shape changes and the weight doesn't.
- **The centre holds still, not the top-left.** The gesture is a double-click on a *corner*, and pinning the opposite corner would send the one under the cursor the entire distance — the picture would read as having fled the pointer. The centre halves that on both axes and is the same answer whichever corner was clicked.
- **A picture already true yields `null`** and drops out of the batch; an empty batch takes no checkpoint, so there's no undo step that undoes nothing — the same deal a tap with the pen gets in `finishGesture`.
- **Every degenerate case ends in "do nothing"** rather than in maths: no natural size, a zero natural axis, a box with no height. One NaN here gets autosaved and takes the file with it. An extreme ratio that would push an axis under `MIN_SIZE` grows both axes by one factor, so the shape survives the floor.

## Tests

21 new assertions in `scripts/test-crop.ts` (59 total, all passing): uncropped, cropped wide, cropped tall, a crop that is neither square nor square-on-a-square-picture (both ratios multiply), already-true, and the NaN-proofing.

## Verified in the browser

Seeded two pictures (120 × 40 pixels, both in squashed 300 × 220 boxes; the second with a `{x:0.1, y:0, w:0.2, h:1}` crop) and, at 254% zoom:

- Double-clicked the SE corner handle of the uncropped one → 300 × 220 became **445 × 148** (3:1), centre held at (-170, 0), no crop mode entered.
- Double-clicked that corner again → nothing moved, and a single ⌘Z went back to 300 × 220, confirming the no-op left no undo step.
- Selected the **cropped** one and clicked Unsquash → 300 × 220 became **199 × 332** (0.6:1, the 24 × 40 visible ratio, not the file's 3:1), centred where it was, Reset still enabled — the crop survived.
- Selected both and clicked Unsquash once: the squashed one moved, the already-true one sat it out.
- Read the autosaved document back out of localStorage: every number finite, area preserved to 66,000 on both.

Left out on purpose: no command-palette or context-menu entry (the inspector and the handle felt like enough surface for one edit), and no keyboard shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
