### PR TITLE
Three flags that outlived what they were set for

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -21,7 +21,7 @@ import { useSquig } from "@/lib/store"
 import type { ArrowNode, ImageNode, SquigNode, TextNode } from "@/lib/types"
 import { screenToWorld } from "@/lib/types"
 import { arrowEnds, bindOf, bindPair, bindTargetAt, endsPatch, withBind } from "@/lib/canvas/arrow-binding"
-import { clampWindow, cropAnchor, cropPatch, imageSheet, panSheet } from "@/lib/canvas/crop"
+import { clampWindow, cropAnchor, cropPatch, cropTarget, imageSheet, panSheet } from "@/lib/canvas/crop"
 import { autoSizeTextBox, setTextWidth } from "@/lib/canvas/text-reflow"
 import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type SnapRect } from "@/lib/canvas/snap-engine"
 import { pinchViewport, type PinchStart, type Pt } from "@/lib/canvas/pinch"
@@ -230,26 +230,6 @@ const inRect = (b: Bounds, x: number, y: number) => x >= b.x && x <= b.x + b.w &
 
 /** Every pointer a gesture is riding on. Only a pinch has more than one. */
 const gesturePointers = (g: Gesture): number[] => (g.kind === "pinch" ? [g.pointerId, g.idB] : [g.pointerId])
-
-/**
- * The picture the crop mode is on, or null.
- *
- * Crop mode runs on one picture and only while that picture is the entire
- * selection, so reaching for anything else is what ends it. Deriving that here
- * rather than trusting the flag alone means no code path that changes the
- * selection — ⌘A, Tab, invert, select-same-kind, a marquee — has to remember
- * to turn the mode off, and none of them can leave a crop window floating over
- * a set of nodes it doesn't belong to.
- */
-function croppingImage(
-  nodes: Record<string, SquigNode>,
-  selection: string[],
-  croppingId: string | null
-): ImageNode | null {
-  if (!croppingId || selection.length !== 1 || selection[0] !== croppingId) return null
-  const n = nodes[croppingId]
-  return n?.type === "image" ? n : null
-}
 
 const canAutoPan = (g: Gesture | null) =>
   !!g &&
@@ -1275,7 +1255,7 @@ export function Canvas() {
       e.stopPropagation()
       e.preventDefault()
       const s = st()
-      const n = croppingImage(s.nodes, s.selection, s.croppingId)
+      const n = cropTarget(s.nodes, s.selection, s.croppingId)
       if (!n) return
       modsRef.current = readMods(e)
       const [wx, wy] = toWorld(e)
@@ -1397,7 +1377,7 @@ export function Canvas() {
       // targets (startCrop), a press anywhere over the picture slides it, and
       // a press off the picture is how you leave.
       if (s.croppingId) {
-        const n = croppingImage(s.nodes, s.selection, s.croppingId)
+        const n = cropTarget(s.nodes, s.selection, s.croppingId)
         if (n && inRect(imageSheet(n), wx, wy)) {
           beginGesture(
             {
@@ -1929,7 +1909,7 @@ export function Canvas() {
           else if (s.linkOpen) s.setLinkOpen(false)
           else if (s.editingId) s.setEditing(null)
           // leaving keeps the crop, the way leaving an edit keeps the words
-          else if (croppingImage(s.nodes, s.selection, s.croppingId)) s.setCropping(null)
+          else if (cropTarget(s.nodes, s.selection, s.croppingId)) s.setCropping(null)
           else if (s.contextMenu) s.setContextMenu(null)
           else if (s.placing) s.setPlacing(null)
           else if (s.panel) s.setPanel(null)
@@ -1950,7 +1930,7 @@ export function Canvas() {
           // Only on a lone node: with several selected there's no "the" text.
           if (e.shiftKey) break
           // in crop mode Return is the commit, so it steps back out again
-          if (croppingImage(s.nodes, s.selection, s.croppingId)) {
+          if (cropTarget(s.nodes, s.selection, s.croppingId)) {
             e.preventDefault()
             s.setCropping(null)
             break
@@ -2081,7 +2061,7 @@ export function Canvas() {
   // the picture being cropped comes out of the document order and is redrawn
   // on top, under its own dimmed ghost — the mode is a spotlight, and a node
   // that happened to be stacked above it shouldn't sit in the middle of it
-  const cropNode = croppingImage(nodes, selection, croppingId)
+  const cropNode = cropTarget(nodes, selection, croppingId)
   const hoverNode = hover && !selection.includes(hover.id) && !cropNode ? nodes[hover.id] : null
   const bindNode = bindHint ? nodes[bindHint] : null
   /**

--- a/lib/canvas/crop.ts
+++ b/lib/canvas/crop.ts
@@ -30,7 +30,7 @@
 // ---------------------------------------------------------------------------
 
 import type { Bounds } from "../selection"
-import { cropOf, normalizeCrop, type ImageCrop, type ImageNode } from "../types"
+import { cropOf, normalizeCrop, type ImageCrop, type ImageNode, type SquigNode } from "../types"
 import { MIN_SIZE, mirrorBounds, type Handle } from "./transform"
 
 const EPS = 1e-6
@@ -179,6 +179,27 @@ export function panSheet(sheet: Bounds, win: Bounds, dx: number, dy: number): Bo
     x: clamp(sheet.x + dx, win.x + win.w - sheet.w, win.x),
     y: clamp(sheet.y + dy, win.y + win.h - sheet.h, win.y),
   }
+}
+
+/**
+ * The picture crop mode is on, or null — the mode's whole definition, in one
+ * function, so the canvas that draws it and the store that holds the flag are
+ * answering the same question.
+ *
+ * Crop mode runs on one picture and only while that picture is the entire
+ * selection: reaching for anything else — another node, a second one, the
+ * empty canvas — is how you leave. That rule is what the overlay is drawn
+ * from, and lib/store keeps `croppingId` honest against it after every write,
+ * so no path that changes the selection has to remember the mode exists.
+ */
+export function cropTarget(
+  nodes: Record<string, SquigNode>,
+  selection: readonly string[],
+  croppingId: string | null
+): ImageNode | null {
+  if (!croppingId || selection.length !== 1 || selection[0] !== croppingId) return null
+  const n = nodes[croppingId]
+  return n?.type === "image" ? n : null
 }
 
 /** Is any of this picture hidden? */

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -103,8 +103,9 @@ export function listFiles(): FileMeta[] {
   return parsed.filter(isMeta).sort(byRecent)
 }
 
-function writeIndex(list: FileMeta[]) {
-  writeJSON(INDEX_KEY, list)
+/** Same contract as writeJSON: false when the browser refused it. */
+function writeIndex(list: FileMeta[]): boolean {
+  return writeJSON(INDEX_KEY, list)
 }
 
 export function readFile(id: string): StoredDoc | null {
@@ -177,10 +178,26 @@ export function saveFile(doc: StoredDoc, seen: number | null): SavePlan {
   if (!canWrite(index, doc.id, seen)) return { index, forget: [], full: false, stale: true }
   const meta: FileMeta = { id: doc.id, name: doc.name, updatedAt: doc.updatedAt }
   const plan = planSave(index, meta, writeJSON(fileKey(doc.id), doc))
+  // nothing landed, so there is nothing to write down — and the index write
+  // would only be one more thing for a full quota to refuse
+  if (plan.full) return plan
+  // The index can be refused on its own. It is small, but it *grows* — a
+  // document's first save adds an entry, a rename lengthens one — so the write
+  // that fills the last of the quota can be this one rather than the document.
+  // Then the bytes are on disk and the drawer still describes the version
+  // before them, which is a save that only half happened, and calling it a
+  // success is the expensive half of the lie: the caller would move its `seen`
+  // stamp forward onto a version the index has never heard of, and from the
+  // next save on canWrite would read that disagreement as another tab writing
+  // this document and refuse every write for the rest of the session — over a
+  // quota, in the one tab there is. So this counts as full, on the same policy
+  // planSave argues for above: a failed save changes nothing at all, and the
+  // drawing stays owed until there is room for it.
+  if (!writeIndex(plan.index)) return { index, forget: [], full: true, stale: false }
+  // Only now: the tail is trimmed against an index that says so. Dropping
+  // first would leave the refused case listing documents whose bytes are
+  // already gone — rows in the drawer that open onto nothing.
   for (const id of plan.forget) drop(fileKey(id))
-  // nothing moved, so nothing to write — and the index write would only be one
-  // more thing for a full quota to refuse
-  if (!plan.full) writeIndex(plan.index)
   return plan
 }
 

--- a/lib/sketch/node-prims.ts
+++ b/lib/sketch/node-prims.ts
@@ -62,8 +62,18 @@ export function basePrims(node: SquigNode): Prim[] {
       return [{ t: "rect", x: 0, y: 0, w: node.w, h: node.h, r: 6, o }]
     }
     case "draw":
-      // freehand is already the user's own line — barely roughen it
-      return [{ t: "poly", pts: node.points, o: outline(node, 1.9, { roughness: 0.2 }) }]
+      // freehand is already the user's own line — barely roughen it.
+      //
+      // The copy is the cheap half of a bargain the store makes elsewhere: a
+      // checkpoint keeps references to live nodes rather than cloning them, so
+      // the array behind `points` is shared with every undo step that node
+      // appears in. Handing it out to rough.js and the SVG exporter as-is is
+      // safe today — both only read it — but "only reads it" is a promise made
+      // by a dependency we upgrade, and the day one of them sorts or reverses
+      // the points in place, it would rewrite history under itself with
+      // nothing to catch it. One array per stroke per render is the whole
+      // price of not having to trust that. scripts/test-history.ts says so.
+      return [{ t: "poly", pts: [...node.points], o: outline(node, 1.9, { roughness: 0.2 }) }]
     case "arrow": {
       const [[x1, y1], [x2, y2]] = node.points
       const o = outline(node, 1.6)

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -6,7 +6,7 @@ import type { ComponentNode, ImageNode, SquigNode, TextAlign, TextNode, Tool, Vi
 import { normalizeFill, screenToWorld, unionBox } from "./types"
 import { validNode } from "./clipboard-payload"
 import { remapBinds, settleBinds } from "./canvas/arrow-binding"
-import { isCropped, trueShapePatch, uncropPatch } from "./canvas/crop"
+import { cropTarget, isCropped, trueShapePatch, uncropPatch } from "./canvas/crop"
 import {
   clampGestureZoom,
   fitViewport,
@@ -418,17 +418,37 @@ function sanitize(
 }
 
 /**
- * Was this node put on the canvas by the checkpoint currently on top?
+ * Is this the untouched draft the checkpoint on top just placed?
  *
  * The text editor opens on two nodes wearing identical clothes: a draft the
  * click before last just placed, and a layer that has been sitting there since
  * before lunch. The undo stack can tell them apart on its own — a checkpoint
  * that predates the node *is* the click that placed it — which saves passing a
  * flag down through the view and back, and saves it being wrong.
+ *
+ * That question alone isn't enough, though, and it took a second edit to show
+ * why. The top checkpoint keeps predating the node for as long as nothing else
+ * pushes one, so a layer typed into, dismissed and then opened again still
+ * looked freshly placed — and the second run of words folded into the
+ * placement exactly like the first, right on top of the first. ⌘Z then lifted
+ * the whole layer off the canvas, and the words in between had never been
+ * checkpointed at all, so redo couldn't reach them either. Two keystrokes
+ * apart, a version of the drawing that no longer existed anywhere.
+ *
+ * So the node has to still be *as it was placed* as well: an empty run, which
+ * is the only thing the text tool ever puts down and the only thing that can
+ * truthfully be called part of the click that placed it. The first words are
+ * that click finishing; every set after them is an edit of a layer that is
+ * already there, and pays for its own step. A component's label is never empty
+ * when it lands — the library drops it wearing its own default and opens no
+ * editor — so renaming one is an edit from the first letter, which is what a
+ * person renaming a button expects ⌘Z to hand back.
  */
-function placedByTop(past: DocSnapshot[], id: string): boolean {
+function freshDraft(past: DocSnapshot[], nodes: Record<string, SquigNode>, id: string): boolean {
   const top = past[past.length - 1]
-  return !!top && !top.nodes[id]
+  if (!top || top.nodes[id]) return false
+  const cur = nodes[id]
+  return cur?.type === "text" && cur.text === ""
 }
 
 const freshSeed = () => Math.floor(Math.random() * 2 ** 31)
@@ -797,7 +817,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   setCropping: (id) => {
     // only a picture has a crop window to step into, and only one at a time —
     // the mode owns the whole selection while it's on, which is also how it
-    // ends: see croppingImage in components/canvas/canvas
+    // ends: see cropTarget in lib/canvas/crop
     if (!id) {
       set({ croppingId: null })
       return
@@ -871,9 +891,10 @@ export const useSquig = create<SquigState>((set, get) => ({
       if (next.length === s.selection.length && next.every((id, i) => s.selection[i] === id)) return s
       // the crop window belongs to one picture and to nothing else: reaching
       // for anything at all — another node, a second one, empty canvas — is
-      // how you leave, and leaving keeps the crop you'd dragged so far
-      const cropping = s.croppingId && next.length === 1 && next[0] === s.croppingId ? s.croppingId : null
-      return { selection: next, croppingId: cropping }
+      // how you leave, and leaving keeps the crop you'd dragged so far. This
+      // path doesn't have to say so; see the note at the foot of this file,
+      // which says it for every path.
+      return { selection: next }
     })
   },
   setCommandOpen: (open) =>
@@ -1070,22 +1091,26 @@ export const useSquig = create<SquigState>((set, get) => ({
    * Emptying words that were already there is a real edit, and keeps its step.
    */
   dismissDraft: (id) => {
-    if (placedByTop(get().past, id)) get().revertToCheckpoint()
+    const { past, nodes } = get()
+    if (freshDraft(past, nodes, id)) get().revertToCheckpoint()
     else get().removeNodes([id])
   },
 
   /**
    * The text editor closing with words in it.
    *
-   * Placing a draft and typing into it is one act, so the words land on the
-   * checkpoint the click already took — ⌘Z then lifts the whole text layer off
-   * the canvas instead of stopping halfway, on the same empty run dismissDraft
-   * exists to keep out of the history. Editing a layer that was already there
-   * is a step of its own and goes through edit(), which is also what makes
-   * closing the editor on words you didn't really change cost nothing.
+   * Placing a draft and typing into it is one act, so the first words land on
+   * the checkpoint the click already took — ⌘Z then lifts the whole text layer
+   * off the canvas instead of stopping halfway, on the same empty run
+   * dismissDraft exists to keep out of the history. Editing a layer that was
+   * already there — including the one you just typed into, the moment the
+   * editor opens on it a second time — is a step of its own and goes through
+   * edit(), which is also what makes closing the editor on words you didn't
+   * really change cost nothing. See freshDraft for where that line is drawn.
    */
   commitText: (id, patch) => {
-    if (placedByTop(get().past, id)) get().updateNode(id, patch)
+    const { past, nodes } = get()
+    if (freshDraft(past, nodes, id)) get().updateNode(id, patch)
     else get().edit(() => get().updateNode(id, patch))
   },
 
@@ -1796,3 +1821,34 @@ export const useSquig = create<SquigState>((set, get) => ({
     }
   },
 }))
+
+/**
+ * The crop flag, kept honest.
+ *
+ * Crop mode is on for exactly as long as one picture is the whole selection —
+ * cropTarget in lib/canvas/crop is that rule, and the canvas draws the overlay
+ * straight from it rather than from `croppingId` alone. Deriving it that way
+ * means no path that changes the selection can leave a crop window floating
+ * over a set of nodes it doesn't belong to.
+ *
+ * What deriving it does *not* do is end the mode, whatever the comment on the
+ * canvas's own copy of this rule used to claim. `croppingId` went on pointing
+ * at the picture the whole time the selection was elsewhere, so every path that
+ * writes `selection` through a raw set rather than setSelection — Tab, ⌘A,
+ * invert, select-same-kind, ⌘D, ⌘V, a library drop — left the mode armed and
+ * merely hidden. Land the selection back on that one picture, by any means at
+ * all, and the overlay came back from a keystroke; the next drag inside it
+ * re-framed the picture instead of moving it. The pointer paths were fine only
+ * because pressing on the canvas happens to call setCropping(null) first.
+ *
+ * The answer is not a list of the eight callers, which is the same mistake
+ * written out longer — the ninth gets added next month. So the flag heals
+ * itself: every write to the store lands, and then this asks the rule whether
+ * the mode it points at is still the mode we're in. It runs on a subscription
+ * rather than inside a component, because state must never be cleared during
+ * render, and it costs one identity check on `croppingId` in the ordinary case
+ * where nothing is being cropped at all.
+ */
+useSquig.subscribe((s) => {
+  if (s.croppingId && !cropTarget(s.nodes, s.selection, s.croppingId)) useSquig.setState({ croppingId: null })
+})

--- a/scripts/test-crop.ts
+++ b/scripts/test-crop.ts
@@ -1,16 +1,19 @@
 // ---------------------------------------------------------------------------
 // Crop maths — the window, the sheet, and the arithmetic between them.
 //
-//   node --experimental-strip-types scripts/test-crop.ts
+//   node --experimental-strip-types --import ./scripts/register-loader.mjs \
+//        scripts/test-crop.ts
 //
-// lib/canvas/crop imports only types and MIN_SIZE, so this runs standalone
-// with no bundler and no test framework.
+// The maths needs nothing but types and MIN_SIZE. The last section reaches for
+// the store, to ask when crop mode ends — hence the loader, and the stand-in
+// browser it sets up down there.
 // ---------------------------------------------------------------------------
 
 import {
   clampWindow,
   cropAnchor,
   cropPatch,
+  cropTarget,
   imageSheet,
   isCropped,
   panSheet,
@@ -20,7 +23,7 @@ import {
   windowToCrop,
 } from "../lib/canvas/crop.ts"
 import { resizeBounds, MIN_SIZE, type Handle } from "../lib/canvas/transform.ts"
-import { cropOf, normalizeCrop, type ImageCrop, type ImageNode } from "../lib/types.ts"
+import { cropOf, normalizeCrop, type ImageCrop, type ImageNode, type SquigNode } from "../lib/types.ts"
 import type { Bounds } from "../lib/selection.ts"
 
 let passed = 0
@@ -499,6 +502,113 @@ const inSheet = (b: Bounds, x: number, y: number) => x >= b.x && x <= b.x + b.w 
     boxIs(`${what}: unsquash reaches the same box`, trueShapePatch(turned)! as Bounds, plain as Bounds)
     check(`${what}: …off the same visible ratio`, close(visibleAspect(turned)!, visibleAspect(pic(squashed))!))
   }
+}
+
+// ---------------------------------------------------------------------------
+// The flag, not the maths: when does crop mode end?
+//
+// Everything above is arithmetic on two rectangles. This last part needs the
+// store, because the bug it exists for was never in the numbers. Crop mode is
+// derived — one picture, and that picture the whole selection — but deriving
+// it only ever *hid* the mode while the selection was elsewhere. The flag
+// stayed on the picture, so the mode came back on its own the moment the
+// selection landed there again: three Tabs, and the next drag re-framed a
+// picture the user was trying to move.
+//
+// So every path that changes the selection without going through setSelection
+// gets a line here. The store heals the flag in one place, after every write,
+// which is what makes the list below a check rather than a to-do list.
+// ---------------------------------------------------------------------------
+
+;(globalThis as { window?: unknown }).window = {
+  innerWidth: 1440,
+  innerHeight: 900,
+  addEventListener() {},
+  removeEventListener() {},
+}
+const held = new Map<string, string>()
+;(globalThis as { localStorage?: unknown }).localStorage = {
+  getItem: (k: string) => held.get(k) ?? null,
+  setItem: (k: string, v: string) => void held.set(k, v),
+  removeItem: (k: string) => void held.delete(k),
+}
+
+const { useSquig } = await import("../lib/store.ts")
+const s = () => useSquig.getState()
+const add = (n: Partial<SquigNode>) => s().addNode(n as unknown as Omit<SquigNode, "id" | "seed">, { checkpoint: false })
+
+/** Two pictures and a rectangle, with crop mode on the first picture. */
+function cropping(): string {
+  useSquig.setState({
+    nodes: {},
+    order: [],
+    selection: [],
+    clipboard: [],
+    past: [],
+    future: [],
+    dupTrail: null,
+    editingId: null,
+    croppingId: null,
+  })
+  const img = add({ ...pic(), id: undefined })
+  add({ ...pic(), id: undefined, x: 400 })
+  add({ type: "shape", shape: "rect", fill: "none", x: 700, y: 0, w: 100, h: 60 } as Partial<SquigNode>)
+  s().setCropping(img)
+  return img
+}
+
+/** The mode as the canvas asks about it. */
+const modeOn = () => !!cropTarget(s().nodes, s().selection, s().croppingId)
+
+{
+  const img = cropping()
+  check("double-clicking a picture puts crop mode on", modeOn() && s().selection.join() === img)
+
+  // the gesture itself: a crop writes to the picture on every pointermove, and
+  // none of that is a reason to leave
+  s().updateNodes({ [img]: { crop: { x: 0.1, y: 0.1, w: 0.5, h: 0.5 } } as Partial<SquigNode> })
+  check("dragging the crop window doesn't end crop mode", modeOn())
+}
+
+// Each of these takes the selection off the picture. What's checked is not
+// that the overlay is gone while the selection is away — deriving it did that
+// much — but that the flag itself is gone, so nothing can re-arm the mode by
+// landing on that picture again.
+const leaves: [string, (img: string) => void][] = [
+  ["Tab steps to the next layer", () => s().cycleSelection(1)],
+  ["⇧Tab steps back", () => s().cycleSelection(-1)],
+  ["⌘A takes everything", () => s().selectAll()],
+  ["invert swaps the selection", () => s().invertSelection()],
+  ["select-same-kind grows it", () => s().selectSameKind()],
+  ["⌘D leaves the copy selected", () => void s().duplicateSelected()],
+  ["⌘V leaves the paste selected", (img) => s().pasteNodes([s().nodes[img]], [800, 800])],
+  ["a click on another layer", () => s().setSelection([s().order[2]])],
+  ["a click on empty canvas", () => s().selectNone()],
+]
+
+for (const [what, run] of leaves) {
+  const img = cropping()
+  run(img)
+  check(`${what}: the crop flag is dropped`, s().croppingId === null, `croppingId ${s().croppingId}`)
+  // and then whatever lands the selection back on the picture — another Tab, a
+  // click, an undo. The mode must not come back on its own.
+  s().setSelection([img])
+  check(`${what}: …and selecting that picture again doesn't re-arm crop mode`, !modeOn())
+}
+
+{
+  // the one selection change that legitimately leaves the mode alone: the one
+  // that didn't actually move
+  const img = cropping()
+  s().setSelection([img])
+  check("a selection that never moved keeps crop mode", modeOn() && s().croppingId === img)
+}
+
+{
+  // and the picture going away takes the mode with it
+  const img = cropping()
+  s().removeNodes([img])
+  check("deleting the picture ends crop mode", s().croppingId === null)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-files.ts
+++ b/scripts/test-files.ts
@@ -9,7 +9,10 @@
 // document in hand, and whether the browser took it, what should change.
 // ---------------------------------------------------------------------------
 
-import { MAX_FILES, planSave, type FileMeta } from "../lib/files.ts"
+// The one thing planSave can't answer is what happens when the *index* write
+// is the one refused, since planSave never sees it — so the last section drives
+// saveFile itself, over a localStorage that can be told to say no to one key.
+import { INDEX_KEY, MAX_FILES, listFiles, planSave, saveFile, type FileMeta, type StoredDoc } from "../lib/files.ts"
 
 let passed = 0
 const failures: string[] = []
@@ -117,6 +120,77 @@ function meta(id: string, updatedAt = 20_000, name = "in hand"): FileMeta {
   // there is nothing to lose on an empty drawer, and nothing to invent either
   const nothing = planSave([], meta("new"), false)
   check("a first save that won't fit lists nothing", nothing.index.length === 0 && nothing.full)
+}
+
+// -- the half-landed save ---------------------------------------------------
+
+// A save is two writes: the document, then the entry that says where and when
+// it landed. The document is the big one, so it is the one a full quota
+// usually refuses — but the index *grows* too, by an entry on a document's
+// first save and by a few characters on a rename, and it goes down second. So
+// there is a real save in which the drawing lands and the drawer never hears
+// about it.
+//
+// That used to be reported as a success. The caller would move its `seen`
+// stamp forward onto a version the index had never heard of, canWrite would
+// read the disagreement as another tab writing this document, and every save
+// for the rest of the session was refused with "this drawing changed in
+// another tab" — in the one tab there was. Freeing space didn't help; only
+// opening another document did. It counts as a full drawer now, which is the
+// policy planSave already argues for: a failed save changes nothing at all.
+{
+  const store = new Map<string, string>()
+  let refuse: string | null = null
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      if (k === refuse) throw new Error("QuotaExceededError")
+      store.set(k, v)
+    },
+    removeItem: (k: string) => void store.delete(k),
+  }
+
+  const doc = (updatedAt: number, name = "d"): StoredDoc => ({ id: "d1", name, nodes: {}, order: [], updatedAt })
+
+  // a normal first save, and the tab now knows what's on disk
+  let seen: number | null = null
+  let plan = saveFile(doc(1000), seen)
+  if (!plan.full && !plan.stale) seen = 1000
+  check("the ordinary save lands", !plan.full && !plan.stale && listFiles()[0]?.updatedAt === 1000)
+
+  // now the index write alone is refused — the document write still gets through
+  refuse = INDEX_KEY
+  plan = saveFile(doc(2000), seen)
+  if (!plan.full && !plan.stale) seen = 2000
+  check("a refused index write is a refused save", plan.full === true && plan.stale === false)
+  check("…and the drawer it reports is the one on disk", plan.index[0]?.updatedAt === 1000, JSON.stringify(plan.index))
+  check("…so the caller is still holding the stamp the index has", seen === 1000, `seen ${seen}`)
+
+  // and that is the whole point: the next save must go out normally, rather
+  // than being mistaken for another tab's work forever after
+  refuse = null
+  for (const at of [3000, 4000]) {
+    const again = saveFile(doc(at), seen)
+    if (!again.full && !again.stale) seen = at
+    check(`the save at ${at} goes out as normal`, !again.stale && !again.full, JSON.stringify(again))
+  }
+  check("…and the drawer ends up describing what's on disk", listFiles()[0]?.updatedAt === 4000 && seen === 4000)
+
+  // the tail is trimmed against an index that says so, never before it: a
+  // refused index write must not leave rows pointing at documents whose bytes
+  // have already been dropped
+  store.clear()
+  seen = null
+  const packed: FileMeta[] = []
+  for (let i = 0; i < MAX_FILES; i++) packed.push({ id: `f${i}`, name: `drawing ${i}`, updatedAt: 10_000 - i })
+  store.set(INDEX_KEY, JSON.stringify(packed))
+  for (const f of packed) store.set(`squig:file:${f.id}`, JSON.stringify({ id: f.id, name: f.name, nodes: {}, order: [], updatedAt: f.updatedAt }))
+  refuse = INDEX_KEY
+  const overflow = saveFile({ id: "new", name: "new", nodes: {}, order: [], updatedAt: 20_000 }, null)
+  check("a refused index write on a full drawer is refused too", overflow.full === true)
+  check("…and the oldest drawing is still on disk", store.has(`squig:file:f${MAX_FILES - 1}`))
+  check("…and still listed", listFiles().some((f) => f.id === `f${MAX_FILES - 1}`))
+  refuse = null
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-history.ts
+++ b/scripts/test-history.ts
@@ -37,6 +37,7 @@ const held = new Map<string, string>()
 }
 
 const { useSquig } = await import("../lib/store.ts")
+const { nodePrims } = await import("../lib/sketch/node-prims.ts")
 import type { ImageNode, SquigNode } from "../lib/types.ts"
 
 let passed = 0
@@ -312,6 +313,35 @@ const docJson = () => JSON.stringify({ nodes: s().nodes, order: s().order })
   for (let i = 0; i < 100; i++) s().redo()
   check("all the way forward again: pixels intact", img(a)?.src === srcA)
   check("all the way forward again: at the last x", img(a)?.x === 120)
+}
+
+// -- what the drawing hands out ---------------------------------------------
+
+{
+  // The other half of the sharing bargain. Nothing writes to a node that is in
+  // the document — but a node's own arrays leave the document all the time, as
+  // the prims the canvas draws and the exporter walks, and from there they
+  // reach rough.js. Every consumer only reads them today, and a shared
+  // reference is exactly as safe as that stays true: sort a freehand stroke's
+  // points in place, in a library upgrade nobody here would think to look at,
+  // and every checkpoint holding that node quietly changes shape with it. The
+  // stroke is the one array long enough to be worth sorting, so it is the one
+  // this checks.
+  reset()
+  const pts: [number, number][] = [[0, 0], [10, 4], [20, 1]]
+  const d = s().addNode({ type: "draw", points: pts, x: 0, y: 0, w: 20, h: 4 } as unknown as Omit<SquigNode, "id" | "seed">)
+  const stroke = (s().nodes[d] as unknown as { points: [number, number][] }).points
+  const prims = nodePrims(s().nodes[d])
+  const poly = prims.find((p) => p.t === "poly") as { pts: [number, number][] } | undefined
+  check("a freehand stroke draws as a poly", !!poly)
+  check("…whose points are not the document's own array", poly?.pts !== stroke)
+  // and the copy really is one: reordering it leaves the drawing alone
+  poly?.pts.reverse()
+  check(
+    "…so a consumer that reorders them can't reach the layer",
+    stroke.map((p) => p.join()).join(" ") === "0,0 10,4 20,1",
+    JSON.stringify(stroke)
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-undo.ts
+++ b/scripts/test-undo.ts
@@ -126,6 +126,65 @@ function docJson(): string {
 }
 
 {
+  // …and the very next edit of that same layer is a layer that's already
+  // there, however little has happened since. The top checkpoint goes on
+  // predating the node for as long as nothing else pushes one, so this used to
+  // fold into the placement too — a second run of words landing on top of the
+  // first, with the first never checkpointed at all. ⌘Z lifted the whole layer
+  // off the canvas, and redo couldn't reach the words in between either.
+  reset()
+  const id = placeDraft(200, 200)
+  s().commitText(id, { text: "hello", w: 46 } as Partial<SquigNode>)
+  s().setEditing(null)
+  const before = depth()
+
+  // double-click the same layer, select all, type over it, click away
+  s().setEditing(id)
+  s().commitText(id, { text: "goodbye", w: 70 } as Partial<SquigNode>)
+  s().setEditing(null)
+  check("typing over it again: a step of its own", depth() === before + 1, `past ${before} -> ${depth()}`)
+  check("typing over it again: the new words landed", (s().nodes[id] as TextNode).text === "goodbye")
+
+  s().undo()
+  check(
+    "typing over it again: ⌘Z hands back the words before, not an empty canvas",
+    (s().nodes[id] as TextNode)?.text === "hello",
+    s().nodes[id] ? JSON.stringify((s().nodes[id] as TextNode).text) : "the layer is gone"
+  )
+  s().redo()
+  check("typing over it again: ⇧⌘Z puts the new words back", (s().nodes[id] as TextNode)?.text === "goodbye")
+  // and the placement is still one step under it, exactly where it was
+  s().undo()
+  s().undo()
+  check("typing over it again: one more ⌘Z takes the layer off", !order().length)
+}
+
+{
+  // the same shape on a component: a label is never empty when the library
+  // drops it, so renaming one is an edit from the first letter — ⌘Z hands back
+  // the label it came with rather than deleting the layer
+  reset()
+  const id = s().addNode({
+    type: "component",
+    kind: "button",
+    props: { label: "Button" },
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 36,
+  } as unknown as Omit<SquigNode, "id" | "seed">)
+  const before = depth()
+  s().setEditing(id)
+  s().commitText(id, { props: { label: "Save" } } as Partial<SquigNode>)
+  s().setEditing(null)
+  check("renaming a just-dropped button: one step", depth() === before + 1, `past ${before} -> ${depth()}`)
+  const labelOf = (nid: string) => (s().nodes[nid] as unknown as { props?: { label?: string } })?.props?.label
+  check("renaming a just-dropped button: the new label landed", labelOf(id) === "Save")
+  s().undo()
+  check("renaming a just-dropped button: ⌘Z brings the old label back", labelOf(id) === "Button", `label ${labelOf(id)}`)
+}
+
+{
   // emptying words that were already there is a real edit and keeps its step
   reset()
   const id = s().addNode({ type: "text", text: "hello", fontSize: 18, x: 0, y: 0, w: 60, h: 23.4 } as Omit<SquigNode, "id" | "seed">)


### PR DESCRIPTION
Three flags that kept pointing at something that was over, all found by an
adversarial review of code that shipped today, all reproduced in the running
app before and after.

### Crop mode came back on its own, and then a drag re-framed the picture

`croppingImage(nodes, selection, croppingId)` is true only while the picture is
also the whole selection, and the canvas draws the overlay from that — but
deriving it only ever *hid* the mode. The flag went on pointing at the picture,
so every selection path that writes `selection` through a raw `set` rather than
`setSelection` left it armed: `cycleSelection`, `selectAll`, `invertSelection`,
`selectSameKind`, `duplicateSelected`, `pasteNodes`, `addNode`, `addNodes`, and
`place()` in lib/clipboard.

Crop a picture, press Tab three times to cycle back to it, and the overlay,
thirds grid and dashed ghost were all back from a keystroke. Drag inside to
move it and it re-framed instead:

```
before: {"x":218,"y":120,"w":282,"h":200,"crop":{"x":0.295,…}}
after : {"x":218,"y":120,"w":282,"h":200,"crop":{"x":0.0875,…}}
```

Fixed at one point rather than nine. The rule moves into `cropTarget` in
lib/canvas/crop, where the canvas and the store can both ask it, and the store
heals `croppingId` against it after every write — on a subscription, so nothing
is cleared during render. A path added next month inherits it. The comment that
claimed deriving the mode meant nobody had to turn it off now says what the
code actually guarantees.

### Re-editing a freshly placed text layer folded into the placement

`placedByTop(past, id)` asked whether the top checkpoint predates the node.
Right once, for a never-typed draft — and still true for every later commit
while nothing else pushes a checkpoint. So: text tool, click, type `hello`,
Escape, double-click, type `goodbye`, Escape, ⌘Z, and the layer went off the
canvas with `hello` never checkpointed and unreachable by redo either.

The doc comment had the intended rule right — "placing a draft and typing into
it is one act" — so the condition now matches it. `freshDraft` folds only while
the node is still the empty run the click placed. A component label, which is
never empty when the library drops it, is an edit from the first letter, so ⌘Z
after renaming a just-dropped button hands back `Button` instead of deleting it.

### A refused index write stopped the tab saving, and blamed another tab

`planSave` decided `full` from the document write only, and `writeIndex` threw
away `writeJSON`'s boolean. Document write lands, index write is refused,
`saveFile` reports success — the store advances `seen` past a version the index
has never heard of, and from then on `canWrite` reads the disagreement as
another tab and refuses every save as `stale`:

```
save #2 (index write refused) -> {"full":false,"stale":false} seen: 2000
    index on disk says: [{"id":"d1","updatedAt":1000}]
save at 3000 -> stale:true   <-- refuses forever after
```

The user is told *"this drawing changed in another tab — export to keep your
version"* when there is no other tab, and freeing space doesn't recover it.
`writeIndex` returns its boolean now and a refused index write counts as full,
leaving `seen` where it was — the "a failed save changes nothing at all" policy
`planSave`'s own comment argues for. The tail trim also moved after the index
write, so a refused one can't leave rows pointing at bytes already dropped.

### Also

`lib/sketch/node-prims` passed `node.points` — the store's own array — straight
into a Prim, and from there to rough.js and the SVG export by reference. Every
consumer is read-only today, but undo history now shares live node objects, so
a future rough.js that sorted or reversed that array in place would corrupt
history with no crash. One shallow copy per stroke per render, plus a check in
test-history that reorders the handed-out array and asserts the layer is
untouched.

### Tests

Each bug had a hole in the suite, and each hole is now a check that fails
without its fix (16, 4 and 8 failures respectively when reverted):

- `test-crop.ts` gains a store-level section: `croppingId` dropped by Tab, ⇧Tab,
  ⌘A, invert, select-same-kind, ⌘D, ⌘V, a click elsewhere and a click on empty
  canvas — and, each time, that landing back on the picture doesn't re-arm the
  mode. Plus the two that must not change: a crop drag keeps the mode, and a
  selection that didn't actually move keeps it too.
- `test-undo.ts` gains the untested cell — the second commit with nothing in
  between — and the component-label version of it.
- `test-files.ts` gains the refused-index-write case, including that a save
  after it goes out normally, and that a refused index write on a full drawer
  leaves the oldest drawing on disk.

### Verified

`tsc --noEmit`, `eslint components lib app`, `npm test` (19 files) and
`npm run build` all clean. All three reproduced by hand in `next dev` on a
scratch document and confirmed gone: Tab-Tab-Tab then drag now moves the
picture (+50,+20 with `crop` untouched); ⌘Z after the second text edit gives
back `hello` and ⇧⌘Z returns `goodbye`; and with `localStorage.setItem`
refusing only the index key, squig says "no room left in this browser" instead
of blaming another tab, and resumes saving the moment the refusal lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
