### PR TITLE
Resize selections with keyboard nudges

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Figma's, so your hands already know it. `?` opens the full list in the app.
 | `⇧H` / `⇧V` | flip horizontal / vertical |
 | `⌘B` `⌘I` `⌘U` | bold, italic, underline |
 | `⌘S` / `⇧⌘S` | save to this browser / export a copy |
-| arrows (`⇧` for 10px) | nudge |
+| arrows (`⇧` for the big nudge) | move by 1px / the custom big nudge (10px by default) |
+| `⌘`-arrows (`⇧` for the big nudge) | resize by 1px / the custom big nudge |
 | space-drag, middle-drag | pan |
 | `⌘+` / `⌘-`, `⌘`-scroll | zoom the canvas, never the browser |
 | `⇧0` `⇧1` `⇧2` | 100%, fit, selection |

--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -44,7 +44,7 @@ import { computeSnap, computeResizeSnap, makeSnapRect, type GuideLine, type Snap
 import { pinchViewport, type PinchStart, type Pt } from "@/lib/canvas/pinch"
 import { useSpacebarPan } from "@/lib/canvas/use-spacebar-pan"
 import { useFileDrop } from "@/lib/canvas/use-file-drop"
-import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, scaleNodes, type Handle } from "@/lib/canvas/transform"
+import { HANDLES, HANDLE_CURSORS, handleOffset, resizeBounds, resizeNodesBy, scaleNodes, type Handle } from "@/lib/canvas/transform"
 import { pickAt, pickInRect, pickSoftAt, type PickOpts } from "@/lib/canvas/hit-test"
 import { canvasOwnsKeyboard } from "@/lib/canvas/keyboard-owner"
 import { useClipboard } from "@/lib/canvas/use-clipboard"
@@ -61,6 +61,7 @@ import { ContextRow } from "./context-row"
 import { EmptyCanvas } from "./empty-canvas"
 import { TextEditOverlay } from "./text-edit-overlay"
 import { nodeVisualBounds, worldRouteHandle, type RouteHandle } from "@/lib/canvas/line-routing"
+import { SMALL_NUDGE } from "@/lib/nudge"
 
 /**
  * A gesture's zoom floor is not a constant: ⇧1 is allowed below MIN_ZOOM to
@@ -283,9 +284,15 @@ export function Canvas() {
   const containerRef = useRef<HTMLDivElement>(null)
   const gestureRef = useRef<Gesture | null>(null)
   const gestureAbort = useRef<AbortController | null>(null)
-  const nudgeRef = useRef<{ timer: ReturnType<typeof setTimeout> | null; sel: string; top: unknown }>({
+  const nudgeRef = useRef<{
+    timer: ReturnType<typeof setTimeout> | null
+    sel: string
+    kind: "move" | "resize"
+    top: unknown
+  }>({
     timer: null,
     sel: "",
+    kind: "move",
     top: null,
   })
   const modsRef = useRef<Mods>(NO_MODS)
@@ -1893,6 +1900,26 @@ export function Canvas() {
       // physical position, so on AZERTY it fires the tool printed elsewhere
       const key = e.key.length === 1 ? e.key.toLowerCase() : e.key
 
+      /** One held-key run is one undo step; changing command or selection is not. */
+      const beginNudge = (kind: "move" | "resize") => {
+        const sig = s.selection.join(",")
+        const nudge = nudgeRef.current
+        const separate =
+          nudge.timer === null ||
+          nudge.sel !== sig ||
+          nudge.kind !== kind ||
+          nudge.top !== s.past[s.past.length - 1]
+        if (nudge.timer !== null) clearTimeout(nudge.timer)
+        if (separate) {
+          s.checkpoint()
+          nudge.sel = sig
+          nudge.kind = kind
+          const after = st().past
+          nudge.top = after[after.length - 1]
+        }
+        nudge.timer = setTimeout(() => (nudge.timer = null), 900)
+      }
+
       // a gesture in flight owns the keyboard — including ⌘K, or the palette
       // opens over a drag that is still moving nodes underneath it, and the
       // Escape meant to close it gets eaten cancelling the drag instead
@@ -2007,13 +2034,28 @@ export function Canvas() {
             e.preventDefault()
             s.setUiHidden(!s.uiHidden)
             return
-          // the canvas ignores these, so stop the browser navigating away
           case "ArrowLeft":
           case "ArrowRight":
           case "ArrowUp":
-          case "ArrowDown":
+          case "ArrowDown": {
             e.preventDefault()
+            if (!s.selection.length) return
+            const selected = s.selection.map((id) => s.nodes[id]).filter(Boolean) as SquigNode[]
+            const bounds = unionBounds(selected.map(nodeVisualBounds))
+            if (!bounds) return
+            const amount = e.shiftKey ? s.bigNudge : SMALL_NUDGE
+            const axis = e.code === "ArrowLeft" || e.code === "ArrowRight" ? "width" : "height"
+            const delta = e.code === "ArrowLeft" || e.code === "ArrowUp" ? -amount : amount
+            const patches = resizeNodesBy(selected, bounds, axis, delta)
+            const changed = Object.entries(patches).some(([id, patch]) => {
+              const node = s.nodes[id] as unknown as Record<string, unknown> | undefined
+              return !!node && Object.entries(patch).some(([field, value]) => !Object.is(node[field], value))
+            })
+            if (!changed) return
+            beginNudge("resize")
+            s.updateNodes(patches)
             return
+          }
         }
         return // every other ⌘ combo is the browser's business
       }
@@ -2158,24 +2200,8 @@ export function Canvas() {
         case "ArrowDown": {
           if (!s.selection.length) break
           e.preventDefault()
-          // coalesce a burst of nudges into one undo step, but only while it's
-          // the same selection — otherwise ⌘Z reverts a move to another object
-          const sig = s.selection.join(",")
-          const nudge = nudgeRef.current
-          // the burst also has to still be writing against its own checkpoint.
-          // Compare the entry itself, not the stack depth: past is capped at
-          // MAX_HISTORY, so past a hundred edits the length stops changing and
-          // a count would happily coalesce onto someone else's entry.
-          if (nudge.timer === null || nudge.sel !== sig || nudge.top !== s.past[s.past.length - 1]) {
-            s.checkpoint()
-            nudge.sel = sig
-            const after = st().past
-            nudge.top = after[after.length - 1]
-          } else {
-            clearTimeout(nudge.timer)
-          }
-          nudge.timer = setTimeout(() => (nudge.timer = null), 900)
-          const d = e.shiftKey ? 10 : 1
+          beginNudge("move")
+          const d = e.shiftKey ? s.bigNudge : SMALL_NUDGE
           const dx = key === "ArrowLeft" ? -d : key === "ArrowRight" ? d : 0
           const dy = key === "ArrowUp" ? -d : key === "ArrowDown" ? d : 0
           const patches: Record<string, Partial<SquigNode>> = {}

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -56,6 +56,7 @@ import { kbd } from "@/lib/shortcuts"
 import { InkPicker } from "./ink-picker"
 import { bgOf, paletteOf, PAPER_SHADES, type FontMode, type PaperShade } from "@/lib/theme"
 import { LineStyleSegments } from "./line-style-controls"
+import { MAX_BIG_NUDGE, MIN_BIG_NUDGE } from "@/lib/nudge"
 
 // ---------------------------------------------------------------------------
 // Option sets. Declared out here so they aren't rebuilt on every keystroke.
@@ -220,6 +221,7 @@ function PageSettings() {
   const font = useSquig((s) => s.font)
   const theme = useSquig((s) => s.theme)
   const contextRow = useSquig((s) => s.contextRow)
+  const bigNudge = useSquig((s) => s.bigNudge)
   const nodes = useSquig((s) => s.nodes)
   const order = useSquig((s) => s.order)
   const st = useSquig.getState
@@ -289,6 +291,16 @@ function PageSettings() {
       </PanelSection>
 
       <PanelSection id="page-view" title="View">
+        <Row label="Big nudge">
+          <MixedNumberField
+            label="px"
+            min={MIN_BIG_NUDGE}
+            max={MAX_BIG_NUDGE}
+            className="w-[78px]"
+            shared={{ mixed: false, value: bigNudge }}
+            onCommit={(n) => st().setBigNudge(n)}
+          />
+        </Row>
         <Row spread label="Context menu">
           <Switch
             checked={contextRow}
@@ -297,7 +309,7 @@ function PageSettings() {
             className="scale-90"
           />
         </Row>
-        <PanelNote>quick controls float above the selection</PanelNote>
+        <PanelNote>Shift uses this step for move and resize nudges.</PanelNote>
       </PanelSection>
     </>
   )

--- a/lib/canvas/transform.ts
+++ b/lib/canvas/transform.ts
@@ -10,7 +10,7 @@ import type { SquigNode } from "../types"
 import type { Bounds } from "../selection"
 import { textBlockHeight, textContentWidth } from "../sketch/text-layout"
 import { wrapText } from "./text-metrics"
-import { textNaturalHeight } from "./text-reflow"
+import { setTextHeight, setTextWidth, textNaturalHeight } from "./text-reflow"
 
 export const HANDLES = ["nw", "n", "ne", "e", "se", "s", "sw", "w"] as const
 export type Handle = (typeof HANDLES)[number]
@@ -235,6 +235,35 @@ export function scaleNodes(
   }
 
   return patches
+}
+
+export type ResizeNudgeAxis = "width" | "height"
+
+/**
+ * Resize a selection from its right or bottom edge by an exact keyboard step.
+ * The top-left stays put, matching Figma's Cmd/Ctrl + arrow behavior. Text on
+ * its own keeps the same container semantics as its side handles; everything
+ * else goes through the selection scale used by pointer resizing.
+ */
+export function resizeNodesBy(
+  origNodes: readonly SquigNode[],
+  orig: Bounds,
+  axis: ResizeNudgeAxis,
+  delta: number
+): Record<string, Partial<SquigNode>> {
+  if (!origNodes.length || !Number.isFinite(delta) || delta === 0) return {}
+  const next: Bounds =
+    axis === "width"
+      ? { ...orig, w: Math.max(MIN_SIZE, orig.w + delta) }
+      : { ...orig, h: Math.max(MIN_SIZE, orig.h + delta) }
+  if (next.w === orig.w && next.h === orig.h) return {}
+
+  const solo = origNodes.length === 1 ? origNodes[0] : null
+  if (solo?.type === "text") {
+    const patch = axis === "width" ? setTextWidth(solo, next.w) : setTextHeight(solo, next.h)
+    return { [solo.id]: patch as Partial<SquigNode> }
+  }
+  return scaleNodes(origNodes, orig, next)
 }
 
 /** Handle offsets within a bbox of the given size, for the overlay. */

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -17,6 +17,7 @@
 
 import type { SquigNode } from "./types"
 import { canWrite } from "./tabs"
+import { DEFAULT_BIG_NUDGE, normalizeBigNudge } from "./nudge"
 import { DEFAULT_FONT, DEFAULT_LOOK, DEFAULT_PAPER, DEFAULT_THEME, THEMES, type FontMode, type Look, type PaperShade, type ThemeName } from "./theme"
 
 export interface FileMeta {
@@ -40,6 +41,8 @@ export interface Prefs {
   /** the last look you set — what a new document starts from, nothing more */
   look: Look
   contextRow: boolean
+  /** Shift's step for both move and resize nudges. */
+  bigNudge: number
   activeId: string | null
 }
 
@@ -245,6 +248,7 @@ export function loadPrefs(): Prefs {
     // prefs used to keep the look's fields flat, so read them either way
     look: knownLook(p.look ?? p, DEFAULT_LOOK),
     contextRow: p.contextRow === true,
+    bigNudge: normalizeBigNudge(p.bigNudge),
     activeId: typeof p.activeId === "string" ? p.activeId : null,
   }
 }
@@ -281,6 +285,7 @@ export function migrateLegacyDoc(newId: () => string): { doc: StoredDoc; prefs: 
   const prefs: Prefs = {
     look,
     contextRow: old.contextRow === true,
+    bigNudge: DEFAULT_BIG_NUDGE,
     activeId: doc.id,
   }
   savePrefs(prefs)

--- a/lib/nudge.ts
+++ b/lib/nudge.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// Keyboard nudge settings shared by moving and resizing.
+// ---------------------------------------------------------------------------
+
+export const SMALL_NUDGE = 1
+export const DEFAULT_BIG_NUDGE = 10
+export const MIN_BIG_NUDGE = 1
+export const MAX_BIG_NUDGE = 1000
+
+/** Storage and number fields are both outside the trust boundary. */
+export function normalizeBigNudge(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_BIG_NUDGE
+  return Math.min(MAX_BIG_NUDGE, Math.max(MIN_BIG_NUDGE, Math.round(value)))
+}

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -141,6 +141,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ["shift+v"], label: "Flip vertical" },
       { keys: ["←↑→↓"], label: "Nudge" },
       { keys: ["shift+←↑→↓"], label: "Nudge further" },
+      { keys: ["mod+←↑→↓"], label: "Resize by 1 px" },
+      { keys: ["mod+shift+←↑→↓"], label: "Resize by the big nudge" },
     ],
   },
   {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -41,6 +41,7 @@ import {
   type FileMeta,
 } from "./files"
 import { planTabSync } from "./tabs"
+import { DEFAULT_BIG_NUDGE, normalizeBigNudge } from "./nudge"
 
 // ---------------------------------------------------------------------------
 // Store — flat node map + z-order, selection, viewport, tool, history.
@@ -97,6 +98,8 @@ interface SquigState {
   /** the picture whose crop window is being dragged — see lib/canvas/crop */
   croppingId: string | null
   contextRow: boolean
+  /** Shift's configurable step for canvas move and resize nudges. */
+  bigNudge: number
   /* --- the look, kept flat so a control can subscribe to just its own knob.
      It belongs to the open document: every setter writes it back to the file,
      and opening another one brings that file's look with it. */
@@ -156,6 +159,7 @@ interface SquigState {
   /** put a squashed picture back on the ratio its pixels actually have */
   restoreAspect: (ids?: string[]) => void
   setContextRow: (on: boolean) => void
+  setBigNudge: (n: number) => void
   setTheme: (t: ThemeName) => void
   setFont: (f: FontMode) => void
   setPaper: (s: PaperShade) => void
@@ -598,7 +602,7 @@ function flushSave(get: () => SquigState, force = false) {
   const s = get()
   // the look goes to prefs too, but only as the default a new file will start
   // from — the copy that matters travels inside the document below
-  savePrefs({ look: lookOf(s), contextRow: s.contextRow, activeId: s.docId })
+  savePrefs({ look: lookOf(s), contextRow: s.contextRow, bigNudge: s.bigNudge, activeId: s.docId })
   // This tab has been told its document moved on without it. Not one more
   // write goes out until it is pointed at another document — ⌘S included,
   // since nobody pressing it is asking to throw away work they can't see.
@@ -792,6 +796,7 @@ export const useSquig = create<SquigState>((set, get) => ({
   editingId: null,
   croppingId: null,
   contextRow: false,
+  bigNudge: DEFAULT_BIG_NUDGE,
   ...DEFAULT_LOOK,
   hydrated: false,
   commandOpen: false,
@@ -868,6 +873,10 @@ export const useSquig = create<SquigState>((set, get) => ({
 
   setContextRow: (on) => {
     set({ contextRow: on })
+    scheduleSave(get)
+  },
+  setBigNudge: (n) => {
+    set({ bigNudge: normalizeBigNudge(n) })
     scheduleSave(get)
   },
   // each of these edits the open document, so each schedules a save
@@ -1275,6 +1284,7 @@ export const useSquig = create<SquigState>((set, get) => ({
       order: clean.order,
       files,
       contextRow: prefs.contextRow,
+      bigNudge: prefs.bigNudge,
       hydrated: true,
     })
     // the document's own look, or — for one saved before looks existed — the

--- a/scripts/test-files.ts
+++ b/scripts/test-files.ts
@@ -12,7 +12,18 @@
 // The one thing planSave can't answer is what happens when the *index* write
 // is the one refused, since planSave never sees it — so the last section drives
 // saveFile itself, over a localStorage that can be told to say no to one key.
-import { INDEX_KEY, MAX_FILES, listFiles, planSave, saveFile, type FileMeta, type StoredDoc } from "../lib/files.ts"
+import {
+  INDEX_KEY,
+  MAX_FILES,
+  listFiles,
+  loadPrefs,
+  planSave,
+  saveFile,
+  savePrefs,
+  type FileMeta,
+  type StoredDoc,
+} from "../lib/files.ts"
+import { DEFAULT_LOOK } from "../lib/theme.ts"
 
 let passed = 0
 const failures: string[] = []
@@ -149,6 +160,11 @@ function meta(id: string, updatedAt = 20_000, name = "in hand"): FileMeta {
     },
     removeItem: (k: string) => void store.delete(k),
   }
+
+  check("an older preference set gets the default big nudge", loadPrefs().bigNudge === 10)
+  savePrefs({ look: DEFAULT_LOOK, contextRow: false, bigNudge: 24, activeId: null })
+  check("a custom big nudge survives a preference round trip", loadPrefs().bigNudge === 24)
+  store.clear()
 
   const doc = (updatedAt: number, name = "d"): StoredDoc => ({ id: "d1", name, nodes: {}, order: [], updatedAt })
 

--- a/scripts/test-geometry.ts
+++ b/scripts/test-geometry.ts
@@ -7,7 +7,7 @@
 // bundler and no test framework.
 // ---------------------------------------------------------------------------
 
-import { resizeBounds, scaleNodes, MIN_SIZE, type Handle } from "../lib/canvas/transform.ts"
+import { resizeBounds, resizeNodesBy, scaleNodes, MIN_SIZE, type Handle } from "../lib/canvas/transform.ts"
 import { hitsInterior, hitsPoint, hitsRect, pickAt, pickInRect, pickSoftAt, pickTolerance } from "../lib/canvas/hit-test.ts"
 import { repeatStep } from "../lib/canvas/duplicate.ts"
 import type { SquigNode } from "../lib/types.ts"
@@ -74,6 +74,18 @@ const text = (id: string, x: number, y: number, w: number, h: number, fontSize =
   h,
   text: "hi",
   fontSize,
+  seed: 1,
+})
+
+const component = (id: string, x: number, y: number, w: number, h: number): SquigNode => ({
+  id,
+  type: "component",
+  kind: "button",
+  props: { label: "Go" },
+  x,
+  y,
+  w,
+  h,
   seed: 1,
 })
 
@@ -196,6 +208,74 @@ const apply = (ns: SquigNode[], patches: Record<string, Partial<SquigNode>>): Sq
   const a = [arrow("a", 0, 0, 10, 10)]
   const out = apply(a, scaleNodes(a, bounds(a), { x: 0, y: 0, w: 20, h: 40 })) as [SquigNode & { points: number[][] }]
   check("arrow points scale with the box", close(out[0].points[1][0], 20) && close(out[0].points[1][1], 40))
+}
+
+// -- keyboard resize nudges -------------------------------------------------
+
+{
+  const n = rect("r", 20, 30, 100, 50)
+  const wider = apply([n], resizeNodesBy([n], bounds([n]), "width", 1))[0]
+  check(
+    "a right resize nudge adds exactly one pixel and pins the top-left",
+    wider.x === 20 && wider.y === 30 && wider.w === 101 && wider.h === 50,
+    JSON.stringify(wider)
+  )
+
+  const shorter = apply([n], resizeNodesBy([n], bounds([n]), "height", -1))[0]
+  check(
+    "an up resize nudge removes exactly one pixel from height",
+    shorter.x === 20 && shorter.y === 30 && shorter.w === 100 && shorter.h === 49,
+    JSON.stringify(shorter)
+  )
+
+  const big = apply([n], resizeNodesBy([n], bounds([n]), "width", 10))[0]
+  check("the default big resize nudge adds ten pixels", close(big.w, 110), `${big.w}`)
+}
+
+{
+  const group = [
+    { ...rect("a", 10, 20, 40, 20), groupIds: ["g"] },
+    { ...component("b", 70, 20, 40, 20), groupIds: ["g"] },
+  ] as SquigNode[]
+  const from = bounds(group)
+  const resized = apply(group, resizeNodesBy(group, from, "width", 10))
+  const after = bounds(resized)
+  check(
+    "a group resize nudge changes the whole selection width by the requested step",
+    after.x === from.x && after.y === from.y && close(after.w, from.w + 10) && after.h === from.h,
+    JSON.stringify(after)
+  )
+  check(
+    "group members keep their relative layout while resizing",
+    close((resized[1].x - after.x) / after.w, (group[1].x - from.x) / from.w)
+  )
+}
+
+{
+  const n = component("component", 0, 0, 80, 32)
+  const taller = apply([n], resizeNodesBy([n], bounds([n]), "height", 10))[0]
+  check("a component accepts the big height nudge", taller.w === 80 && taller.h === 42, JSON.stringify(taller))
+}
+
+{
+  const n = rect("minimum", 0, 0, MIN_SIZE, 20)
+  check(
+    "a resize nudge at the minimum is a no-op",
+    Object.keys(resizeNodesBy([n], bounds([n]), "width", -1)).length === 0
+  )
+}
+
+{
+  const n = text("text", 5, 6, 100, 24)
+  const wider = apply([n], resizeNodesBy([n], bounds([n]), "width", 1))[0] as SquigNode & {
+    fixedW?: boolean
+    fontSize: number
+  }
+  check(
+    "a lone text resize uses its container width without scaling the type",
+    wider.x === n.x && wider.y === n.y && wider.w === 101 && wider.fixedW === true && wider.fontSize === 18,
+    JSON.stringify(wider)
+  )
 }
 
 // -- hit testing ------------------------------------------------------------

--- a/scripts/test-shortcuts.ts
+++ b/scripts/test-shortcuts.ts
@@ -12,6 +12,7 @@ import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { SHORTCUT_GROUPS, kbd } from "../lib/shortcuts.ts"
+import { DEFAULT_BIG_NUDGE, MAX_BIG_NUDGE, normalizeBigNudge } from "../lib/nudge.ts"
 
 let passed = 0
 const failures: string[] = []
@@ -91,6 +92,14 @@ check("a PC joins with pluses", kbd("mod+shift+g") === "Ctrl+Shift+G", kbd("mod+
 check("a PC needs no extra air", kbd("alt+drag") === "Alt+drag", kbd("alt+drag"))
 check("far is Ctrl+Shift on a PC", kbd("far+]") === "Ctrl+Shift+]", kbd("far+]"))
 
+// -- the configurable large step --------------------------------------------
+
+check("the big nudge defaults to ten pixels", DEFAULT_BIG_NUDGE === 10)
+check("an absent big nudge falls back safely", normalizeBigNudge(undefined) === 10)
+check("a custom big nudge is rounded to whole pixels", normalizeBigNudge(12.6) === 13)
+check("the big nudge never drops below one pixel", normalizeBigNudge(-20) === 1)
+check("a corrupt giant big nudge is bounded", normalizeBigNudge(Infinity) === 10 && normalizeBigNudge(99999) === MAX_BIG_NUDGE)
+
 // -- the sheet isn't describing a canvas that stopped doing it ---------------
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -107,6 +116,8 @@ const CLAIMS: [string, string][] = [
   ["double-click a corner handle to restore a picture", "restoreAspect"],
   ["shift-drag draws a square", 'mods.shift && g.what === "shape"'],
   ["the modifier wheel zooms", "e.ctrlKey || e.metaKey"],
+  ["modifier arrows resize the selection", "resizeNodesBy"],
+  ["Shift uses the custom big nudge", "s.bigNudge"],
 ]
 for (const [claim, token] of CLAIMS) {
   check(`the canvas still does ${claim}`, canvas.includes(token), token)


### PR DESCRIPTION
Adds Figma-style Command/Ctrl + arrow resizing for selected elements, groups, and components. Shift uses a persisted, customizable big-nudge step (10px by default), and held-key bursts collapse into one undo step.

Includes shortcut documentation, focused geometry and preference coverage, and browser verification for Mac and Windows modifier paths.

Validated with pnpm test, pnpm lint, and pnpm build.