### PR TITLE
Constrain Shift moves to 45-degree directions

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -63,6 +63,7 @@ import { EmptyCanvas } from "./empty-canvas"
 import { TextEditOverlay } from "./text-edit-overlay"
 import { nodeVisualBounds, worldRouteHandle, type RouteHandle } from "@/lib/canvas/line-routing"
 import { SMALL_NUDGE } from "@/lib/nudge"
+import { constrainMoveTo45, constrainSnapToDirection, type DragDirection } from "@/lib/canvas/move"
 
 /**
  * A gesture's zoom floor is not a constant: ⇧1 is allowed below MIN_ZOOM to
@@ -617,16 +618,15 @@ export function Canvas() {
 
         let dx = wx - g.wx
         let dy = wy - g.wy
-        let lockedAxis: "x" | "y" | null = null
+        let lockedDirection: DragDirection | null = null
         if (mods.shift) {
-          // axis lock, on whichever direction you committed to
-          if (Math.abs(dx) > Math.abs(dy)) {
-            dy = 0
-            lockedAxis = "y"
-          } else {
-            dx = 0
-            lockedAxis = "x"
-          }
+          // Eight-way lock: horizontal, vertical, or either 45-degree diagonal.
+          // Recompute from the gesture origin so releasing Shift returns to
+          // the pointer without accumulated drift.
+          const constrained = constrainMoveTo45(dx, dy)
+          dx = constrained.dx
+          dy = constrained.dy
+          lockedDirection = constrained.direction
         }
 
         let minX = Infinity
@@ -656,12 +656,29 @@ export function Canvas() {
             (maxY - minY) * v.zoom
           )
           const snap = computeSnap(dragged, collectCandidates(ids), SNAP_THRESHOLD)
-          // a locked axis stays locked; only the free one may be nudged
-          sdx = lockedAxis === "x" ? 0 : snap.dx
-          sdy = lockedAxis === "y" ? 0 : snap.dy
-          setGuides(
-            snap.guides.filter((gl) => (lockedAxis === "x" ? gl.axis !== "x" : lockedAxis === "y" ? gl.axis !== "y" : true))
-          )
+          if (lockedDirection) {
+            // A guide may move a constrained drag, but only along its locked
+            // line. Independent x/y corrections would turn 45° into 44.8°.
+            let hasXGuide = false
+            let hasYGuide = false
+            for (const guide of snap.guides) {
+              if (guide.axis === "x") hasXGuide = true
+              else hasYGuide = true
+            }
+            const constrainedSnap = constrainSnapToDirection(lockedDirection, snap, {
+              x: hasXGuide,
+              y: hasYGuide,
+            })
+            sdx = constrainedSnap.dx
+            sdy = constrainedSnap.dy
+            setGuides(
+              snap.guides.filter((guide) => (guide.axis === "x" ? constrainedSnap.useX : constrainedSnap.useY))
+            )
+          } else {
+            sdx = snap.dx
+            sdy = snap.dy
+            setGuides(snap.guides)
+          }
         } else {
           setGuides([])
         }
@@ -1237,7 +1254,7 @@ export function Canvas() {
       // a lost window means we'll never see the release; keep the work
       window.addEventListener("blur", finishGesture, opts)
 
-      // modifiers are live: pressing Shift mid-drag locks the axis now, not on
+      // modifiers are live: pressing Shift mid-drag locks the direction now, not on
       // the next pixel of mouse movement
       const onModKey = (ev: KeyboardEvent) => {
         if (ev.key === "Escape") {

--- a/docs/multiselect-spec.md
+++ b/docs/multiselect-spec.md
@@ -36,7 +36,7 @@ Legend: **[new]** to build, **[has]** already works, **[fix]** exists but wrong.
 | B3 | **Shift+click** on a selected node removes it | [has] |
 | B4 | **Ctrl+click and Cmd+click behave as Shift+click** (toggle). squig has no nesting, so "deep select" is meaningless. | [new] |
 | B5 | On macOS this deliberately diverges from Figma, where Ctrl+click is the OS right-click: it was asked for explicitly, and a two-finger tap or a real right-click still opens the context menu, so nothing is lost. Ctrl+click therefore suppresses the menu under the select tool. | [new] |
-| B5b | **Shift+drag axis-locks a move** to whichever axis you committed to. Composes with B6 (a shift-click that adds, then drags, is locked) and with Alt (axis-locked duplicate) | [new] |
+| B5b | **Shift+drag locks a move to the nearest 45-degree direction**: horizontal, vertical, or diagonal. Composes with B6 (a shift-click that adds, then drags, is locked), Alt (constrained duplicate), and smart guides without letting a snap pull the move off-angle. | [has] |
 | B5c | **Cmd/Ctrl held during a move or resize bypasses snapping** — the escape hatch from a magnetised board | [new] |
 | B6 | **Additive click can immediately drag.** After a shift/ctrl-click that *adds* a node, the pointer is already in a move gesture for the whole selection. A shift-click that *removes* does not drag. | [fix] |
 | B7 | **Click on an already-multi-selected node does not collapse the selection on pointer-down** — it starts a drag of the whole selection. Only a pointer-*up* with no movement collapses to that single node. (Classic Figma/Sketch behaviour.) | [new] |

--- a/lib/canvas/move.ts
+++ b/lib/canvas/move.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// Move constraint maths — pure, so pointer gestures and their tests agree.
+// ---------------------------------------------------------------------------
+
+export type DirectionStep = -1 | 0 | 1
+
+/** One of the eight 45-degree directions around a drag's starting point. */
+export interface DragDirection {
+  x: DirectionStep
+  y: DirectionStep
+}
+
+export interface ConstrainedMove {
+  dx: number
+  dy: number
+  direction: DragDirection
+}
+
+export interface DirectionalSnap {
+  dx: number
+  dy: number
+  /** guide axes whose correction the constrained move actually accepted */
+  useX: boolean
+  useY: boolean
+}
+
+/** tan(22.5°), the boundary halfway between an axis and a diagonal. */
+const OCTANT_BOUNDARY = Math.SQRT2 - 1
+const SAME_SNAP = 1e-6
+
+/**
+ * Project a pointer delta onto its nearest 45-degree line.
+ *
+ * Projection, rather than keeping the pointer's radial distance, puts the
+ * constrained object at the point on that line closest to the pointer. That
+ * keeps Shift engaging and disengaging without an avoidable jump.
+ */
+export function constrainMoveTo45(dx: number, dy: number): ConstrainedMove {
+  if (dx === 0 && dy === 0) return { dx: 0, dy: 0, direction: { x: 0, y: 0 } }
+
+  const absX = Math.abs(dx)
+  const absY = Math.abs(dy)
+  if (absY <= absX * OCTANT_BOUNDARY) {
+    return { dx, dy: 0, direction: { x: Math.sign(dx) as DirectionStep, y: 0 } }
+  }
+  if (absX <= absY * OCTANT_BOUNDARY) {
+    return { dx: 0, dy, direction: { x: 0, y: Math.sign(dy) as DirectionStep } }
+  }
+
+  // Projecting onto y=±x averages the two absolute components.
+  const distance = (absX + absY) / 2
+  const direction: DragDirection = {
+    x: Math.sign(dx) as DirectionStep,
+    y: Math.sign(dy) as DirectionStep,
+  }
+  return {
+    dx: distance * direction.x,
+    dy: distance * direction.y,
+    direction,
+  }
+}
+
+/**
+ * Keep smart-guide correction on a constrained line.
+ *
+ * A diagonal move cannot accept independent x/y snap deltas: doing so would
+ * make the result almost, but not exactly, 45 degrees. Turn each available
+ * axis snap into travel along the locked direction and take the nearer one.
+ */
+export function constrainSnapToDirection(
+  direction: DragDirection,
+  snap: { dx: number; dy: number },
+  availableAxes: { x: boolean; y: boolean }
+): DirectionalSnap {
+  const xDistance = direction.x !== 0 && availableAxes.x ? snap.dx / direction.x : null
+  const yDistance = direction.y !== 0 && availableAxes.y ? snap.dy / direction.y : null
+
+  let distance: number
+  if (xDistance === null) {
+    if (yDistance === null) return { dx: 0, dy: 0, useX: false, useY: false }
+    distance = yDistance
+  } else if (yDistance === null || Math.abs(xDistance) <= Math.abs(yDistance)) distance = xDistance
+  else distance = yDistance
+
+  return {
+    dx: distance * direction.x,
+    dy: distance * direction.y,
+    useX: xDistance !== null && Math.abs(xDistance - distance) <= SAME_SNAP,
+    useY: yDistance !== null && Math.abs(yDistance - distance) <= SAME_SNAP,
+  }
+}

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -112,7 +112,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     // does shift do while I drag?" has one place to look.
     title: "While you drag",
     rows: [
-      { keys: ["shift+drag"], label: "Keep the move to one axis" },
+      { keys: ["shift+drag"], label: "Move in 45° directions" },
       { keys: ["alt+drag"], label: "Drag off a copy" },
       { keys: ["mod+drag"], label: "Ignore the snapping" },
       { keys: ["shift+drag"], label: "Resize in proportion" },

--- a/scripts/test-geometry.ts
+++ b/scripts/test-geometry.ts
@@ -10,6 +10,7 @@
 import { resizeBounds, resizeNodesBy, scaleNodes, MIN_SIZE, type Handle } from "../lib/canvas/transform.ts"
 import { hitsInterior, hitsPoint, hitsRect, pickAt, pickInRect, pickSoftAt, pickTolerance } from "../lib/canvas/hit-test.ts"
 import { repeatStep } from "../lib/canvas/duplicate.ts"
+import { constrainMoveTo45, constrainSnapToDirection } from "../lib/canvas/move.ts"
 import type { SquigNode } from "../lib/types.ts"
 
 let passed = 0
@@ -99,6 +100,66 @@ const bounds = (ns: SquigNode[]) => {
 
 const apply = (ns: SquigNode[], patches: Record<string, Partial<SquigNode>>): SquigNode[] =>
   ns.map((n) => ({ ...n, ...patches[n.id] }) as SquigNode)
+
+// -- move constraints -------------------------------------------------------
+
+{
+  const still = constrainMoveTo45(0, 0)
+  check(
+    "shift-move at the origin stays finite and still",
+    still.dx === 0 && still.dy === 0 && still.direction.x === 0 && still.direction.y === 0,
+    JSON.stringify(still)
+  )
+
+  const horizontal = constrainMoveTo45(100, 20)
+  check(
+    "shift-move locks a near-horizontal drag to 0 degrees",
+    close(horizontal.dx, 100) && close(horizontal.dy, 0) && horizontal.direction.x === 1 && horizontal.direction.y === 0,
+    JSON.stringify(horizontal)
+  )
+
+  const vertical = constrainMoveTo45(-10, -80)
+  check(
+    "shift-move locks a near-vertical drag to 90 degrees",
+    close(vertical.dx, 0) && close(vertical.dy, -80) && vertical.direction.x === 0 && vertical.direction.y === -1,
+    JSON.stringify(vertical)
+  )
+
+  const diagonal = constrainMoveTo45(50, 40)
+  check(
+    "shift-move projects onto the nearest 45-degree diagonal",
+    close(diagonal.dx, 45) && close(diagonal.dy, 45) && diagonal.direction.x === 1 && diagonal.direction.y === 1,
+    JSON.stringify(diagonal)
+  )
+
+  const reverseDiagonal = constrainMoveTo45(-60, 40)
+  check(
+    "all diagonal quadrants keep equal absolute deltas",
+    close(reverseDiagonal.dx, -50) && close(reverseDiagonal.dy, 50) && reverseDiagonal.direction.x === -1 && reverseDiagonal.direction.y === 1,
+    JSON.stringify(reverseDiagonal)
+  )
+
+  const snapped = constrainSnapToDirection(diagonal.direction, { dx: 2, dy: -5 }, { x: true, y: true })
+  check(
+    "smart guides cannot pull a diagonal move off 45 degrees",
+    close(snapped.dx, 2) && close(snapped.dy, 2) && snapped.useX && !snapped.useY,
+    JSON.stringify(snapped)
+  )
+
+  const verticalSnap = constrainSnapToDirection(vertical.direction, { dx: 1, dy: 3 }, { x: true, y: true })
+  check(
+    "a vertical lock only accepts vertical travel from smart guides",
+    close(verticalSnap.dx, 0) && close(verticalSnap.dy, 3) && !verticalSnap.useX && verticalSnap.useY,
+    JSON.stringify(verticalSnap)
+  )
+
+  const cornerSnap = constrainSnapToDirection(diagonal.direction, { dx: 3, dy: 3 }, { x: true, y: true })
+  check(
+    "one diagonal correction can satisfy both smart guides",
+    close(cornerSnap.dx, 3) && close(cornerSnap.dy, 3) && cornerSnap.useX && cornerSnap.useY,
+    JSON.stringify(cornerSnap)
+  )
+}
 
 // -- resizeBounds -----------------------------------------------------------
 

--- a/scripts/test-shortcuts.ts
+++ b/scripts/test-shortcuts.ts
@@ -107,7 +107,7 @@ const canvas = readFileSync(join(here, "../components/canvas/canvas.tsx"), "utf8
 
 // each claim, and the thing in the canvas that has to be there for it to hold
 const CLAIMS: [string, string][] = [
-  ["shift-drag axis lock", "lockedAxis"],
+  ["shift-drag 45-degree lock", "constrainMoveTo45"],
   ["shift-resize proportion lock", "aspect: lockAspect"],
   ["alt-resize from the middle", "fromCenter: mods.alt"],
   ["the modifier that skips snapping", "!mods.toggle"],


### PR DESCRIPTION
Summary:
- constrain Shift-drag movement to horizontal, vertical, and diagonal 45-degree paths
- keep smart-guide corrections on the locked path
- document the interaction and cover movement/snap edge cases

Verification:
- pnpm test
- pnpm lint
- pnpm build
- browser Shift-drag: 100x60 pointer delta resolved to exact 80x80 movement