### PR TITLE
Arrows remember the side you snapped them to

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -18,9 +18,20 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useSquig } from "@/lib/store"
-import type { ArrowNode, ImageNode, SquigNode, TextNode } from "@/lib/types"
-import { screenToWorld } from "@/lib/types"
-import { arrowEnds, bindOf, bindPair, bindTargetAt, endsPatch, withBind } from "@/lib/canvas/arrow-binding"
+import type { ArrowAnchor, ArrowNode, ImageNode, SquigNode, TextNode } from "@/lib/types"
+import { ARROW_ANCHORS, screenToWorld } from "@/lib/types"
+import {
+  anchorPair,
+  anchorPoint,
+  anchorTargetAt,
+  arrowEnds,
+  bindOf,
+  bindPair,
+  endsPatch,
+  snapsToObjects,
+  withTarget,
+  type ArrowTarget,
+} from "@/lib/canvas/arrow-binding"
 import { clampWindow, cropAnchor, cropPatch, cropTarget, imageSheet, panSheet } from "@/lib/canvas/crop"
 import { autoSizeTextBox, setTextWidth } from "@/lib/canvas/text-reflow"
 import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type SnapRect } from "@/lib/canvas/snap-engine"
@@ -163,9 +174,9 @@ type Gesture =
       what: "shape" | "arrow"
       /** the node the press landed on, if any — an arrow started on a box is
        *  attached to it from its very first frame */
-      tailBind: string | null
+      tailTarget: ArrowTarget | null
       /** and the one under the pointer right now, which the head takes on release */
-      headBind: string | null
+      headTarget: ArrowTarget | null
     }
   | {
       /**
@@ -311,7 +322,7 @@ export function Canvas() {
    *  it but a drag would marquee, so the outline shows without a move cursor */
   const [hover, setHover] = useState<{ id: string; soft: boolean; locked: boolean } | null>(null)
   /** the node an arrow end would attach to if it were let go right now */
-  const [bindHint, setBindHint] = useState<string | null>(null)
+  const [bindHint, setBindHint] = useState<ArrowTarget | null>(null)
   const [altHeld, setAltHeld] = useState(false)
   const [gestureKind, setGestureKind] = useState<Gesture["kind"] | null>(null)
   /**
@@ -637,7 +648,9 @@ export function Canvas() {
         // whatever the far end is already holding is off the table: a straight
         // line from a box back to itself has nowhere to go, and squig has no
         // curve to draw instead
-        const target = bindTargetAt(s.nodes, s.order, wx, wy, v.zoom, [g.id, other])
+        const target = snapsToObjects(g.orig)
+          ? anchorTargetAt(s.nodes, s.order, wx, wy, v.zoom, [g.id, other])
+          : null
         setBindHint(target)
 
         // The end in hand goes exactly where the pointer is. If that's over a
@@ -647,7 +660,7 @@ export function Canvas() {
         const ends = arrowEnds(g.orig)
         ends[g.end] = [wx, wy]
         s.updateNodes({
-          [g.id]: { ...endsPatch(ends[0], ends[1]), bind: withBind(bind, g.end, target) } as Partial<SquigNode>,
+          [g.id]: { ...endsPatch(ends[0], ends[1]), ...withTarget(g.orig, g.end, target) } as Partial<SquigNode>,
         })
         return
       }
@@ -756,8 +769,8 @@ export function Canvas() {
         // aim as you draw: the box under the pointer lights up and takes the
         // head the moment you let go. The tail was decided on pointer down.
         if (g.what === "arrow" && g.exceeded) {
-          g.headBind = bindTargetAt(s.nodes, s.order, wx, wy, v.zoom, [g.id, g.tailBind])
-          setBindHint(g.headBind)
+          g.headTarget = anchorTargetAt(s.nodes, s.order, wx, wy, v.zoom, [g.id, g.tailTarget?.id])
+          setBindHint(g.headTarget)
         }
         if (!g.id) {
           if (!g.exceeded) return
@@ -782,7 +795,8 @@ export function Canvas() {
                   [0, 0],
                   [Math.max(w, 8), Math.max(h, 8)],
                 ],
-                bind: bindPair(g.tailBind, g.headBind),
+                bind: bindPair(g.tailTarget?.id ?? null, g.headTarget?.id ?? null),
+                anchors: anchorPair(g.tailTarget?.anchor ?? null, g.headTarget?.anchor ?? null),
               } as Omit<SquigNode, "id" | "seed">,
               { select: false }
             )
@@ -801,7 +815,8 @@ export function Canvas() {
             w: Math.max(w, 2),
             h: Math.max(h, 2),
             points: pts,
-            bind: bindPair(g.tailBind, g.headBind),
+            bind: bindPair(g.tailTarget?.id ?? null, g.headTarget?.id ?? null),
+            anchors: anchorPair(g.tailTarget?.anchor ?? null, g.headTarget?.anchor ?? null),
           } as Partial<SquigNode>)
         } else {
           s.updateNode(g.id, { x, y, w: Math.max(w, 2), h: Math.max(h, 2) })
@@ -949,7 +964,8 @@ export function Canvas() {
                     [0, 0],
                     [w, h],
                   ],
-                  bind: bindPair(g.tailBind, g.headBind),
+                  bind: bindPair(g.tailTarget?.id ?? null, g.headTarget?.id ?? null),
+                  anchors: anchorPair(g.tailTarget?.anchor ?? null, g.headTarget?.anchor ?? null),
                 } as Omit<SquigNode, "id" | "seed">,
                 { select: false }
               )
@@ -1419,7 +1435,7 @@ export function Canvas() {
         // an arrow that starts on top of a box starts attached to it, so the
         // common case — draw from this thing to that thing — needs no second
         // step at all
-        const tailBind = tool === "arrow" ? bindTargetAt(s.nodes, s.order, wx, wy, s.viewport.zoom) : null
+        const tailTarget = tool === "arrow" ? anchorTargetAt(s.nodes, s.order, wx, wy, s.viewport.zoom) : null
         beginGesture(
           {
             kind: "create",
@@ -1428,8 +1444,8 @@ export function Canvas() {
             wy,
             id: null,
             what: tool === "shape" ? "shape" : "arrow",
-            tailBind,
-            headBind: null,
+            tailTarget,
+            headTarget: null,
           },
           e
         )
@@ -1603,8 +1619,9 @@ export function Canvas() {
       pointerWorld.current = toWorld(e)
       // the ghost is driven at the window level instead — see below
       if (s.placing) return
-      if (gestureRef.current || s.tool !== "select" || isSpacebarHeld || s.editingId) {
+      if (gestureRef.current || isSpacebarHeld || s.editingId || (s.tool !== "select" && s.tool !== "arrow")) {
         if (hover) setHover(null)
+        if (!gestureRef.current) setBindHint(null)
         return
       }
       if (hoverRafRef.current !== null) return
@@ -1615,6 +1632,12 @@ export function Canvas() {
         // different geometry than the hit test is just a lie
         const cur = st()
         const [wx, wy] = toWorld({ clientX, clientY })
+        if (cur.tool === "arrow") {
+          setHover(null)
+          setBindHint(anchorTargetAt(cur.nodes, cur.order, wx, wy, cur.viewport.zoom))
+          return
+        }
+        setBindHint(null)
         // locked layers are in this pick and in no other: a click won't take
         // one, but the hover has to say so, or a held-down rectangle is
         // indistinguishable from a wedged app. What it draws is different too
@@ -1627,7 +1650,10 @@ export function Canvas() {
     [st, toWorld, hover, isSpacebarHeld]
   )
 
-  const onPointerLeave = useCallback(() => setHover(null), [])
+  const onPointerLeave = useCallback(() => {
+    setHover(null)
+    if (!gestureRef.current) setBindHint(null)
+  }, [])
 
   /**
    * The placement ghost tracks the pointer on `window`, not on the canvas, so a
@@ -2063,7 +2089,7 @@ export function Canvas() {
   // that happened to be stacked above it shouldn't sit in the middle of it
   const cropNode = cropTarget(nodes, selection, croppingId)
   const hoverNode = hover && !selection.includes(hover.id) && !cropNode ? nodes[hover.id] : null
-  const bindNode = bindHint ? nodes[bindHint] : null
+  const bindNode = bindHint ? nodes[bindHint.id] : null
   /**
    * The world worth drawing. Recomputed on every pan and zoom, which is
    * cheap — four divisions — and has to be, since it is what decides which
@@ -2202,18 +2228,7 @@ export function Canvas() {
       {/* what the arrow end in hand would attach to — the same hint the hover
           draws, turned up, because this one is a promise about what happens
           when you let go rather than a note about what's under the cursor */}
-      {bindNode && (
-        <div
-          className="pointer-events-none absolute rounded-sm"
-          style={{
-            left: bindNode.x * v.zoom + v.x,
-            top: bindNode.y * v.zoom + v.y,
-            width: bindNode.w * v.zoom,
-            height: bindNode.h * v.zoom,
-            border: "2px solid color-mix(in srgb, var(--sq-select) 75%, transparent)",
-          }}
-        />
-      )}
+      {bindNode && bindHint && <AnchorZones node={bindNode} active={bindHint.anchor} viewport={v} />}
 
       {/* selection rings + handles (screen space) — the crop window replaces
           them outright while it's up: two boxes with two meanings, one of them
@@ -2470,6 +2485,54 @@ function handleHitBox(hd: Handle, w: number, h: number, padX: number, padY: numb
   const [dx, width] = span(hd.includes("w"), hd.includes("e"), padX)
   const [dy, height] = span(hd.includes("n"), hd.includes("s"), padY)
   return { left: hx + dx, top: hy + dy, width, height, dotLeft: -dx - r, dotTop: -dy - r }
+}
+
+/** The target's complete connection vocabulary, with the nearest zone active. */
+function AnchorZones({
+  node,
+  active,
+  viewport,
+}: {
+  node: SquigNode
+  active: ArrowAnchor
+  viewport: { x: number; y: number; zoom: number }
+}) {
+  const v = viewport
+  return (
+    <>
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          left: node.x * v.zoom + v.x,
+          top: node.y * v.zoom + v.y,
+          width: node.w * v.zoom,
+          height: node.h * v.zoom,
+          borderRadius: node.type === "shape" && node.shape === "ellipse" ? "9999px" : "4px",
+          border: "1px solid color-mix(in srgb, var(--sq-select) 58%, transparent)",
+        }}
+      />
+      {ARROW_ANCHORS.map((anchor) => {
+        const [wx, wy] = anchorPoint(node, anchor)
+        const selected = anchor === active
+        const size = selected ? 12 : 9
+        return (
+          <div
+            key={anchor}
+            className="pointer-events-none absolute rounded-full"
+            style={{
+              left: wx * v.zoom + v.x - size / 2,
+              top: wy * v.zoom + v.y - size / 2,
+              width: size,
+              height: size,
+              background: selected ? "var(--sq-select)" : "var(--sq-bg)",
+              border: "2px solid var(--sq-select)",
+              boxShadow: selected ? "0 0 0 3px color-mix(in srgb, var(--sq-select) 18%, transparent)" : undefined,
+            }}
+          />
+        )
+      })}
+    </>
+  )
 }
 
 /**

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -590,6 +590,27 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
               onChange={(on) => patch((n) => (n.type === "arrow" ? ({ head: on } as Partial<SquigNode>) : null))}
             />
           </Row>
+          <Row spread label="Snap">
+            <MixedSwitch
+              ariaLabel="Snap to objects"
+              shared={shared(arrows.map((n) => n.snap !== false))}
+              onChange={(on) =>
+                patch((n) =>
+                  n.type === "arrow"
+                    ? ({
+                        snap: on ? undefined : false,
+                        // Turning snapping off means free, not merely "do not
+                        // make another connection". The endpoints stay where
+                        // they are because their current points already hold
+                        // the last settled route.
+                        bind: on ? n.bind : undefined,
+                        anchors: on ? n.anchors : undefined,
+                      } as Partial<SquigNode>)
+                    : null
+                )
+              }
+            />
+          </Row>
         </PanelSection>
       )}
 

--- a/lib/canvas/arrow-binding.ts
+++ b/lib/canvas/arrow-binding.ts
@@ -1,12 +1,10 @@
 // ---------------------------------------------------------------------------
 // Arrows that stick to the boxes they point at — pure.
 //
-// An arrow's two ends may each be bound to a node. A bound end doesn't
-// remember a spot on that node; it remembers only which node, and the line is
-// aimed centre-to-centre and cut off where it leaves the outline. Move either
-// box and the answer changes, which is the point: a napkin gets rearranged,
-// and an anchor pinned to the left edge is a promise about a layout that stops
-// being true the moment you drag the box past the thing it points at.
+// An arrow's two ends may each be bound to a node at one of five anchors. The
+// anchor is a relationship rather than a cached point: move or resize the node
+// and the end is recalculated from the same side. Old documents named only the
+// node; settleBinds gives those bindings the primary side they currently face.
 //
 // That inverts the usual arrangement. Everywhere else in squig the box is the
 // truth and `points` ride along inside it; for a bound arrow the two world
@@ -19,7 +17,7 @@
 // line between two boxes is the whole vocabulary.
 // ---------------------------------------------------------------------------
 
-import type { ArrowBind, ArrowNode, SquigNode } from "../types"
+import type { ArrowAnchor, ArrowAnchors, ArrowBind, ArrowNode, SquigNode } from "../types"
 import { hitsInterior, hitsPoint } from "./hit-test"
 
 /**
@@ -46,10 +44,26 @@ const EPS = 1e-6
 type Point = [number, number]
 
 const NO_BIND: ArrowBind = [null, null]
+const NO_ANCHORS: ArrowAnchors = [null, null]
+
+export interface ArrowTarget {
+  id: string
+  anchor: ArrowAnchor
+}
 
 /** An arrow's bindings, with the absent-means-neither case spelled out. */
 export function bindOf(n: ArrowNode): ArrowBind {
   return n.bind ?? NO_BIND
+}
+
+/** An arrow's explicit anchors, with the old-document case spelled out. */
+export function anchorsOf(n: ArrowNode): ArrowAnchors {
+  return n.anchors ?? NO_ANCHORS
+}
+
+/** Auto-snapping is opt-out so every existing arrow keeps the modern default. */
+export function snapsToObjects(n: ArrowNode): boolean {
+  return n.snap !== false
 }
 
 /**
@@ -117,6 +131,28 @@ export function withBind(bind: ArrowBind, end: 0 | 1, target: string | null): Ar
   return end === 0 ? bindPair(target, bind[1]) : bindPair(bind[0], target)
 }
 
+/** Two anchors, or undefined when neither end has one. */
+export function anchorPair(a: ArrowAnchor | null, b: ArrowAnchor | null): ArrowAnchors | undefined {
+  return a || b ? [a, b] : undefined
+}
+
+/** Set one end's anchor, leaving the other alone. */
+export function withAnchor(
+  anchors: ArrowAnchors,
+  end: 0 | 1,
+  anchor: ArrowAnchor | null
+): ArrowAnchors | undefined {
+  return end === 0 ? anchorPair(anchor, anchors[1]) : anchorPair(anchors[0], anchor)
+}
+
+/** Patch one end's complete relationship in one operation. */
+export function withTarget(n: ArrowNode, end: 0 | 1, target: ArrowTarget | null): Partial<ArrowNode> {
+  return {
+    bind: withBind(bindOf(n), end, target?.id ?? null),
+    anchors: withAnchor(anchorsOf(n), end, target?.anchor ?? null),
+  }
+}
+
 // -- the geometry -----------------------------------------------------------
 
 /**
@@ -158,22 +194,85 @@ export function edgeDistance(n: SquigNode, ux: number, uy: number): number {
 
 const centreOf = (n: SquigNode): Point => [n.x + n.w / 2, n.y + n.h / 2]
 
+/** The visible dot for one anchor, exactly on the node's box. */
+export function anchorPoint(n: SquigNode, anchor: ArrowAnchor): Point {
+  const cx = n.x + n.w / 2
+  const cy = n.y + n.h / 2
+  switch (anchor) {
+    case "top": return [cx, n.y]
+    case "right": return [n.x + n.w, cy]
+    case "bottom": return [cx, n.y + n.h]
+    case "left": return [n.x, cy]
+    case "center": return [cx, cy]
+  }
+}
+
+/**
+ * The endpoint drawn for an anchor. Side anchors keep the small bit of
+ * daylight Squig has always put between ink and outline; center means center.
+ */
+function connectionPoint(n: SquigNode, anchor: ArrowAnchor): Point {
+  const [x, y] = anchorPoint(n, anchor)
+  switch (anchor) {
+    case "top": return [x, y - EDGE_GAP]
+    case "right": return [x + EDGE_GAP, y]
+    case "bottom": return [x, y + EDGE_GAP]
+    case "left": return [x - EDGE_GAP, y]
+    case "center": return [x, y]
+  }
+}
+
+/** Which primary side of a node faces a point. Used only to upgrade old binds. */
+function facingAnchor(n: SquigNode, toward: Point, fallback: ArrowAnchor): ArrowAnchor {
+  const [cx, cy] = centreOf(n)
+  const dx = toward[0] - cx
+  const dy = toward[1] - cy
+  if (Math.abs(dx) <= EPS && Math.abs(dy) <= EPS) return fallback
+
+  // Compare in box-relative space so a wide card still gives its top and
+  // bottom useful zones instead of treating almost every direction as a side.
+  const nx = dx / Math.max(n.w / 2, EPS)
+  const ny = dy / Math.max(n.h / 2, EPS)
+  if (Math.abs(nx) >= Math.abs(ny)) return nx < 0 ? "left" : "right"
+  return ny < 0 ? "top" : "bottom"
+}
+
+/** Fill the missing anchors on a legacy binding from its current geometry. */
+function resolvedAnchors(n: ArrowNode, bind: ArrowBind, nodes: Record<string, SquigNode>): ArrowAnchors {
+  const existing = anchorsOf(n)
+  const ends = arrowEnds(n)
+  const rawA = bind[0] ? nodes[bind[0]] : undefined
+  const rawB = bind[1] ? nodes[bind[1]] : undefined
+  const a = bindable(rawA) ? rawA : undefined
+  const b = bindable(rawB) ? rawB : undefined
+  const towardA = b ? centreOf(b) : ends[1]
+  const towardB = a ? centreOf(a) : ends[0]
+  return [
+    a ? (existing[0] ?? facingAnchor(a, towardA, "right")) : null,
+    b ? (existing[1] ?? facingAnchor(b, towardB, "left")) : null,
+  ]
+}
+
 /**
  * Where a bound arrow's ends belong, given where its boxes are now.
  *
- * A bound end aims from its node's centre; a free end stays exactly where the
- * user last put it and does the aiming for the other one. Both ends are then
- * pulled back to their own outline plus the gap.
+ * A bound end is recalculated from its named anchor; a free end stays exactly
+ * where the user last put it. This is what keeps a relationship live without
+ * letting a rearranged board silently switch the side the user chose.
  */
 export function routeEnds(n: ArrowNode, nodes: Record<string, SquigNode>): [Point, Point] | null {
+  if (!snapsToObjects(n)) return null
   const [ba, bb] = bindOf(n)
-  const a = ba ? nodes[ba] : undefined
-  const b = bb ? nodes[bb] : undefined
-  if (!bindable(a) && !bindable(b)) return null
+  const rawA = ba ? nodes[ba] : undefined
+  const rawB = bb ? nodes[bb] : undefined
+  const a = bindable(rawA) ? rawA : undefined
+  const b = bindable(rawB) ? rawB : undefined
+  if (!a && !b) return null
 
   const ends = arrowEnds(n)
-  const from: Point = a ? centreOf(a) : ends[0]
-  const to: Point = b ? centreOf(b) : ends[1]
+  const anchors = resolvedAnchors(n, [a ? ba : null, b ? bb : null], nodes)
+  const from: Point = a && anchors[0] ? connectionPoint(a, anchors[0]) : ends[0]
+  const to: Point = b && anchors[1] ? connectionPoint(b, anchors[1]) : ends[1]
 
   const dx = to[0] - from[0]
   const dy = to[1] - from[1]
@@ -184,15 +283,7 @@ export function routeEnds(n: ArrowNode, nodes: Record<string, SquigNode>): [Poin
   const ux = d > EPS ? dx / d : 1
   const uy = d > EPS ? dy / d : 0
 
-  const ta = a ? edgeDistance(a, ux, uy) + EDGE_GAP : 0
-  const tb = b ? edgeDistance(b, ux, uy) + EDGE_GAP : 0
-
-  if (d - ta - tb >= MIN_RUN) {
-    return [
-      [from[0] + ux * ta, from[1] + uy * ta],
-      [to[0] - ux * tb, to[1] - uy * tb],
-    ]
-  }
+  if (d >= MIN_RUN) return [from, to]
 
   // no room left between the boxes — see MIN_RUN
   const mx = (from[0] + to[0]) / 2
@@ -237,8 +328,21 @@ export function settleBinds(nodes: Record<string, SquigNode>): Record<string, Sq
     const n = nodes[id]
     if (n?.type !== "arrow" || !n.bind) continue
 
+    // `snap: false` is the canonical free-line state. Sanitizers already drop
+    // stale relationships, but keeping this guard here makes direct store
+    // writes just as honest as imported files.
+    if (!snapsToObjects(n)) {
+      if (out === nodes) out = { ...nodes }
+      out[id] = { ...n, bind: undefined, anchors: undefined }
+      continue
+    }
+
     const bind = livingBind(n.bind, nodes)
-    let next: ArrowNode = bind === n.bind ? n : { ...n, bind }
+    const anchors = bind ? resolvedAnchors(n, bind, nodes) : undefined
+    const sameAnchors =
+      (!anchors && !n.anchors) ||
+      (!!anchors && !!n.anchors && anchors[0] === n.anchors[0] && anchors[1] === n.anchors[1])
+    let next: ArrowNode = bind === n.bind && sameAnchors ? n : { ...n, bind, anchors }
     if (bind) {
       const ends = routeEnds(next, nodes)
       const was = arrowEnds(next)
@@ -266,23 +370,78 @@ export function remapBinds(clones: readonly SquigNode[], idMap: ReadonlyMap<stri
   for (const c of clones) {
     if (c.type !== "arrow" || !c.bind) continue
     const [a, b] = c.bind
+    const anchors = anchorsOf(c)
     const na = a ? (idMap.get(a) ?? null) : null
     const nb = b ? (idMap.get(b) ?? null) : null
     c.bind = na || nb ? [na, nb] : undefined
+    c.anchors = anchorPair(na ? anchors[0] : null, nb ? anchors[1] : null)
   }
 }
 
 // -- aiming at a box --------------------------------------------------------
 
+/** Screen-space reach beyond an object's outline for connector detection. */
+export const ANCHOR_CAPTURE_PX = 18
+
+const ANCHOR_CHOICES = ["top", "right", "bottom", "left", "center"] as const
+const SIDE_ANCHORS = ["top", "right", "bottom", "left"] as const
+
+/** Whether a point is close enough for this object to offer its anchor zones. */
+function nearNode(n: SquigNode, x: number, y: number, zoom: number): boolean {
+  if (hitsPoint(n, x, y, zoom) || hitsInterior(n, x, y)) return true
+  const pad = ANCHOR_CAPTURE_PX / Math.max(zoom, EPS)
+  if (n.type === "shape" && n.shape === "ellipse") {
+    // The corners of an ellipse's bounding box are empty air. Outside the
+    // actual fill/stroke, only the four visible side dots extend detection.
+    return SIDE_ANCHORS.some((anchor) => {
+      const [ax, ay] = anchorPoint(n, anchor)
+      return Math.hypot(x - ax, y - ay) <= pad
+    })
+  }
+  return x >= n.x - pad && x <= n.x + n.w + pad && y >= n.y - pad && y <= n.y + n.h + pad
+}
+
+/** The closest of the four side midpoints and center. */
+export function closestAnchor(n: SquigNode, x: number, y: number): ArrowAnchor {
+  let best: ArrowAnchor = "center"
+  let distance = Infinity
+  for (const anchor of ANCHOR_CHOICES) {
+    const [ax, ay] = anchorPoint(n, anchor)
+    const d = (x - ax) ** 2 + (y - ay) ** 2
+    if (d < distance) {
+      distance = d
+      best = anchor
+    }
+  }
+  return best
+}
+
 /**
- * The node an endpoint dropped here would grab, or null.
+ * The node and stable anchor an endpoint dropped here would grab, or null.
  *
- * The whole box counts, hollow middle included — "point at the box" has to
- * mean the box, or binding to an empty rectangle would mean hitting its 1px
- * outline. That's a deliberate divergence from `pickAt`, which keeps hollow
- * shapes see-through so a marquee can start inside one; there's no marquee to
- * protect in the middle of an endpoint drag.
+ * The whole interior counts, plus a forgiving screen-sized reach around the
+ * boundary. Once a node is found, its five anchors divide that space by which
+ * dot is closest. The topmost eligible object wins, just like a normal pick.
  */
+export function anchorTargetAt(
+  nodes: Record<string, SquigNode>,
+  order: readonly string[],
+  x: number,
+  y: number,
+  zoom: number,
+  skip: readonly (string | null | undefined)[] = []
+): ArrowTarget | null {
+  for (let i = order.length - 1; i >= 0; i--) {
+    const id = order[i]
+    if (skip.includes(id)) continue
+    const n = nodes[id]
+    if (!bindable(n)) continue
+    if (nearNode(n, x, y, zoom)) return { id, anchor: closestAnchor(n, x, y) }
+  }
+  return null
+}
+
+/** The pre-anchor API retained for callers that only need the target id. */
 export function bindTargetAt(
   nodes: Record<string, SquigNode>,
   order: readonly string[],
@@ -291,12 +450,5 @@ export function bindTargetAt(
   zoom: number,
   skip: readonly (string | null | undefined)[] = []
 ): string | null {
-  for (let i = order.length - 1; i >= 0; i--) {
-    const id = order[i]
-    if (skip.includes(id)) continue
-    const n = nodes[id]
-    if (!bindable(n)) continue
-    if (hitsPoint(n, x, y, zoom) || hitsInterior(n, x, y)) return id
-  }
-  return null
+  return anchorTargetAt(nodes, order, x, y, zoom, skip)?.id ?? null
 }

--- a/lib/clipboard-payload.ts
+++ b/lib/clipboard-payload.ts
@@ -16,7 +16,7 @@
 // ---------------------------------------------------------------------------
 
 import type { SquigNode, TextNode } from "./types"
-import { normalizeBind, normalizeCrop } from "./types"
+import { normalizeArrowAnchors, normalizeBind, normalizeCrop } from "./types"
 
 const PAYLOAD_VERSION = 1
 /** the attribute the HTML carrier hides the payload in */
@@ -128,6 +128,14 @@ export function validNode(v: unknown): SquigNode | null {
       // the whole paste rather than this node, and gets answered where the
       // ids are remapped onto the copies — see cloneNodes in lib/store
       n.bind = normalizeBind(n.bind)
+      n.anchors = normalizeArrowAnchors(n.anchors, n.bind)
+      n.snap = n.snap === false ? false : undefined
+      // A free line cannot carry a live relationship in through a file or the
+      // clipboard. Keeping both spellings would make the inspector lie.
+      if (n.snap === false) {
+        n.bind = undefined
+        n.anchors = undefined
+      }
       break
     case "text":
       if (!str(n.text) || !num(n.fontSize)) return null

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -138,16 +138,13 @@ export interface TextNode extends BaseNode {
   link?: string
 }
 
-/**
- * What an arrow's two ends are stuck to — [start, end], null for a free end.
- *
- * A binding is a node id and nothing else: no anchor, no side, no offset. The
- * end is routed to whichever part of the box faces the other end, worked out
- * fresh every time either box moves. That's the whole reason to prefer it over
- * a pinned anchor point — an anchor is a promise about a layout, and the one
- * thing a wireframe does all day is stop being that layout.
- */
+/** What an arrow's two ends are stuck to — [start, end], null for a free end. */
 export type ArrowBind = [string | null, string | null]
+
+/** The five stable places an attached end can occupy on a node. */
+export const ARROW_ANCHORS = ["top", "right", "bottom", "left", "center"] as const
+export type ArrowAnchor = (typeof ARROW_ANCHORS)[number]
+export type ArrowAnchors = [ArrowAnchor | null, ArrowAnchor | null]
 
 export interface ArrowNode extends BaseNode, Outlined {
   type: "arrow"
@@ -160,6 +157,10 @@ export interface ArrowNode extends BaseNode, Outlined {
    * and the box are a *consequence* of it — see lib/canvas/arrow-binding.
    */
   bind?: ArrowBind
+  /** The fixed anchor on each bound node. Old bindings acquire these on load. */
+  anchors?: ArrowAnchors
+  /** False makes this a free line. Absent is the default, auto-snapping state. */
+  snap?: false
 }
 
 /**
@@ -175,6 +176,18 @@ export function normalizeBind(v: unknown): ArrowBind | undefined {
   const end = (e: unknown) => (typeof e === "string" && e ? e : null)
   const a = end(v[0])
   const b = end(v[1])
+  return a || b ? [a, b] : undefined
+}
+
+/** Anchors from an imported document, with anchors on free ends discarded. */
+export function normalizeArrowAnchors(v: unknown, bind?: ArrowBind): ArrowAnchors | undefined {
+  if (!bind || !Array.isArray(v) || v.length !== 2) return undefined
+  const anchor = (value: unknown) =>
+    typeof value === "string" && (ARROW_ANCHORS as readonly string[]).includes(value)
+      ? (value as ArrowAnchor)
+      : null
+  const a = bind[0] ? anchor(v[0]) : null
+  const b = bind[1] ? anchor(v[1]) : null
   return a || b ? [a, b] : undefined
 }
 

--- a/scripts/test-arrows.ts
+++ b/scripts/test-arrows.ts
@@ -9,6 +9,7 @@
 // ---------------------------------------------------------------------------
 
 import {
+  anchorTargetAt,
   arrowEnds,
   bindTargetAt,
   bindable,
@@ -18,9 +19,11 @@ import {
   remapBinds,
   routeEnds,
   settleBinds,
+  snapsToObjects,
   withBind,
+  withTarget,
 } from "../lib/canvas/arrow-binding.ts"
-import { normalizeBind, type ArrowNode, type ShapeNode, type SquigNode } from "../lib/types.ts"
+import { normalizeArrowAnchors, normalizeBind, type ArrowNode, type ShapeNode, type SquigNode } from "../lib/types.ts"
 
 let passed = 0
 const failures: string[] = []
@@ -134,7 +137,7 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   // two 100×100 boxes, centres 300 apart on the x axis
   const a = box("a", 0, 0, 100, 100)
   const b = box("b", 300, 0, 100, 100)
-  const arr = arrowBetween([0, 0], [1, 1], { bind: ["a", "b"] })
+  const arr = arrowBetween([0, 0], [1, 1], { bind: ["a", "b"], anchors: ["right", "left"] })
   const nodes = doc([a, b, arr])
 
   const ends = routeEnds(arr, nodes)!
@@ -146,7 +149,8 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   const moved = settleBinds(doc([a, { ...b, y: 400 }, arr]))
   const after = arrowEnds(moved.arr as ArrowNode)
   check("both bound: moving a box moves the arrow", after[1][1] > 100, `head y ${after[1][1]}`)
-  check("…and the tail comes off a different edge now", after[0][1] > 50)
+  pointIs("…and the tail stays locked to its chosen side", after[0], [100 + EDGE_GAP, 50])
+  pointIs("…while the head stays on b's left midpoint", after[1], [300 - EDGE_GAP, 450])
 
   // and resizing one is the same question asked again
   const grown = settleBinds(doc([{ ...a, w: 200 }, b, arr]))
@@ -158,6 +162,13 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   const once = settleBinds(nodes)
   const twice = settleBinds(once)
   check("routing is a fixed point", twice === once)
+
+  // Bindings written before anchors existed are upgraded once, choosing the
+  // primary sides they currently face, then stop changing sides.
+  const legacy = settleBinds(doc([a, b, arrowBetween([0, 0], [1, 1], { bind: ["a", "b"] })]))
+  check("legacy bindings acquire stable anchors", JSON.stringify((legacy.arr as ArrowNode).anchors) === '["right","left"]')
+  const rearranged = settleBinds(doc([a, { ...b, y: 600 }, legacy.arr as ArrowNode]))
+  pointIs("a migrated anchor stays on the same side after rearranging", arrowEnds(rearranged.arr as ArrowNode)[0], [106, 50])
 }
 
 // -- one end bound ----------------------------------------------------------
@@ -165,17 +176,16 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
 {
   const a = box("a", 0, 0, 100, 100)
   // head parked out at (400, 50), tail attached to the box on the left
-  const arr = arrowBetween([50, 50], [400, 50], { bind: ["a", null] })
+  const arr = arrowBetween([50, 50], [400, 50], { bind: ["a", null], anchors: ["right", null] })
   const nodes = doc([a, arr])
   const ends = routeEnds(arr, nodes)!
   pointIs("one bound: the free end doesn't move", ends[1], [400, 50])
   pointIs("one bound: the bound end comes off the edge facing it", ends[0], [100 + EDGE_GAP, 50])
 
-  // the free end is what the bound end aims at, so dragging it round the box
-  // walks the tail onto another edge
+  // Dragging the free end around does not silently change the side the user chose.
   const above = settleBinds(doc([a, { ...arr, ...endsPatch([50, 50], [50, -400]) } as ArrowNode]))
   const up = arrowEnds(above.arr as ArrowNode)
-  pointIs("one bound: the free end decides which edge the bound one uses", up[0], [50, -EDGE_GAP])
+  pointIs("one bound: the chosen side remains stable", up[0], [100 + EDGE_GAP, 50])
 }
 
 // -- bound nodes that overlap -----------------------------------------------
@@ -185,13 +195,14 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   // of trim each out of 60 units of centre-to-centre
   const a = box("a", 0, 0, 200, 100)
   const b = box("b", 60, 0, 200, 100)
-  const arr = arrowBetween([0, 0], [1, 1], { bind: ["a", "b"] })
+  const arr = arrowBetween([0, 0], [1, 1], { bind: ["a", "b"], anchors: ["right", "left"] })
   const ends = routeEnds(arr, doc([a, b, arr]))!
 
   check("overlapping: both ends are real numbers", finite(ends[0]) && finite(ends[1]))
   const run = Math.hypot(ends[1][0] - ends[0][0], ends[1][1] - ends[0][1])
   check("overlapping: there's still a visible run of line", run > 1, `run ${run}`)
-  check("overlapping: it still points from a to b", ends[1][0] > ends[0][0])
+  pointIs("overlapping: the tail keeps a's right anchor", ends[0], [200 + EDGE_GAP, 50])
+  pointIs("overlapping: the head keeps b's left anchor", ends[1], [60 - EDGE_GAP, 50])
   const mid = [(ends[0][0] + ends[1][0]) / 2, (ends[0][1] + ends[1][1]) / 2]
   // centres are 100 and 160, so halfway is 130
   pointIs("overlapping: it sits between the two centres", mid as Point, [130, 50])
@@ -227,7 +238,7 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   // two boxes stacked dead on top of each other: no direction to point in
   const a = box("a", 0, 0, 100, 100)
   const b = box("b", 0, 0, 100, 100)
-  const ends = routeEnds(arrowBetween([0, 0], [1, 1], { bind: ["a", "b"] }), doc([a, b]))!
+  const ends = routeEnds(arrowBetween([0, 0], [1, 1], { bind: ["a", "b"], anchors: ["center", "center"] }), doc([a, b]))!
   check("coincident: no divide by zero", finite(ends[0]) && finite(ends[1]))
   check("coincident: the arrow lies down rather than collapsing", ends[1][0] > ends[0][0])
   check("…about the shared centre", close((ends[0][1] + ends[1][1]) / 2, 50))
@@ -304,10 +315,15 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
     ["b", "b2"],
     ["arr", "arr2"],
   ])
-  const clones: SquigNode[] = [box("a2", 0, 0, 100, 100), box("b2", 300, 0, 100, 100), arrowBetween([0, 0], [1, 1], { id: "arr2", bind: ["a", "b"] })]
+  const clones: SquigNode[] = [
+    box("a2", 0, 0, 100, 100),
+    box("b2", 300, 0, 100, 100),
+    arrowBetween([0, 0], [1, 1], { id: "arr2", bind: ["a", "b"], anchors: ["bottom", "center"] }),
+  ]
   remapBinds(clones, map)
   const copied = clones[2] as ArrowNode
   check("duplicate: the copy's arrow points at the copies", copied.bind?.[0] === "a2" && copied.bind?.[1] === "b2")
+  check("duplicate: the copy keeps both chosen anchors", JSON.stringify(copied.anchors) === '["bottom","center"]')
 
   // and the copy is genuinely independent: moving the original box leaves it
   const both = settleBinds(doc([box("a", 0, 0, 100, 100), box("b", 300, 0, 100, 100), ...clones]))
@@ -321,10 +337,11 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   check("copying an arrow without its boxes gives a loose arrow", (lone[0] as ArrowNode).bind === undefined)
 
   // half a copy keeps the half it can
-  const half: SquigNode[] = [arrowBetween([0, 0], [1, 1], { id: "arr4", bind: ["a", "b"] })]
+  const half: SquigNode[] = [arrowBetween([0, 0], [1, 1], { id: "arr4", bind: ["a", "b"], anchors: ["top", "right"] })]
   remapBinds(half, new Map([["a", "a4"]]))
   check("copying one of the two boxes keeps that one end", (half[0] as ArrowNode).bind?.[0] === "a4")
   check("…and lets the other go", (half[0] as ArrowNode).bind?.[1] === null)
+  check("…and clears only the released end's anchor", JSON.stringify((half[0] as ArrowNode).anchors) === '["top",null]')
 }
 
 // -- a stranger's document --------------------------------------------------
@@ -335,6 +352,9 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   check("…and not a number pretending to be an id", normalizeBind([1, 2]) === undefined)
   check("two nulls is spelled 'absent'", normalizeBind([null, null]) === undefined)
   check("one id survives on its own", JSON.stringify(normalizeBind([null, "b"])) === '[null,"b"]')
+  check("valid anchors survive", JSON.stringify(normalizeArrowAnchors(["top", "center"], ["a", "b"])) === '["top","center"]')
+  check("unknown anchors are dropped", JSON.stringify(normalizeArrowAnchors(["corner", "left"], ["a", "b"])) === '[null,"left"]')
+  check("a free end cannot retain an anchor", normalizeArrowAnchors(["top", null], [null, "b"]) === undefined)
 
   // an id nobody in the document answers to is dropped on the way in
   const stranger = settleBinds(doc([box("a", 0, 0, 100, 100), arrowBetween([0, 0], [200, 0], { bind: ["a", "ghost"] })]))
@@ -360,6 +380,20 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   check("an oval isn't grabbable by the corner of its box", bindTargetAt(round, ["o"], 2, 2, 1) === null)
   check("…but is by its middle", bindTargetAt(round, ["o"], 50, 50, 1) === "o")
 
+  const top = anchorTargetAt(nodes, order, 50, 2, 1)
+  const right = anchorTargetAt(nodes, order, 98, 50, 1)
+  const bottom = anchorTargetAt(nodes, order, 50, 98, 1)
+  const left = anchorTargetAt(nodes, order, 2, 50, 1)
+  const center = anchorTargetAt(nodes, order, 50, 50, 1)
+  check("the top zone resolves to the top midpoint", top?.anchor === "top")
+  check("the right zone resolves to the right midpoint", right?.anchor === "right")
+  check("the bottom zone resolves to the bottom midpoint", bottom?.anchor === "bottom")
+  check("the left zone resolves to the left midpoint", left?.anchor === "left")
+  check("the center zone resolves to center", center?.anchor === "center")
+  check("the capture reach is screen-sized", anchorTargetAt(nodes, order, -15, 50, 1)?.anchor === "left")
+  check("the capture reach scales with zoom", anchorTargetAt(nodes, order, -8, 50, 2)?.anchor === "left")
+  check("the same world gap is too far when zoomed in", anchorTargetAt(nodes, order, -15, 50, 2) === null)
+
   check("an arrow can't be a binding target at all", !bindable(arr))
   check("…and a shape can", bindable(hollow))
 }
@@ -370,6 +404,16 @@ function doc(list: SquigNode[]): Record<string, SquigNode> {
   check("attaching the tail leaves the head alone", JSON.stringify(withBind([null, "b"], 0, "a")) === '["a","b"]')
   check("letting the head go leaves the tail attached", JSON.stringify(withBind(["a", "b"], 1, null)) === '["a",null]')
   check("letting the last one go clears the binding", withBind(["a", null], 0, null) === undefined)
+
+  const attached = arrow({ bind: ["a", null], anchors: ["top", null] })
+  const switched = withTarget(attached, 0, { id: "a", anchor: "bottom" })
+  check("switching sides updates the anchor without losing the target", switched.bind?.[0] === "a" && switched.anchors?.[0] === "bottom")
+
+  const free = arrowBetween([106, 50], [250, 50], { bind: ["a", null], anchors: ["right", null], snap: false })
+  const released = settleBinds(doc([box("a", 0, 0, 100, 100), free])).arr as ArrowNode
+  check("Snap off drops live relationships", released.bind === undefined && released.anchors === undefined)
+  pointIs("Snap off leaves the endpoint where it was", arrowEnds(released)[0], [106, 50])
+  check("Snap off is the only opt-out state", !snapsToObjects(released) && snapsToObjects(arrow({})))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- snap connector endpoints to persistent top, right, bottom, left, or center anchors
- show all available anchor zones and highlight the active target while drawing or reconnecting
- keep relationships live through shape moves and resizes, while migrating existing target-only bindings safely
- add a per-arrow Snap switch that detaches the line in place for free positioning
- preserve anchors through import, copy, undo, save, and reload

## Verification

- pnpm test
- pnpm build
- TypeScript and ESLint on all changed files
- browser-tested create, reconnect, move, Snap off, undo, and reload workflows with no console or framework errors