### PR TITLE
A full browser stops the save and says so, instead of eating other drawings

### DIFF
--- a/components/chrome/file-name.tsx
+++ b/components/chrome/file-name.tsx
@@ -9,6 +9,11 @@
 // Only hands-on-the-geometry counts. Panning, marquee-selecting and plain
 // mousing around leave every layer where it is, and a label that flickered at
 // each of those would be its own kind of noise.
+//
+// The small line under the name is where saving speaks: a receipt after ⌘S,
+// and — when the browser has no room left — a standing note that this drawing
+// isn't being kept. It sits here rather than in the corner flash because the
+// name is what the eye goes to when it wonders where the drawing lives.
 // ---------------------------------------------------------------------------
 
 import { useEffect, useRef, useState } from "react"
@@ -23,6 +28,7 @@ const SAVED_MS = 1800
 export function FileName() {
   const fileName = useSquig((s) => s.fileName)
   const renaming = useSquig((s) => s.renamingFile)
+  const full = useSquig((s) => s.drawerFull)
   const st = useSquig.getState
   const [ducked, setDucked] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -66,9 +72,17 @@ export function FileName() {
     }
   }, [])
 
-  // renaming and the save note both outrank the duck: neither should vanish
-  // because the other hand started a drag
-  const shown = !ducked || renaming || saved
+  // One line under the name, two jobs. "saved" is a receipt and fades; the
+  // out-of-room note is a condition and stays until a write gets through, so
+  // it takes the line whenever both would speak. It's the only red squig
+  // leaves standing — muted would read as one more status and get skimmed
+  // past, and what it's reporting is that the drawing on screen is the only
+  // copy of itself there is.
+  const note = full ? "not saved — export to keep this one" : saved ? "saved to this browser" : ""
+
+  // renaming and the note both outrank the duck: neither should vanish because
+  // the other hand started a drag
+  const shown = !ducked || renaming || !!note
 
   return (
     <div
@@ -93,10 +107,12 @@ export function FileName() {
       )}
       <span
         aria-live="polite"
-        className="absolute top-full left-1/2 mt-1 -translate-x-1/2 text-[11px] whitespace-nowrap text-muted-foreground transition-opacity duration-200"
-        style={{ opacity: saved ? 1 : 0 }}
+        className={`absolute top-full left-1/2 mt-1 -translate-x-1/2 text-[11px] whitespace-nowrap transition-opacity duration-200 ${
+          full ? "text-destructive" : "text-muted-foreground"
+        }`}
+        style={{ opacity: note ? 1 : 0 }}
       >
-        {saved ? "saved to this browser" : ""}
+        {note}
       </span>
     </div>
   )

--- a/components/chrome/recent-files.tsx
+++ b/components/chrome/recent-files.tsx
@@ -25,6 +25,7 @@ const ARM_MS = 3000
 export function RecentFiles() {
   const files = useSquig((s) => s.files)
   const docId = useSquig((s) => s.docId)
+  const full = useSquig((s) => s.drawerFull)
 
   return (
     <DropdownMenuSub>
@@ -34,6 +35,15 @@ export function RecentFiles() {
           <p className="px-2.5 py-1.5 text-row text-muted-foreground">nothing saved yet</p>
         ) : (
           files.slice(0, SHOWN).map((f) => <FileRow key={f.id} file={f} current={f.id === docId} />)
+        )}
+        {/* The whole explanation lands here rather than under the file name,
+            because this is the list you're looking at when you go to make
+            room — and the trash to do it with is on the row above. */}
+        {full && (
+          <p className="mt-1 border-t px-2.5 pt-2 pb-1 text-label leading-relaxed text-muted-foreground">
+            this browser is out of room, so nothing new is being saved. pictures fill it fastest, and a cropped one
+            still carries the parts it hides. export what you want to keep, then let a drawing go here.
+          </p>
         )}
       </DropdownMenuSubContent>
     </DropdownMenuSub>

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -8,6 +8,11 @@
 //
 // No cloud, no accounts. Clearing site data still clears everything, which is
 // why Export stays one keystroke away.
+//
+// The room here is small and shared: a browser hands the whole origin a few
+// megabytes, and pictures ride along as data URLs, so a few pasted screenshots
+// can fill it on their own. When it fills, squig stops writing and says so. It
+// never makes room by throwing out a drawing the user didn't choose to lose.
 // ---------------------------------------------------------------------------
 
 import type { SquigNode } from "./types"
@@ -43,8 +48,17 @@ const PREFS_KEY = "squig:prefs:v1"
 const LEGACY_KEY = "squig:doc:v1"
 const fileKey = (id: string) => `squig:file:${id}`
 
-/** Past this many the drawer starts forgetting its oldest documents. */
-const MAX_FILES = 40
+/**
+ * Past this many the drawer starts forgetting its oldest documents.
+ *
+ * This is the one place squig lets go of something on its own, and it stays
+ * silent about it on purpose: it only ever reaches the document you last
+ * touched forty drawings ago, it fires during an autosave nobody is watching,
+ * and there is nothing to do about it once it has — a flash reading "your
+ * fortieth-oldest drawing is gone" is alarm without an action. The quota
+ * warning below is the opposite on all three counts, which is why it speaks.
+ */
+export const MAX_FILES = 40
 
 function readJSON(key: string): unknown {
   try {
@@ -104,31 +118,57 @@ export function readFile(id: string): StoredDoc | null {
   }
 }
 
+/** What a save changed, and whether the drawing actually landed. */
+export interface SavePlan {
+  /** the index as it should now read */
+  index: FileMeta[]
+  /** documents to forget — only ever the drawer's own tail, never a casualty */
+  forget: string[]
+  /** the browser refused the write: what's on disk is whatever was there before */
+  full: boolean
+}
+
 /**
- * Write a document and return the new index. If the browser is out of room we
- * forget the oldest documents — never the one in hand — and try again.
+ * What a save should do to the drawer, given what it holds, the document in
+ * hand, and whether the browser accepted it. Pure, so the rules can be read
+ * and tested without a localStorage in the room — see scripts/test-files.ts.
+ *
+ * squig used to answer a refused write by deleting the user's other documents,
+ * oldest first, until the one in hand fit. That is the worst trade a drawing
+ * program can make: it destroyed work nobody asked it to destroy, silently and
+ * with no undo, to save work that might not have been worth more. So a failed
+ * write now changes nothing at all — not the tail, not the index, not one
+ * other document. The drawing stays on screen and squig says so out loud.
+ *
+ * Leaving the index untouched is also the honest answer for the document
+ * itself. If it has been saved before, its old bytes are still on disk and its
+ * old entry still describes them — dropping the entry would orphan a document
+ * that genuinely exists. If it has never been saved, there is nothing to point
+ * an entry at, and a drawer row that opens onto an empty canvas would be a
+ * worse lie than a missing row.
  */
-export function saveFile(doc: StoredDoc): FileMeta[] {
+export function planSave(index: FileMeta[], meta: FileMeta, stored: boolean): SavePlan {
+  if (!stored) return { index, forget: [], full: true }
+  const next = [meta, ...index.filter((f) => f.id !== meta.id)]
+  return { index: next.slice(0, MAX_FILES), forget: next.slice(MAX_FILES).map((f) => f.id), full: false }
+}
+
+/**
+ * Write a document and report how the drawer stands afterwards.
+ *
+ * The document goes down first and the bookkeeping follows, so that a browser
+ * that refuses the write leaves every other file exactly where it was — the
+ * tail trim included, since a document that never landed has no business
+ * pushing anything off the end.
+ */
+export function saveFile(doc: StoredDoc): SavePlan {
   const meta: FileMeta = { id: doc.id, name: doc.name, updatedAt: doc.updatedAt }
-  let index = [meta, ...listFiles().filter((f) => f.id !== doc.id)]
-
-  // trim the tail first, so the common case never hits the quota at all
-  for (const old of index.slice(MAX_FILES)) drop(fileKey(old.id))
-  index = index.slice(0, MAX_FILES)
-
-  let stored = writeJSON(fileKey(doc.id), doc)
-  while (!stored) {
-    const oldest = [...index].reverse().find((f) => f.id !== doc.id)
-    if (!oldest) break
-    drop(fileKey(oldest.id))
-    index = index.filter((f) => f.id !== oldest.id)
-    stored = writeJSON(fileKey(doc.id), doc)
-  }
-
-  // a document we couldn't store has no business being listed
-  if (!stored) index = index.filter((f) => f.id !== doc.id)
-  writeIndex(index)
-  return index
+  const plan = planSave(listFiles(), meta, writeJSON(fileKey(doc.id), doc))
+  for (const id of plan.forget) drop(fileKey(id))
+  // nothing moved, so nothing to write — and the index write would only be one
+  // more thing for a full quota to refuse
+  if (!plan.full) writeIndex(plan.index)
+  return plan
 }
 
 export function deleteFile(id: string): FileMeta[] {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -109,6 +109,10 @@ interface SquigState {
   /** a one-line flash in the corner; the id makes a repeat of the same words
    *  count as a new message */
   notice: { id: number; text: string } | null
+  /** the browser has no room left: this drawing is on screen and nowhere else.
+   *  It stays true until a save gets through, because the trouble does too — a
+   *  flash that fades is the wrong shape for "your work isn't being kept". */
+  drawerFull: boolean
 
   past: DocSnapshot[]
   future: DocSnapshot[]
@@ -375,7 +379,7 @@ function flushSave(get: () => SquigState, force = false) {
   if (!dirty && !force) return
   const known = s.files.some((f) => f.id === s.docId)
   if (!s.order.length && !known && !force) return
-  const files = saveFile({
+  const { index, full } = saveFile({
     id: s.docId,
     name: s.fileName,
     nodes: s.nodes,
@@ -383,8 +387,15 @@ function flushSave(get: () => SquigState, force = false) {
     updatedAt: Date.now(),
     look: lookOf(s),
   })
-  useSquig.setState({ files })
-  dirty = false
+  // Say it once, on the way into trouble — every autosave after this one would
+  // be saying the same thing about the same drawing. The line under the file
+  // name carries it from there, for as long as it lasts.
+  if (full && !s.drawerFull) s.setNotice("no room left in this browser — export this one to keep it")
+  useSquig.setState({ files: index, drawerFull: full })
+  // a refused write leaves the drawing unsaved, so it stays owed: the next
+  // edit, or the tab closing, tries again — which is how squig comes back on
+  // its own once the user has made room
+  dirty = full
 }
 
 let watching = false
@@ -439,6 +450,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   clipboard: [],
   dupTrail: null,
   notice: null,
+  drawerFull: false,
   past: [],
   future: [],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-text.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-crop.ts"
+    "test": "tsc --noEmit -p scripts/tsconfig.json && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-geometry.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-selection.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-clipboard.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-text.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-crop.ts && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test-files.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/test-files.ts
+++ b/scripts/test-files.ts
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------
+// The drawer's bookkeeping — what a save does to the index, and above all what
+// it must never do to somebody else's drawing.
+//
+//   node --experimental-strip-types scripts/test-files.ts
+//
+// planSave is the whole decision, pulled out of saveFile so it can be read and
+// checked without a localStorage in the room: given what the drawer holds, the
+// document in hand, and whether the browser took it, what should change.
+// ---------------------------------------------------------------------------
+
+import { MAX_FILES, planSave, type FileMeta } from "../lib/files.ts"
+
+let passed = 0
+const failures: string[] = []
+
+function check(name: string, cond: boolean, detail = "") {
+  if (cond) passed++
+  else failures.push(`${name}${detail ? ` — ${detail}` : ""}`)
+}
+
+const ids = (list: FileMeta[]) => list.map((f) => f.id).join(",")
+
+// -- fixtures ---------------------------------------------------------------
+
+/** newest first, the way listFiles hands them over */
+function drawer(n: number): FileMeta[] {
+  const out: FileMeta[] = []
+  for (let i = 0; i < n; i++) out.push({ id: `f${i}`, name: `drawing ${i}`, updatedAt: 10_000 - i })
+  return out
+}
+
+function meta(id: string, updatedAt = 20_000, name = "in hand"): FileMeta {
+  return { id, name, updatedAt }
+}
+
+// -- the ordinary save ------------------------------------------------------
+
+{
+  const index = drawer(3)
+
+  // a document nobody has seen before goes on the front of the list
+  const fresh = planSave(index, meta("new"), true)
+  check("a new document joins the drawer", ids(fresh.index) === "new,f0,f1,f2", ids(fresh.index))
+  check("…and nothing is forgotten to make room for it", fresh.forget.length === 0)
+  check("…and the drawer isn't full", fresh.full === false)
+
+  // saving one that's already listed moves it to the front rather than
+  // listing it twice — the drawer is keyed by document, not by save
+  const again = planSave(index, meta("f2", 20_000, "renamed"), true)
+  check("saving a listed document moves it to the front", ids(again.index) === "f2,f0,f1", ids(again.index))
+  check("…exactly once", again.index.filter((f) => f.id === "f2").length === 1)
+  check("…and the entry is the one we just wrote", again.index[0].name === "renamed" && again.index[0].updatedAt === 20_000)
+
+  // an empty drawer is the first save of a browser's life, not a special case
+  const first = planSave([], meta("only"), true)
+  check("the first save of all works the same", ids(first.index) === "only" && first.forget.length === 0)
+}
+
+// -- the tail trim ----------------------------------------------------------
+
+{
+  // a full drawer plus one more: the oldest falls off the end, and only the
+  // oldest. This is the drawer's own bound, nothing to do with the quota.
+  const index = drawer(MAX_FILES)
+  const plan = planSave(index, meta("new"), true)
+  check("the drawer stops at MAX_FILES", plan.index.length === MAX_FILES, `${plan.index.length}`)
+  check("…and the one that falls off is the oldest", plan.forget.join(",") === `f${MAX_FILES - 1}`, plan.forget.join(","))
+  check("…and it's gone from the index too", !plan.index.some((f) => f.id === `f${MAX_FILES - 1}`))
+  check("…while the document in hand is at the front", plan.index[0].id === "new")
+
+  // re-saving something already listed can't push the drawer over the edge,
+  // so nothing should fall off at all
+  const resave = planSave(index, meta("f9"), true)
+  check("re-saving a listed document forgets nothing", resave.forget.length === 0)
+  check("…and the drawer is the same size", resave.index.length === MAX_FILES)
+
+  // a drawer already over the line — an index written before MAX_FILES was
+  // this number, or by another tab — is trimmed back to it
+  const over = planSave(drawer(MAX_FILES + 5), meta("f0"), true)
+  check("an over-long drawer is trimmed back", over.index.length === MAX_FILES)
+  check("…forgetting only the tail", over.forget.length === 5 && over.forget[0] === `f${MAX_FILES}`)
+}
+
+// -- the document that won't fit --------------------------------------------
+
+{
+  const index = drawer(5)
+  const before = ids(index)
+  const plan = planSave(index, meta("new"), false)
+
+  check("a refused write says so", plan.full === true)
+  check("…and forgets nothing at all", plan.forget.length === 0, plan.forget.join(","))
+  check("…and leaves the drawer exactly as it found it", ids(plan.index) === before, ids(plan.index))
+  check("…and doesn't list a document that was never written", !plan.index.some((f) => f.id === "new"))
+
+  // the point of the whole exercise: squig used to delete the user's other
+  // drawings, oldest first, until the one in hand fit. Every id that went in
+  // comes back out, however badly the write went.
+  for (const f of index) {
+    check(`a failed save keeps ${f.id}`, plan.index.some((g) => g.id === f.id && g.updatedAt === f.updatedAt))
+  }
+
+  // a document that has been saved before keeps its old entry — the bytes on
+  // disk are the previous version, and that is what the entry describes
+  const known = planSave(index, meta("f1", 20_000, "renamed"), false)
+  check("a failed re-save keeps the entry that matches what's on disk", known.index.some((f) => f.id === "f1" && f.name === "drawing 1"))
+  check("…and doesn't move it to the front", known.index[0].id === "f0", ids(known.index))
+
+  // and it must not trim either: the tail would be paying for a document that
+  // never landed
+  const packed = drawer(MAX_FILES)
+  const squeezed = planSave(packed, meta("new"), false)
+  check("a failed save doesn't trim the tail", squeezed.forget.length === 0)
+  check("…and the whole drawer is still listed", ids(squeezed.index) === ids(packed))
+
+  // there is nothing to lose on an empty drawer, and nothing to invent either
+  const nothing = planSave([], meta("new"), false)
+  check("a first save that won't fit lists nothing", nothing.index.length === 0 && nothing.full)
+}
+
+// ---------------------------------------------------------------------------
+
+if (failures.length) {
+  console.error(`\n✗ ${failures.length} failed, ${passed} passed\n`)
+  for (const f of failures) console.error("  ✗ " + f)
+  process.exit(1)
+}
+console.log(`✓ ${passed} drawer checks passed`)


### PR DESCRIPTION
`saveFile` handled a full localStorage by deleting the user's other documents, one at a time, until the current one fit — and if it still didn't fit, it dropped the current document from the index, so the drawing on screen quietly stopped existing in the drawer. Both silent, neither undoable.

Non-destructive crop made it likelier to fire: pictures live in the document as data URLs, and a crop keeps every hidden pixel, so trimming a big screenshot doesn't shrink the file at all.

## What changed

**The eviction loop is gone.** The decision now lives in a pure `planSave(index, meta, stored)` in `lib/files.ts`: given what the drawer holds, the document in hand, and whether the browser took the write, what should change. A refused write changes nothing at all — no eviction, no tail trim, no index rewrite.

Leaving the index untouched is what keeps the current drawing listed, and it's the honest answer in both cases. A document that has been saved before still has its old bytes on disk and its old entry describing them, so dropping the entry would orphan a real file. One that has never been saved has nothing to point a row at, and a drawer row that opens onto an empty canvas is a worse lie than a missing row.

The write also goes **first** now, with the bookkeeping after, which is what makes the guarantee absolute — including for the `MAX_FILES` trim, since a document that never landed has no business pushing anything off the end.

**The `MAX_FILES` (40) trim stays, and stays silent.** The reasoning is written down next to it: it only ever reaches the document you last touched forty drawings ago, it fires during an autosave nobody is watching, and there is nothing to do about it once it has. A flash reading "your fortieth-oldest drawing is gone" is alarm without an action. The quota warning is the opposite on all three counts, which is why that one speaks.

**Three places say it, at three different weights:**

- a one-shot flash on the way into trouble — `no room left in this browser — export this one to keep it`
- a standing red line under the file name — `not saved — export to keep this one` — which lasts as long as the condition does, rather than fading after two seconds. It's the only red squig leaves standing; muted would read as one more status and get skimmed past.
- the whole explanation in **Open recent**, where you go to make room and where the trash to do it with already is: `this browser is out of room, so nothing new is being saved. pictures fill it fastest, and a cropped one still carries the parts it hides. export what you want to keep, then let a drawing go here.`

No modal, and nothing new on the canvas.

**It recovers on its own.** A refused write leaves the document owed, so the next edit or the tab closing tries again; the red line clears the moment a save gets through.

## Testing

`scripts/test-files.ts` (29 checks, wired into `npm test`) covers the ordinary save, the tail trim at and over `MAX_FILES`, a document that won't fit, and the guarantee that matters most: every other drawing in the drawer comes back out of a failed save exactly as it went in.

Exercised for real in the browser too: filled localStorage until writes threw, drew a rectangle, and confirmed the flash, the standing line, and the Open recent note all appear — with all three seeded documents and the whole index intact afterwards. Clearing the junk and drawing again saved cleanly and cleared the warning without a reload.

`npx tsc --noEmit`, `npx eslint components lib app`, `npm test` and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
