### PR TITLE
Make component icons fully editable

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -48,7 +48,7 @@ import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type H
 import { pickAt, pickInRect, pickSoftAt, type PickOpts } from "@/lib/canvas/hit-test"
 import { canvasOwnsKeyboard } from "@/lib/canvas/keyboard-owner"
 import { useClipboard } from "@/lib/canvas/use-clipboard"
-import { editTarget, hasEditableText, textControlAt } from "@/lib/canvas/edit-target"
+import { editTarget, hasEditableText, iconControlAt, textControlAt } from "@/lib/canvas/edit-target"
 import { textBlockHeight } from "@/lib/sketch/text-layout"
 import { unionBounds, type Bounds } from "@/lib/selection"
 import { NodeSketch, SketchPrims, imagePlacement, mirrorBox } from "./sketch"
@@ -1706,6 +1706,19 @@ export function Canvas() {
       }
       // double-clicking inside a multi-selection narrows to what you clicked
       if (s.selection.length !== 1 || s.selection[0] !== hitId) s.setSelection([hitId])
+      // A configurable glyph is a property of the component, not a detached
+      // layer. Hand that property to the inspector just like an aimed text run
+      // is handed to the inline editor below.
+      if (n.type === "component") {
+        const [wx, wy] = toWorld(e)
+        const key = iconControlAt(n, wx - n.x, wy - n.y)
+        if (key) {
+          setAim(null)
+          s.setEditing(null)
+          s.setInspectorFocus({ id: hitId, key })
+          return
+        }
+      }
       // a picture has no words to step into, so the same press steps into its
       // crop instead — the one edit a picture has
       if (n.type === "image") s.setCropping(hitId)

--- a/components/chrome/icon-picker.tsx
+++ b/components/chrome/icon-picker.tsx
@@ -14,8 +14,8 @@
 // frame — the version bump fills it in rather than blocking the panel.
 // ---------------------------------------------------------------------------
 
-import { useEffect, useState } from "react"
-import { MagnifyingGlassIcon } from "@phosphor-icons/react"
+import { useEffect, useRef, useState } from "react"
+import { MagnifyingGlassIcon, XIcon } from "@phosphor-icons/react"
 
 import { useSquig } from "@/lib/store"
 import type { ComponentNode, SquigNode } from "@/lib/types"
@@ -72,7 +72,11 @@ function Glyph({ name, weight, className }: { name: string; weight: IconWeight; 
  */
 function IconPicker({ nodes, control }: { nodes: ComponentNode[]; control: ControlDef }) {
   const st = useSquig.getState
+  const searchRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState("")
+  const focusRequested = useSquig(
+    (s) => nodes.length === 1 && s.inspectorFocus?.id === nodes[0].id && s.inspectorFocus.key === control.key
+  )
   // the tags index arrives after mount; without a re-render the grid would keep
   // showing the popular fallback until something else happened to redraw it
   const [, setIndexReady] = useState(iconIndexReady)
@@ -83,7 +87,12 @@ function IconPicker({ nodes, control }: { nodes: ComponentNode[]; control: Contr
   // aliases and the grid must agree on a spelling, or the current icon never
   // reads as selected — resolve once and compare against that
   const rawName = current.mixed ? null : String(current.value ?? "")
-  const currentName = rawName === "logo" ? "logo" : rawName ? (resolveIconName(rawName) ?? rawName) : null
+  const currentName =
+    rawName === "none" || !rawName
+      ? null
+      : rawName === "logo"
+        ? "logo"
+        : (resolveIconName(rawName) ?? rawName)
   const weight = normalizeIconWeight(nodes[0]?.props.weight)
 
   useEffect(() => {
@@ -94,6 +103,20 @@ function IconPicker({ nodes, control }: { nodes: ComponentNode[]; control: Contr
   useEffect(() => {
     void loadIconWeight(weight)
   }, [weight])
+
+  // A double-click on a component's drawn glyph arrives here through the
+  // inspector-focus handoff. Wait one frame so a previously folded Variant
+  // section has mounted and measured before scrolling to and focusing it.
+  useEffect(() => {
+    if (!focusRequested) return
+    const frame = requestAnimationFrame(() => {
+      searchRef.current?.scrollIntoView({ block: "nearest" })
+      searchRef.current?.focus()
+      searchRef.current?.select()
+      st().setInspectorFocus(null)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [focusRequested, st])
 
   // both calls read the index as it stands, so they're redone every render
   // rather than memoised against it — a scan of 1,500 names costs less than
@@ -123,13 +146,26 @@ function IconPicker({ nodes, control }: { nodes: ComponentNode[]; control: Contr
       <div className="flex h-ctl items-center gap-2">
         {currentName && <Glyph name={currentName} weight={weight} className="size-5 shrink-0 text-foreground" />}
         <span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
-          {current.mixed ? MIXED_LABEL : currentName}
+          {current.mixed ? MIXED_LABEL : (currentName ?? "No icon")}
         </span>
+        {control.allowNone && (
+          <button
+            type="button"
+            aria-label="Remove icon"
+            aria-pressed={!current.mixed && currentName === null}
+            disabled={!current.mixed && currentName === null}
+            onClick={() => setValue("none")}
+            className="flex h-ctl-sm items-center gap-1 rounded-chrome-xs px-1.5 text-label text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/40 disabled:opacity-45"
+          >
+            <XIcon className="size-3" /> None
+          </button>
+        )}
       </div>
 
       <div className="relative">
         <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
+          ref={searchRef}
           value={query}
           aria-label="Search icons"
           placeholder="search 1,500 icons…"

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -14,6 +14,8 @@
 // somewhere else.
 // ---------------------------------------------------------------------------
 
+import { useEffect } from "react"
+
 import { useSquig } from "@/lib/store"
 import type { ArrowNode, ComponentNode, FillTone, ImageNode, InkTone, LineStyle, ShapeNode, SquigNode, StrokeWeight, TextNode } from "@/lib/types"
 import { normalizeFill, normalizeInk, normalizeStroke } from "@/lib/types"
@@ -32,7 +34,7 @@ import {
   sharedAlign,
   sharedVerticalAlign,
 } from "./text-controls"
-import { Panel, PanelFooter, PanelHeader, PanelNote, PanelSection, Row, StackRow } from "@/components/ui/panel"
+import { openPanelSection, Panel, PanelFooter, PanelHeader, PanelNote, PanelSection, Row, StackRow } from "@/components/ui/panel"
 import { IconAction, Segmented, type SegmentOption } from "@/components/ui/segmented"
 import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
@@ -334,6 +336,8 @@ function PageFooter() {
 
 function SelectionEditor({ selected }: { selected: SquigNode[] }) {
   const st = useSquig.getState
+  const focusedId = useSquig((s) => s.inspectorFocus?.id)
+  const focusedKey = useSquig((s) => s.inspectorFocus?.key)
   const multi = selected.length > 1
 
   /**
@@ -367,6 +371,18 @@ function SelectionEditor({ selected }: { selected: SquigNode[] }) {
   const controls = components.length === selected.length ? sharedControls(components) : []
   const variantControls = controls.filter((c) => c.type !== "text")
   const textControls = controls.filter((c) => c.type === "text")
+  const focusedControlIsHere =
+    !!focusedId &&
+    !!focusedKey &&
+    components.some((n) => n.id === focusedId) &&
+    variantControls.some((c) => c.key === focusedKey)
+
+  // The section can be folded between visits. A double-click on a drawn icon
+  // is an explicit request for one of its controls, so reveal the destination
+  // before IconControl moves keyboard focus into the search field.
+  useEffect(() => {
+    if (focusedControlIsHere) openPanelSection("variant")
+  }, [focusedControlIsHere])
 
   const textBoxState = shared(texts.map((n) => !!n.boxed))
   const textBoxBorder = shared(

--- a/components/ui/panel.tsx
+++ b/components/ui/panel.tsx
@@ -102,6 +102,12 @@ function toggleSection(id: string) {
   listeners.forEach((fn) => fn())
 }
 
+/** Reveal a section when the canvas hands one of its nested properties over. */
+export function openPanelSection(id: string) {
+  if (!collapsed.delete(id)) return
+  listeners.forEach((fn) => fn())
+}
+
 function useSectionOpen(id: string): boolean {
   return React.useSyncExternalStore(
     (fn) => {

--- a/lib/canvas/edit-target.ts
+++ b/lib/canvas/edit-target.ts
@@ -17,6 +17,11 @@
 // runs backed by a control count: a lorem line or a timestamp isn't a prop, so
 // aiming at one falls back to the first control rather than editing something
 // you weren't pointing at.
+//
+// Configurable icons use the same ownership rule. A component may draw several
+// structural glyphs around one editable icon; rendering its icon prop with a
+// marker tells us exactly which path belongs to the control, so a double-click
+// on that glyph can hand the real property to the inspector.
 // ---------------------------------------------------------------------------
 
 import { INK, type Prim } from "@/lib/sketch/kit"
@@ -28,6 +33,7 @@ import { normalizeInk } from "@/lib/types"
 import type { ComponentNode, SquigNode, TextAlign, TextNode } from "@/lib/types"
 
 type TextPrim = Extract<Prim, { t: "text" }>
+type IconPrim = Extract<Prim, { t: "path" }>
 
 export interface EditTarget {
   /** the string the editor starts on */
@@ -83,9 +89,18 @@ function textPrims(prims: Prim[]): TextPrim[] {
   return prims.filter((p): p is TextPrim => p.t === "text")
 }
 
+function iconPrims(prims: Prim[]): IconPrim[] {
+  return prims.filter((p): p is IconPrim => p.t === "path" && !!p.name)
+}
+
 /** Every text control a def declares, in the order the inspector lists them. */
 export function textControlKeys(node: ComponentNode): string[] {
   return (getDef(node.kind)?.controls ?? []).filter((c) => c.type === "text").map((c) => c.key)
+}
+
+/** Every searchable icon property a component exposes. */
+export function iconControlKeys(node: ComponentNode): string[] {
+  return (getDef(node.kind)?.controls ?? []).filter((c) => c.type === "icon").map((c) => c.key)
 }
 
 /** The text control an unaimed edit lands on — the first one the def declares. */
@@ -170,6 +185,54 @@ function runBox(p: TextPrim): { x0: number; y0: number; x1: number; y1: number }
 /** How far a point sits outside a box — zero anywhere inside it. */
 function gapTo(b: { x0: number; y0: number; x1: number; y1: number }, x: number, y: number): number {
   return Math.hypot(Math.max(b.x0 - x, 0, x - b.x1), Math.max(b.y0 - y, 0, y - b.y1))
+}
+
+/**
+ * Curated icons that are always available synchronously. We choose one the
+ * property is not already using, then look for that name in the marked render.
+ */
+const ICON_MARKERS = ["bug", "rocket-launch", "crown"] as const
+
+/** Which rendered icon paths are owned by one searchable icon control. */
+function iconRuns(node: ComponentNode, key: string, runs: IconPrim[]): number[] {
+  if (!runs.length) return []
+  const value = currentValue(node, key)
+  const marker = ICON_MARKERS.find((name) => name !== value) ?? ICON_MARKERS[0]
+  const marked = iconPrims(nodePrims({ ...node, props: { ...node.props, [key]: marker } }))
+
+  // A visible icon swapped for another icon keeps the path count and geometry.
+  // If a component uses the property as a visibility switch or has an invalid
+  // saved value, there is no drawn glyph to aim at, so declining the hit is the
+  // honest fallback.
+  if (marked.length !== runs.length) return []
+  return marked.flatMap((run, i) => (run.name === marker && runs[i]?.name !== marker ? [i] : []))
+}
+
+/**
+ * The searchable icon property whose drawn glyph sits under a component-local
+ * point. Structural carets, status marks, and other fixed glyphs return null.
+ */
+export function iconControlAt(node: ComponentNode, x: number, y: number): string | null {
+  const keys = iconControlKeys(node)
+  if (!keys.length) return null
+
+  const runs = iconPrims(nodePrims(node))
+  const owner = new Map<number, string>()
+  for (const key of keys) {
+    for (const i of iconRuns(node, key, runs)) if (!owner.has(i)) owner.set(i, key)
+  }
+
+  let best: string | null = null
+  let bestGap = Infinity
+  runs.forEach((run, i) => {
+    const key = owner.get(i)
+    if (!key) return
+    const gap = gapTo({ x0: run.x, y0: run.y, x1: run.x + run.size, y1: run.y + run.size }, x, y)
+    if (gap > Math.max(3, run.size * 0.15) || gap >= bestGap) return
+    bestGap = gap
+    best = key
+  })
+  return best
 }
 
 /**

--- a/lib/library/AUTHORING.md
+++ b/lib/library/AUTHORING.md
@@ -170,6 +170,33 @@ hand-waving crown seal-check`
 If you need a name that isn't listed, pick the nearest one that is. Do not
 invent names — an unknown name renders nothing.
 
+Any property whose value is an icon name must declare an `icon` control, not a
+`select` with a curated handful. That gives standalone icons, buttons, list
+items, cards, and blocks the same searchable catalog in the inspector:
+
+```ts
+defaults: { icon: "star" },
+controls: [{ key: "icon", label: "Icon", type: "icon" }],
+```
+
+Use `allowNone: true` when the renderer treats `"none"` as a real absence. An
+icon search is intentionally never `quick`: the floating context row cannot
+hold its search field and grid. Mode controls such as `Icon side:
+none|left|right` remain ordinary selects; their values are layout choices, not
+icon names.
+
+If another property decides whether the configurable icon is drawn, keep the
+large picker out of the way until that mode is active:
+
+```ts
+{ key: "glyph", label: "Icon", type: "icon",
+  visibleWhen: { key: "iconSide", equals: ["left", "right"] } }
+```
+
+Conditional controls only appear when every selected component currently
+matches its condition, so a multi-selection never offers a property that is
+latent on half the selection.
+
 ## Registration
 
 Export a single array at the bottom of your file:

--- a/lib/library/defs-basic.ts
+++ b/lib/library/defs-basic.ts
@@ -27,9 +27,9 @@ export const buttonDef: ComponentDef = {
     { key: "icon", label: "Icon side", type: "select", options: ["none", "left", "right"], quick: true },
     {
       key: "glyph",
-      label: "Glyph",
-      type: "select",
-      options: ["plus", "arrow-right", "arrow-left", "download-simple", "paper-plane-tilt", "sparkle"],
+      label: "Icon",
+      type: "icon",
+      visibleWhen: { key: "icon", equals: ["left", "right"] },
     },
   ],
   render(p, w, h) {
@@ -111,10 +111,11 @@ export const avatarDef: ComponentDef = {
   group: "Display",
   keywords: ["user", "profile", "photo", "person"],
   size: { w: 48, h: 48 },
-  defaults: { shape: "circle", content: "icon", initials: "PS", status: false },
+  defaults: { shape: "circle", content: "icon", glyph: "user", initials: "PS", status: false },
   controls: [
     { key: "shape", label: "Shape", type: "select", options: ["circle", "square"], quick: true },
     { key: "content", label: "Content", type: "select", options: ["icon", "initials"], quick: true },
+    { key: "glyph", label: "Icon", type: "icon", visibleWhen: { key: "content", equals: "icon" } },
     { key: "initials", label: "Initials", type: "text" },
     { key: "status", label: "Status dot", type: "toggle" },
   ],
@@ -125,7 +126,7 @@ export const avatarDef: ComponentDef = {
     if (str(p, "content") === "initials") {
       prims.push(text(w / 2, h / 2 + h * 0.14, str(p, "initials", "PS").slice(0, 2), h * 0.38, { align: "center" }))
     } else {
-      prims.push(...icon("user", w / 2, h / 2, Math.min(w, h) * 0.5))
+      prims.push(...icon(str(p, "glyph", "user"), w / 2, h / 2, Math.min(w, h) * 0.5))
     }
     if (bool(p, "status")) {
       prims.push(ellipse(w - w * 0.28, h - h * 0.28, w * 0.24, h * 0.24, { fill: "solid", fillColor: "ink" }))
@@ -148,7 +149,7 @@ export const inputDef: ComponentDef = {
     { key: "label", label: "Label", type: "text" },
     { key: "showLabel", label: "Show label", type: "toggle", quick: true },
     { key: "placeholder", label: "Placeholder", type: "text" },
-    { key: "icon", label: "Icon", type: "select", options: ["none", "search", "mail", "lock"], quick: true },
+    { key: "icon", label: "Icon", type: "icon", allowNone: true },
   ],
   render(p, w, h) {
     const showLabel = bool(p, "showLabel")

--- a/lib/library/defs-blocks-app.ts
+++ b/lib/library/defs-blocks-app.ts
@@ -1078,7 +1078,7 @@ export const emptyBlockDef: ComponentDef = {
   controls: [
     { key: "title", label: "Title", type: "text" },
     { key: "subtitle", label: "Subtitle", type: "text" },
-    { key: "icon", label: "Icon", type: "select", options: ["folder", "file", "magnifying-glass", "star", "sparkle", "bell"], quick: true },
+    { key: "icon", label: "Icon", type: "icon" },
     { key: "cta", label: "Button", type: "toggle", quick: true },
     { key: "ctaLabel", label: "Button label", type: "text" },
   ],

--- a/lib/library/defs-more.ts
+++ b/lib/library/defs-more.ts
@@ -82,9 +82,7 @@ export const iconButtonDef: ComponentDef = {
     {
       key: "icon",
       label: "Icon",
-      type: "select",
-      options: ["plus", "pencil-simple", "trash", "gear", "heart", "dots-three", "magnifying-glass", "bell"],
-      quick: true,
+      type: "icon",
     },
     { key: "variant", label: "Variant", type: "select", options: ["filled", "outline", "ghost"], quick: true },
     { key: "shape", label: "Shape", type: "select", options: ["square", "round"], quick: true },
@@ -182,7 +180,7 @@ export const fabDef: ComponentDef = {
   size: { w: 56, h: 56 },
   defaults: { icon: "plus", extended: false, label: "New note" },
   controls: [
-    { key: "icon", label: "Icon", type: "select", options: ["plus", "pencil-simple", "paper-plane-tilt", "camera", "chat-circle"], quick: true },
+    { key: "icon", label: "Icon", type: "icon" },
     { key: "extended", label: "Extended", type: "toggle", quick: true },
     { key: "label", label: "Label", type: "text" },
   ],
@@ -1228,7 +1226,7 @@ export const listItemDef: ComponentDef = {
     { key: "leading", label: "Leading", type: "select", options: ["avatar", "icon", "none"], quick: true },
     { key: "trailing", label: "Trailing", type: "select", options: ["chevron", "switch", "badge", "button", "meta", "none"], quick: true },
     { key: "trailingText", label: "Trailing text", type: "text" },
-    { key: "icon", label: "Icon", type: "select", options: ["folder", "file-text", "bell", "lock", "star", "clock"] },
+    { key: "icon", label: "Icon", type: "icon", visibleWhen: { key: "leading", equals: "icon" } },
     { key: "divider", label: "Divider", type: "toggle" },
   ],
   render(p, w, h) {
@@ -1559,9 +1557,9 @@ export const cardStatDef: ComponentDef = {
     { key: "showIcon", label: "Icon", type: "toggle", quick: true },
     {
       key: "icon",
-      label: "Glyph",
-      type: "select",
-      options: ["currency-dollar", "users", "chart-line", "shopping-cart", "clock", "eye"],
+      label: "Icon",
+      type: "icon",
+      visibleWhen: { key: "showIcon", equals: true },
     },
     { key: "spark", label: "Sparkline", type: "toggle", quick: true },
   ],
@@ -1950,7 +1948,7 @@ export const cardNotificationDef: ComponentDef = {
   defaults: { title: "Ada invited you to Squig", icon: "user-plus", actions: true, unread: true, timestamp: "2m" },
   controls: [
     { key: "title", label: "Title", type: "text" },
-    { key: "icon", label: "Icon", type: "select", options: ["user-plus", "bell", "chat-circle", "git-pull-request", "warning"], quick: true },
+    { key: "icon", label: "Icon", type: "icon" },
     { key: "actions", label: "Actions", type: "toggle", quick: true },
     { key: "unread", label: "Unread", type: "toggle", quick: true },
     { key: "timestamp", label: "Timestamp", type: "text" },

--- a/lib/library/defs-templates.ts
+++ b/lib/library/defs-templates.ts
@@ -453,7 +453,7 @@ export const emptyStateDef: ComponentDef = {
   defaults: { title: "Nothing here yet", cta: true, icon: "image" },
   controls: [
     { key: "title", label: "Title", type: "text" },
-    { key: "icon", label: "Icon", type: "select", options: ["image", "folder", "file", "magnifying-glass", "star", "sparkle", "bell"], quick: true },
+    { key: "icon", label: "Icon", type: "icon" },
     { key: "cta", label: "Button", type: "toggle", quick: true },
   ],
   render(p, w, h) {

--- a/lib/library/registry.ts
+++ b/lib/library/registry.ts
@@ -22,6 +22,10 @@ export interface ControlDef {
   label: string
   type: ControlType
   options?: string[]
+  /** `icon` controls may write the conventional "none" sentinel. */
+  allowNone?: boolean
+  /** only show this control while another prop has one of these values */
+  visibleWhen?: { key: string; equals: unknown | unknown[] }
   min?: number
   max?: number
   /** surfaced in the floating context row */

--- a/lib/selection.ts
+++ b/lib/selection.ts
@@ -16,6 +16,16 @@ export type Shared<T> = { mixed: true; value?: undefined } | { mixed: false; val
 
 export const MIXED = { mixed: true } as const
 
+/** A conditional control is only useful while its companion mode is active. */
+export function controlIsVisible(node: ComponentNode, control: ControlDef): boolean {
+  if (!control.visibleWhen) return true
+  const actual = resolveProp(node, control.visibleWhen.key)
+  const accepted = Array.isArray(control.visibleWhen.equals)
+    ? control.visibleWhen.equals
+    : [control.visibleWhen.equals]
+  return accepted.some((value) => Object.is(value, actual))
+}
+
 /**
  * Collapse a list of values to one shared value, or `mixed`.
  *
@@ -71,16 +81,19 @@ export function sharedControls(nodes: readonly ComponentNode[]): ControlDef[] {
   const out: ControlDef[] = []
 
   for (const control of first.controls) {
+    if (!controlIsVisible(nodes[0], control)) continue
     let options = control.options ? [...control.options] : undefined
     let quick = control.quick
     let min = control.min
     let max = control.max
+    let allowNone = control.allowNone
     let sameLabel = true
     let ok = true
 
-    for (const def of rest) {
+    for (let i = 0; i < rest.length; i++) {
+      const def = rest[i]
       const other = def.controls.find((c) => c.key === control.key)
-      if (!other || other.type !== control.type) {
+      if (!other || other.type !== control.type || !controlIsVisible(nodes[i + 1], other)) {
         ok = false
         break
       }
@@ -100,13 +113,22 @@ export function sharedControls(nodes: readonly ComponentNode[]): ControlDef[] {
           break
         }
       }
+      if (control.type === "icon") allowNone = allowNone && other.allowNone
       if (other.label !== control.label) sameLabel = false
       // only "quick" if every def agrees it belongs in the context row
       quick = quick && other.quick
     }
 
     if (!ok) continue
-    out.push({ ...control, label: sameLabel ? control.label : humanizeKey(control.key), options, quick, min, max })
+    out.push({
+      ...control,
+      label: sameLabel ? control.label : humanizeKey(control.key),
+      options,
+      quick,
+      min,
+      max,
+      allowNone,
+    })
   }
 
   return out

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -66,6 +66,13 @@ export interface ContextMenuState {
   nodeId: string | null
 }
 
+export interface InspectorFocus {
+  /** the selected component whose property should receive focus */
+  id: string
+  /** the component control key, not a DOM id */
+  key: string
+}
+
 interface SquigState {
   /** which file in the drawer this canvas is — every doc has one */
   docId: string
@@ -104,6 +111,8 @@ interface SquigState {
   contextMenu: ContextMenuState | null
   /** the floating file name is in its editable state */
   renamingFile: boolean
+  /** a canvas gesture is handing a nested component property to the inspector */
+  inspectorFocus: InspectorFocus | null
   /** a gesture is actively changing a layer's geometry — move, resize, draw, create */
   transforming: boolean
   /** ⌘\ — everything but the canvas gets out of the way */
@@ -156,6 +165,7 @@ interface SquigState {
   setCommandOpen: (open: boolean) => void
   setContextMenu: (m: ContextMenuState | null) => void
   setRenamingFile: (on: boolean) => void
+  setInspectorFocus: (target: InspectorFocus | null) => void
   setTransforming: (on: boolean) => void
   setUiHidden: (on: boolean) => void
   setShortcutsOpen: (on: boolean) => void
@@ -787,6 +797,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   commandOpen: false,
   contextMenu: null,
   renamingFile: false,
+  inspectorFocus: null,
   transforming: false,
   uiHidden: false,
   shortcutsOpen: false,
@@ -899,6 +910,7 @@ export const useSquig = create<SquigState>((set, get) => ({
     set({ commandOpen: open, contextMenu: null, shortcutsOpen: false, panel: open ? null : get().panel }),
   setContextMenu: (m) => set({ contextMenu: m }),
   setRenamingFile: (on) => set({ renamingFile: on }),
+  setInspectorFocus: (target) => set({ inspectorFocus: target }),
   // called on the edges of a drag, so the hundreds of moves in between don't
   // each write to the store
   setTransforming: (on) => set((s) => (s.transforming === on ? s : { transforming: on })),

--- a/scripts/test-defs.ts
+++ b/scripts/test-defs.ts
@@ -15,6 +15,7 @@
 
 import { ALL_DEFS, type ComponentDef } from "../lib/library/registry.ts"
 import type { Prim } from "../lib/sketch/kit.ts"
+import { resolveIconName } from "../lib/sketch/icons.ts"
 
 let passed = 0
 const failures: string[] = []
@@ -197,6 +198,37 @@ for (const def of ALL_DEFS) {
   // and a text field can't live there: it needs room to type in
   const quickText = def.controls.filter((c) => c.quick && c.type === "text").map((c) => c.key)
   check(`${def.kind} keeps text out of the quick row`, quickText.length === 0, quickText.join(", "))
+
+  // An icon-name select quietly limits the catalog to its authored handful.
+  // Searchable icon properties all use the same full picker; selects remain
+  // appropriate for modes such as "Icon side" or "Content: icon/initials".
+  const limitedIcons = def.controls
+    .filter((c) => c.type === "select" && /icon|glyph/i.test(c.label))
+    .filter((c) => (c.options ?? []).some((o) => !!resolveIconName(o)))
+    .map((c) => c.key)
+  check(`${def.kind} has no curated icon-name selects`, limitedIcons.length === 0, limitedIcons.join(", "))
+
+  const badIconDefaults = def.controls
+    .filter((c) => c.type === "icon")
+    .filter((c) => {
+      const value = String(def.defaults[c.key] ?? "")
+      return value !== "logo" && !(c.allowNone && value === "none") && !resolveIconName(value)
+    })
+    .map((c) => `${c.key}=${JSON.stringify(def.defaults[c.key])}`)
+  check(`${def.kind} icon controls have drawable defaults`, badIconDefaults.length === 0, badIconDefaults.join(", "))
+
+  const quickIcons = def.controls.filter((c) => c.type === "icon" && c.quick).map((c) => c.key)
+  check(`${def.kind} keeps icon search in the inspector`, quickIcons.length === 0, quickIcons.join(", "))
+
+  const orphanConditions = def.controls
+    .filter((c) => c.visibleWhen && !(c.visibleWhen.key in def.defaults))
+    .map((c) => `${c.key} → ${c.visibleWhen!.key}`)
+  check(`${def.kind} conditions refer to real props`, orphanConditions.length === 0, orphanConditions.join(", "))
+
+  const emptyConditions = def.controls
+    .filter((c) => c.visibleWhen && Array.isArray(c.visibleWhen.equals) && c.visibleWhen.equals.length === 0)
+    .map((c) => c.key)
+  check(`${def.kind} conditions allow at least one value`, emptyConditions.length === 0, emptyConditions.join(", "))
 }
 
 // -- phone screens ----------------------------------------------------------

--- a/scripts/test-edit-target.ts
+++ b/scripts/test-edit-target.ts
@@ -8,7 +8,15 @@
 // walk all 150 defs to make sure the aimed route didn't move the unaimed one.
 // ---------------------------------------------------------------------------
 
-import { editTarget, hasEditableText, textControlAt, textControlKey, textControlKeys } from "../lib/canvas/edit-target.ts"
+import {
+  editTarget,
+  hasEditableText,
+  iconControlAt,
+  iconControlKeys,
+  textControlAt,
+  textControlKey,
+  textControlKeys,
+} from "../lib/canvas/edit-target.ts"
 import { ALL_DEFS, getDef } from "../lib/library/registry.ts"
 import { nodePrims } from "../lib/sketch/node-prims.ts"
 import type { Prim } from "../lib/sketch/kit.ts"
@@ -29,6 +37,7 @@ function is(name: string, got: unknown, want: unknown) {
 // -- fixtures ---------------------------------------------------------------
 
 type TextPrim = Extract<Prim, { t: "text" }>
+type IconPrim = Extract<Prim, { t: "path" }>
 
 /** A library item dropped at its default size, with nothing overridden. */
 function drop(kind: string, props: Record<string, unknown> = {}): ComponentNode {
@@ -49,6 +58,14 @@ function drop(kind: string, props: Record<string, unknown> = {}): ComponentNode 
 
 function runs(node: ComponentNode): TextPrim[] {
   return nodePrims(node).filter((p): p is TextPrim => p.t === "text")
+}
+
+function icons(node: ComponentNode): IconPrim[] {
+  return nodePrims(node).filter((p): p is IconPrim => p.t === "path")
+}
+
+function iconMiddle(p: IconPrim): [number, number] {
+  return [p.x + p.size / 2, p.y + p.size / 2]
 }
 
 /**
@@ -174,6 +191,41 @@ function aimAt(node: ComponentNode, text: string, nth = 0): string | null {
   is(`${wordless.kind}: …and no words to step into`, hasEditableText(bare), false)
   is(`${wordless.kind}: …nor a control to name`, textControlKey(bare), null)
   is("button: unlike one that has a label", hasEditableText(button), true)
+}
+
+// -- configurable icons ----------------------------------------------------
+
+{
+  // A wordless icon button still has a nested property to step into. The
+  // pointer names that control from the drawn path, not from the component's
+  // kind or from a hard-coded list of special cases.
+  const iconButton = drop("icon-button")
+  is("icon button: one searchable icon control", iconControlKeys(iconButton).join(","), "icon")
+  const plus = icons(iconButton).find((p) => p.name === "plus")!
+  is("icon button: its drawn plus owns the icon control", iconControlAt(iconButton, ...iconMiddle(plus)), "icon")
+
+  // Conditional component icons only answer while they are actually drawn.
+  // A list item's avatar is structural; switching Leading to Icon reveals the
+  // configurable folder at the same spot.
+  const avatarItem = drop("list-item")
+  const user = icons(avatarItem).find((p) => p.name === "user")!
+  is("list item: its fixed avatar glyph is not editable", iconControlAt(avatarItem, ...iconMiddle(user)), null)
+
+  const iconItem = drop("list-item", { leading: "icon" })
+  const folder = icons(iconItem).find((p) => p.name === "folder")!
+  is("list item: its configurable leading icon is editable", iconControlAt(iconItem, ...iconMiddle(folder)), "icon")
+
+  // A stat card draws both an editable currency glyph and a structural trend
+  // arrow. Ownership keeps the arrow from opening the wrong control.
+  const stat = drop("card-stat")
+  const currency = icons(stat).find((p) => p.name === "currency-dollar")!
+  const trend = icons(stat).find((p) => p.name === "arrow-up")!
+  is("stat: its currency glyph owns the icon control", iconControlAt(stat, ...iconMiddle(currency)), "icon")
+  is("stat: its trend arrow is not the currency control", iconControlAt(stat, ...iconMiddle(trend)), null)
+
+  const avatar = drop("avatar")
+  const person = icons(avatar).find((p) => p.name === "user")!
+  is("avatar: its formerly fixed person glyph is now editable", iconControlAt(avatar, ...iconMiddle(person)), "glyph")
 }
 
 // -- an aim that isn't one ---------------------------------------------------

--- a/scripts/test-selection.ts
+++ b/scripts/test-selection.ts
@@ -93,8 +93,9 @@ check("an empty selection reads as mixed", shared([]).mixed === true)
 {
   const kind = Object.keys(REGISTRY).find((k) => REGISTRY[k].controls.length > 0)!
   const same = sharedControls([comp("a", kind), comp("b", kind)])
-  check("two of the same kind share all their controls", same.length === REGISTRY[kind].controls.length, kind)
-  check("one component shares its own controls", sharedControls([comp("a", kind)]).length === REGISTRY[kind].controls.length)
+  const one = sharedControls([comp("a", kind)])
+  check("two of the same kind share the same visible controls", same.map((c) => c.key).join(",") === one.map((c) => c.key).join(","), kind)
+  check("one component exposes at least one visible control", one.length > 0 && one.length <= REGISTRY[kind].controls.length)
   check("no components, no controls", sharedControls([]).length === 0)
 }
 
@@ -163,6 +164,32 @@ check("an empty selection reads as mixed", shared([]).mixed === true)
   } else {
     passed++ // registry has no type clashes today
   }
+}
+
+{
+  // "None" is only safe when every selected component knows that sentinel.
+  const twoOptional = sharedControls([comp("a", "input"), comp("b", "input")]).find((c) => c.key === "icon")
+  check("optional icon selections keep the None action", twoOptional?.type === "icon" && twoOptional.allowNone === true)
+
+  const mixedRequirement = sharedControls([comp("a", "input"), comp("b", "icon-button")]).find((c) => c.key === "icon")
+  check(
+    "mixed icon selections only offer None when every component allows it",
+    mixedRequirement?.type === "icon" && !mixedRequirement.allowNone
+  )
+}
+
+{
+  const bareButton = sharedControls([comp("a", "button")])
+  check("button hides its large icon picker while Icon side is None", !bareButton.some((c) => c.key === "glyph"))
+
+  const iconButton = sharedControls([comp("a", "button", { icon: "left" })])
+  check("button reveals icon search when an icon side is active", iconButton.some((c) => c.key === "glyph" && c.type === "icon"))
+
+  const mixedMode = sharedControls([comp("a", "button", { icon: "left" }), comp("b", "button")])
+  check("conditional controls stay hidden when only part of a selection shows them", !mixedMode.some((c) => c.key === "glyph"))
+
+  const initials = sharedControls([comp("a", "avatar", { content: "initials" })])
+  check("avatar hides icon search while it is showing initials", !initials.some((c) => c.key === "glyph"))
 }
 
 // -- summaries and bounds ---------------------------------------------------


### PR DESCRIPTION
## What changed

- replace every curated icon-name dropdown with the same searchable 1,500-icon picker used by standalone icons
- let a double-click on a configurable icon inside a component focus its real inspector control
- add a searchable icon choice to avatars and preserve optional “No icon” behavior for inputs
- hide large icon pickers while the component is showing another mode (no button icon, avatar initials, list avatar, hidden stat icon)
- guard icon metadata, mixed-selection behavior, and nested hit targeting with tests

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- browser verification: nested icon focus, folded-section reveal, arbitrary Phosphor selection, optional None, conditional picker visibility, no runtime errors