### PR TITLE
Two shortcut labels that were running off the edge of the sheet

### DIFF
--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -101,7 +101,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ["shift+click"], label: "Add or drop a layer" },
       { keys: ["tab"], label: "Step to the next layer" },
       { keys: ["shift+tab"], label: "Step to the one before" },
-      { keys: ["mod+shift+l"], label: "Lock — the pointer walks past it" },
+      { keys: ["mod+shift+l"], label: "Lock a layer down" },
       { keys: ["right-click"], label: "Unlock a locked layer" },
       { keys: ["del"], label: "Delete" },
       { keys: ["esc"], label: "Deselect" },
@@ -162,7 +162,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     rows: [
       { keys: ["double-click"], label: "Corner — true shape" },
       { keys: ["enter", "double-click"], label: "Crop a picture" },
-      { keys: ["drag"], label: "Slide the picture under the crop" },
+      { keys: ["drag"], label: "Slide the picture" },
       { keys: ["shift+drag"], label: "Crop to the same shape" },
       { keys: ["alt+drag"], label: "Crop both sides at once" },
       { keys: ["enter", "esc"], label: "Done cropping" },


### PR DESCRIPTION
Both rows truncated to an ellipsis in the cheat sheet's narrow columns — spotted while reviewing #59 in a browser, but both came in earlier, with the crop (#48) and lock (#51) merges.

- `Lock — the pointer walks past it` → `Lock a layer down`
- `Slide the picture under the crop` → `Slide the picture`

A row ending in `…` tells you less than a shorter row would. Neither loses anything: the lock row sits under a heading that already says what locking is for, and the slide row sits in the Pictures group between the two crop modifiers, so "under the crop" was the one thing its neighbours had already established.

`tsc`, `eslint`, `npm test` (590 shortcut checks) and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)