### PR TITLE
The kitchen sink waits for the browser before it draws

### DIFF
--- a/app/kitchen-sink/page.tsx
+++ b/app/kitchen-sink/page.tsx
@@ -4,11 +4,16 @@
 // /kitchen-sink — every def rendered at its default size, and again squeezed,
 // so a bad layout shows up without dragging 100 things onto a canvas.
 // Dev aid, not part of the product surface.
+//
+// The grid waits for the browser before it draws anything — see `drawn` below.
 // ---------------------------------------------------------------------------
 
-import { useMemo, useState } from "react"
+import { useMemo, useState, useSyncExternalStore } from "react"
 import { ALL_DEFS, GROUPS, type ComponentDef, type Category } from "@/lib/library/registry"
 import { SketchPrims } from "@/components/canvas/sketch"
+
+/** Nothing to subscribe to — "which engine am I" only ever answers once. */
+const neverChanges = () => () => {}
 
 function Cell({ def, scale }: { def: ComponentDef; scale: number }) {
   const w = Math.round(def.size.w * scale)
@@ -48,6 +53,23 @@ function Cell({ def, scale }: { def: ComponentDef; scale: number }) {
 export default function KitchenSink() {
   const [scale, setScale] = useState(1)
   const [category, setCategory] = useState<Category>("components")
+  /**
+   * Hold the grid back until the browser is the one drawing it.
+   *
+   * rough.js roughens an ellipse by walking Math.cos/Math.sin around it, and
+   * those two are the rare functions the spec lets an engine approximate — the
+   * V8 in Node and the V8 in Chrome disagree in the last bit for a few percent
+   * of inputs. Nothing here is random: the seed is fixed, and either engine on
+   * its own is perfectly repeatable. But a path drawn on the server and the
+   * same path drawn in the browser can land 3e-15 apart, which React reads as
+   * a hydration mismatch and reports as ten unreadable, near-identical `d`
+   * strings. The pixels were never in question; the console noise was.
+   *
+   * The canvas never had this because `/` shows "warming up the pencils…"
+   * until the store hydrates, so no rough.js path is ever in the server HTML.
+   * This is the same trick, for the same reason.
+   */
+  const drawn = useSyncExternalStore(neverChanges, () => true, () => false)
 
   const sections = useMemo(() => {
     const defs = ALL_DEFS.filter((d) => d.category === category)
@@ -92,18 +114,19 @@ export default function KitchenSink() {
         </label>
       </div>
 
-      {sections.map((section) => (
-        <section key={section.group} className="mb-10">
-          <h2 className="mb-3 text-xs font-semibold tracking-wide text-neutral-400 uppercase">
-            {section.group} · {section.defs.length}
-          </h2>
-          <div className="flex flex-wrap items-start gap-6">
-            {section.defs.map((def) => (
-              <Cell key={def.kind} def={def} scale={scale} />
-            ))}
-          </div>
-        </section>
-      ))}
+      {drawn &&
+        sections.map((section) => (
+          <section key={section.group} className="mb-10">
+            <h2 className="mb-3 text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+              {section.group} · {section.defs.length}
+            </h2>
+            <div className="flex flex-wrap items-start gap-6">
+              {section.defs.map((def) => (
+                <Cell key={def.kind} def={def} scale={scale} />
+              ))}
+            </div>
+          </section>
+        ))}
     </div>
   )
 }


### PR DESCRIPTION
Loading `/kitchen-sink` logged a React hydration mismatch. Two agents spotted it in passing while doing other work and neither chased it, which is understandable — React truncates the offending strings in its diff, so all you see is ten `d` attributes that look identical:

```
A tree hydrated but some attributes of the server rendered HTML didn't match
the client properties. This won't be patched up. ...

  <SketchPrims prims={[...]} seed={11}>
+   d="M24.8229410843959 1.6477609080187214 C30.152468776248607 0.63434121..."
-   d="M24.8229410843959 1.6477609080187214 C30.152468776248607 0.63434121..."
```

## What actually differs

Character 542 of the fab's outer circle:

```
node:    ... 27.709330719369436 55.4921797583 ...
chrome:  ... 27.709330719369433 55.4921797583 ...
```

One unit in the last place. 3e-15 of a pixel.

## Why

`Math.sin` and `Math.cos` are among the handful of functions ECMAScript lets an engine approximate however it likes, and the V8 in Node 24.18 and the V8 in Chrome 151 do it differently. Measured over 20,000 inputs: **602 of 20,000 `cos` values and 647 of 20,000 `sin` values differ by exactly 1 ULP** — about 3%. Cold, not a JIT artifact; `Math.sin(0.08772)` is `3fb66d72b60a5c27` in Node and `3fb66d72b60a5c26` in Chrome.

rough.js roughens an ellipse by walking `Math.cos`/`Math.sin` around it, and it emits path data at full float64 precision (`opsToPath` only rounds when `fixedDecimalPlaceDigits` is set, which we don't set). Ellipses are the *only* primitive that touches trig — `_line`, and so every rect, line and poly, uses nothing but `sqrt`/`pow`, which are IEEE-exact and agreed everywhere.

That is exactly the reported symptom. Running every def's prims through rough.js in both engines and diffing: **59 of 465 renders (155 defs × 3 sizes) diverge, and every one of them draws a circle** — fab, radio-group, slider, carousel, timeline, card, stepper, data-table.

So this is **not** a determinism bug. The seed is fixed at `11`, `node.seed` is stable, and either engine on its own repeats itself exactly. Nothing here calls `Math.random()`, and no browser-only text measurement reaches a path coordinate. It is an unfixable environment difference in the last bit of a double.

## Why the canvas was never affected

`app/page.tsx` renders `warming up the pencils…` until `store.hydrated` flips, and that only happens in a `useEffect`. So the server ships the placeholder, the client hydrates the placeholder, and `<Canvas>` — along with every `NodeSketch`, and the `SketchPrims` in the library panel and command palette — mounts afterwards in a client-only commit. No rough.js path has ever been in the canvas's server HTML. The kitchen sink had no such gate and put all 691 paths straight into the prerender (`next build` reports it as `○ (Static)`, so the mismatched HTML was baked in at build time).

## The fix

The grid waits for the browser, the same way `/` already does. `useSyncExternalStore` with a server snapshot of `false` is the lint-clean version of the mount flag (`setState` in an effect trips `react-hooks/set-state-in-effect`).

Rounding the coordinates was the other option and it is the wrong one: it would move real ink to quiet a console. `suppressHydrationWarning` would have to go on every `<path>` in `SketchPrims`, taxing the canvas for a dev page's problem. `/kitchen-sink` is a dev aid; nothing about it wants to be in the prerender.

## Nothing moved

Prims for all 155 defs at three sizes, and the rough.js paths generated from them, hash identically before and after:

```
before  7fd499af…  prims   (465 renders)
after   7fd499af…
before  f7bd7964…  paths   (9,117 generated paths)
after   f7bd7964…
```

## Verified

- `npx tsc --noEmit` clean
- `npx eslint components lib app` clean
- `npm test` — all suites pass, including 1,251 def checks across 155 components
- `npm run build` clean
- dev (`next dev`, port 3137): console.error hooked before hydration — the warning fired before, zero errors after, 691 paths and 8 sections still drawn
- prod (`next build && next start`, port 3138): prerendered HTML contains no `<path>`, page renders all 155 defs, console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
