### PR TITLE
Stand the workspace engine on lib/doc.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,12 +92,12 @@ then change it.
 the file drawer's calls into `lib/files.ts`. Edits go through the store so
 history and autosave stay honest.
 
-**`lib/doc.ts`** and **`lib/agent/engine.ts`** are two implementations of the
-same rules. Both vouch every node through `validNode` before it reaches a
-canvas; past that gate one is a pure local document and the other is the
-workspace's command engine, with revisions and a database behind it. A rule
-that changes has to change twice, which is the cost of having both. The
-follow-up is the engine standing on `lib/doc.ts`, not a third copy.
+**`lib/doc.ts`** is where a node rule lives, and **`lib/agent/engine.ts`**
+stands on it. The engine keeps only what is its own: zod at the API boundary,
+revisions, variations, and the workspace's policy about locked nodes and
+status codes. Everything past that boundary is `vouchNode`, `addNodes`,
+`updateNode`, `removeNodes` and `groupNodes`, so a rule that changes changes
+once and the agent's canvas behaves like the one in the browser.
 
 **`lib/sketch/svg.ts`** is the only thing that turns nodes into SVG markup. The
 image export, the CLI, `window.squig` and the workspace's PNG all print through

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // scratch worktrees carry their own .next/ and out/, which the patterns
+    // above only match at the root
+    ".claude/**",
   ]),
 ]);
 

--- a/lib/agent/docs.ts
+++ b/lib/agent/docs.ts
@@ -152,7 +152,7 @@ export const pages: DocPage[] = [
       },
       {
         title: "Compose and arrange",
-        text: "duplicate clones nodes with remapped group and connector IDs and dx/dy offsets. group prepends a group path; ungroup removes one outer path level. detach converts component drawing primitives into editable nodes. align supports left, right, top, bottom, hcenter and vcenter. distribute uses x or y and even gaps. reorder supports front, back, forward and backward. flip mirrors a node’s visual content horizontally or vertically. Use update geometry for moving an entire composition; no DOM or CSS layout engine is involved.",
+        text: "duplicate clones nodes with remapped group and connector IDs and dx/dy offsets. group wraps the named nodes in one new group beneath the parent they already share, skipping locked ones, and refuses when there is nothing to group; a group left with a single member dissolves. ungroup removes one outer path level. detach converts component drawing primitives into editable nodes. align supports left, right, top, bottom, hcenter and vcenter. distribute uses x or y and even gaps. reorder supports front, back, forward and backward. flip mirrors a node’s visual content horizontally or vertically. Use update geometry for moving an entire composition; no DOM or CSS layout engine is involved.",
       },
       {
         title: "Locked nodes and explicit scope",

--- a/lib/agent/engine.ts
+++ b/lib/agent/engine.ts
@@ -4,14 +4,15 @@ import {
   DocError,
   bringToFront,
   emptyDoc,
-  groupNodes,
   patchNode,
   sendToBack,
+  stampGroup,
   textNode,
   vouchNode,
 } from "@/lib/doc"
 import { pruneDegenerateGroups } from "@/lib/canvas/groups"
 import type { TextMeasurer } from "@/lib/canvas/text-metrics"
+import type { FontMode } from "@/lib/theme"
 import { textMeasurer } from "./text-metrics"
 import { getDef } from "@/lib/library/registry"
 import { breakApart } from "@/lib/library/break-apart"
@@ -130,8 +131,16 @@ export function applyOperations(
   // add name a box the next add brings, the way it always could.
   let d = structuredClone(original)
   // the real faces, so a note wraps here exactly where the render breaks it;
-  // read off the document as it stands, since a look op may have changed it
-  const measure: TextMeasurer = (text, style) => textMeasurer(d.look.font)(text, style)
+  // chosen by the document as it stands, since a look op may have changed
+  // it, and kept per face because a measurer carries a width cache worth
+  // keeping across the thousand probes a long note costs
+  const measurers = new Map<FontMode, TextMeasurer>()
+  const measure: TextMeasurer = (text, style) => {
+    const font = d.look.font
+    let m = measurers.get(font)
+    if (!m) measurers.set(font, (m = textMeasurer(font)))
+    return m(text, style)
+  }
   const createdIds: string[] = []
   const members = (ids: string[], allowLocked = false) =>
     [...new Set(ids)].map((id) => {
@@ -258,13 +267,15 @@ export function applyOperations(
       }
       case "group": {
         members(op.ids, true)
-        const grouped = withDoc(() => groupNodes(d, op.ids, op.groupId))
+        // stamp only: pruning waits for validateDocument, or grouping two
+        // things here could dissolve a group the batch is still rebuilding
+        const grouped = stampGroup(d, op.ids, op.groupId ?? nanoid(12))
         if (!grouped)
           throw new AgentError(
             400,
             "Nothing to group: needs two or more unlocked nodes that are not already one group",
           )
-        d = grouped.doc as CanvasDocument
+        d = grouped as CanvasDocument
         break
       }
       case "ungroup":

--- a/lib/agent/engine.ts
+++ b/lib/agent/engine.ts
@@ -2,16 +2,16 @@ import { lookSchema, nodeFields } from "./schema"
 import { nanoid } from "nanoid"
 import {
   DocError,
-  addNodes,
   bringToFront,
   emptyDoc,
   groupNodes,
-  removeNodes,
+  patchNode,
   sendToBack,
   textNode,
-  updateNode,
   vouchNode,
 } from "@/lib/doc"
+import { pruneDegenerateGroups } from "@/lib/canvas/groups"
+import type { TextMeasurer } from "@/lib/canvas/text-metrics"
 import { textMeasurer } from "./text-metrics"
 import { getDef } from "@/lib/library/registry"
 import { breakApart } from "@/lib/library/break-apart"
@@ -43,18 +43,13 @@ export function emptyDocument(name: string): CanvasDocument {
 const safeId = (s: string) =>
   /^[a-zA-Z0-9_-]{1,80}$/.test(s) &&
   !["__proto__", "constructor", "prototype"].includes(s)
-/**
- * lib/doc refuses in sentences; the workspace refuses in status codes. Every
- * refusal here is something the caller sent, so it leaves as a 400 — except a
- * name that is already on the sheet, which this API has always answered 409.
- */
+/** lib/doc refuses in sentences; the workspace refuses in status codes. */
 function withDoc<T>(fn: () => T): T {
   try {
     return fn()
   } catch (error) {
     if (!(error instanceof DocError)) throw error
-    const taken = error.message.startsWith("there is already a node called")
-    throw new AgentError(taken ? 409 : 400, error.message)
+    throw new AgentError(400, error.message)
   }
 }
 /**
@@ -117,7 +112,9 @@ export function validateDocument(doc: CanvasDocument): CanvasDocument {
     throw new AgentError(413, "Document exceeds 4 MB")
   return {
     ...doc,
-    nodes: settleBinds(nodes),
+    // the batch's invariants, kept once at the end rather than after every
+    // step: a group of one dissolves, an arrow follows its boxes or lets go
+    nodes: settleBinds(pruneDegenerateGroups(nodes)),
     variations: doc.variations.filter((v) =>
       v.nodeIds.every((id) => Object.hasOwn(nodes, id)),
     ),
@@ -127,12 +124,14 @@ export function applyOperations(
   original: CanvasDocument,
   operations: Operation[],
 ): { document: CanvasDocument; createdIds: string[] } {
-  // lib/doc hands back a new document every time, but align, distribute and
-  // flip still write through the node objects, so the batch owns a copy and a
-  // refused operation leaves the caller's document where it was.
+  // The batch owns a copy, so a refused operation leaves the caller's
+  // document where it was. Steps write into the map and validateDocument
+  // settles the whole thing at the end — which is what lets an arrow in one
+  // add name a box the next add brings, the way it always could.
   let d = structuredClone(original)
-  // the real faces, so a note wraps here exactly where the render breaks it
-  const measure = textMeasurer(original.look.font)
+  // the real faces, so a note wraps here exactly where the render breaks it;
+  // read off the document as it stands, since a look op may have changed it
+  const measure: TextMeasurer = (text, style) => textMeasurer(d.look.font)(text, style)
   const createdIds: string[] = []
   const members = (ids: string[], allowLocked = false) =>
     [...new Set(ids)].map((id) => {
@@ -143,11 +142,14 @@ export function applyOperations(
         throw new AgentError(409, `Node is locked: ${id}; unlock it explicitly`)
       return n
     })
-  // one call per batch of new nodes: a group only survives the trip if all of
-  // its members arrive together, since a group of one is not a group
   const place = (nodes: readonly SquigNode[]) => {
-    d = withDoc(() => addNodes(d, nodes)) as CanvasDocument
-    for (const n of nodes) createdIds.push(n.id)
+    for (const n of nodes) {
+      if (Object.hasOwn(d.nodes, n.id))
+        throw new AgentError(409, `there is already a node called "${n.id}"`)
+      d.nodes[n.id] = n
+      d.order.push(n.id)
+      createdIds.push(n.id)
+    }
   }
   for (const op of operations) {
     switch (op.op) {
@@ -199,21 +201,29 @@ export function applyOperations(
       }
       case "update":
         for (const { id, patch, unset } of op.patches) {
-          members(
+          const n = members(
             [id],
             patch.locked === false &&
               Object.keys(patch).length === 1 &&
               !unset?.length,
-          )
+          )[0]
           if (patch.id !== undefined || patch.type !== undefined)
             throw new AgentError(400, "Node id and type are immutable")
           const changes = {
             ...patch,
             ...Object.fromEntries((unset ?? []).map((f) => [f, undefined])),
           } as Partial<SquigNode>
-          d = withDoc(() =>
-            updateNode(d, id, changes, measure),
-          ) as CanvasDocument
+          // zod first: a patch is an untyped record, and the text fitter
+          // would choke on words that aren't a string before the gate saw them
+          const parsed = nodeFields.safeParse({ ...n, ...changes })
+          if (!parsed.success)
+            throw new AgentError(
+              400,
+              parsed.error.issues
+                .map((i) => `${i.path.join(".")}: ${i.message}`)
+                .join("; "),
+            )
+          d.nodes[id] = withDoc(() => patchNode(n, changes, measure))
         }
         break
       case "remove_variation":
@@ -221,11 +231,10 @@ export function applyOperations(
           throw new AgentError(404, "Variation not found")
         d.variations = d.variations.filter((v) => v.id !== op.id)
         break
-      case "delete": {
-        const ids = members(op.ids).map((n) => n.id)
-        d = withDoc(() => removeNodes(d, ids)) as CanvasDocument
+      case "delete":
+        for (const n of members(op.ids)) delete d.nodes[n.id]
+        d.order = d.order.filter((id) => !op.ids.includes(id))
         break
-      }
       case "duplicate": {
         const originals = members(op.ids, true)
         const ids = new Map(originals.map((n) => [n.id, nanoid(12)]))
@@ -273,13 +282,12 @@ export function applyOperations(
               groupIds: n.groupIds,
             } as unknown as Record<string, unknown>),
           )
-          d = withDoc(() => removeNodes(d, [n.id])) as CanvasDocument
+          delete d.nodes[n.id]
+          d.order.splice(at, 1)
           place(parts)
           // the parts landed on top; they belong where the component stood
-          const ids = parts.map((p) => p.id)
-          const fresh = new Set(ids)
-          const rest = d.order.filter((id) => !fresh.has(id))
-          d = { ...d, order: [...rest.slice(0, at), ...ids, ...rest.slice(at)] }
+          if (parts.length) d.order.splice(-parts.length)
+          d.order.splice(at, 0, ...parts.map((p) => p.id))
         }
         break
       case "flip":

--- a/lib/agent/engine.ts
+++ b/lib/agent/engine.ts
@@ -1,11 +1,23 @@
 import { lookSchema, nodeFields } from "./schema"
 import { nanoid } from "nanoid"
-import { validNode } from "@/lib/clipboard-payload"
+import {
+  DocError,
+  addNodes,
+  bringToFront,
+  emptyDoc,
+  groupNodes,
+  removeNodes,
+  sendToBack,
+  textNode,
+  updateNode,
+  vouchNode,
+} from "@/lib/doc"
+import { textMeasurer } from "./text-metrics"
 import { getDef } from "@/lib/library/registry"
 import { breakApart } from "@/lib/library/break-apart"
 import { settleBinds, remapBinds } from "@/lib/canvas/arrow-binding"
 import { unionBox, type SquigNode, type SquigDoc } from "@/lib/types"
-import { DEFAULT_LOOK, THEMES, type Look } from "@/lib/theme"
+import { THEMES, type Look } from "@/lib/theme"
 import type { Operation } from "./schema"
 
 export class AgentError extends Error {
@@ -26,17 +38,31 @@ export interface CanvasDocument extends SquigDoc {
   variations: Variation[]
 }
 export function emptyDocument(name: string): CanvasDocument {
-  return {
-    fileName: name,
-    nodes: {},
-    order: [],
-    look: { ...DEFAULT_LOOK },
-    variations: [],
-  }
+  return { ...emptyDoc(name), variations: [] }
 }
 const safeId = (s: string) =>
   /^[a-zA-Z0-9_-]{1,80}$/.test(s) &&
   !["__proto__", "constructor", "prototype"].includes(s)
+/**
+ * lib/doc refuses in sentences; the workspace refuses in status codes. Every
+ * refusal here is something the caller sent, so it leaves as a 400 — except a
+ * name that is already on the sheet, which this API has always answered 409.
+ */
+function withDoc<T>(fn: () => T): T {
+  try {
+    return fn()
+  } catch (error) {
+    if (!(error instanceof DocError)) throw error
+    const taken = error.message.startsWith("there is already a node called")
+    throw new AgentError(taken ? 409 : 400, error.message)
+  }
+}
+/**
+ * A node from an agent's JSON. Zod is the boundary — its messages name the
+ * field and the API documents them — and the prefill is what the workspace
+ * assumes when a caller leaves a field out. Everything past that is a node
+ * rule, and node rules live in lib/doc.
+ */
 export function cleanNode(raw: Record<string, unknown>): SquigNode {
   const parsed = nodeFields.safeParse(raw)
   if (!parsed.success)
@@ -55,64 +81,20 @@ export function cleanNode(raw: Record<string, unknown>): SquigNode {
       400,
       `Unknown component: ${raw.kind}. Search catalog first.`,
     )
-  const n = validNode({
-    seed: 1,
-    id: nanoid(12),
-    w: def?.size.w ?? 160,
-    h: def?.size.h ?? 80,
-    ...(raw.type === "text" ? { fontSize: 20, text: "" } : {}),
-    ...(raw.type === "shape" ? { shape: "rect", fill: "none" } : {}),
-    ...raw,
-    ...(def
-      ? { props: { ...def.defaults, ...((raw.props as object) ?? {}) } }
-      : {}),
-  })
-  if (
-    !n ||
-    !safeId(n.id) ||
-    [n.x, n.y, n.w, n.h].some((v) => Math.abs(v) > 100000)
+  return withDoc(() =>
+    vouchNode({
+      seed: 1,
+      id: nanoid(12),
+      w: def?.size.w ?? 160,
+      h: def?.size.h ?? 80,
+      ...(raw.type === "text" ? { fontSize: 20, text: "" } : {}),
+      ...(raw.type === "shape" ? { shape: "rect", fill: "none" } : {}),
+      ...raw,
+      ...(def
+        ? { props: { ...def.defaults, ...((raw.props as object) ?? {}) } }
+        : {}),
+    }),
   )
-    throw new AgentError(400, "Invalid node or geometry")
-  if (n.type === "text" && (n.fontSize <= 0 || n.fontSize > 1000))
-    throw new AgentError(400, "fontSize must be 1–1000")
-  if (
-    n.type === "image" &&
-    (!/^data:image\/(png|jpeg|webp|gif);base64,/i.test(n.src) ||
-      !Number.isFinite(n.naturalW) ||
-      !Number.isFinite(n.naturalH) ||
-      n.naturalW <= 0 ||
-      n.naturalH <= 0)
-  )
-    throw new AgentError(
-      400,
-      "Images require a raster data URL and positive naturalW/naturalH",
-    )
-  if (n.type === "component") {
-    try {
-      def!.render(n.props, n.w, n.h)
-    } catch {
-      throw new AgentError(400, `Invalid properties for ${n.kind}`)
-    }
-    for (const c of def!.controls) {
-      const v = n.props[c.key]
-      if (v === undefined) continue
-      if (c.type === "select" && c.options && !c.options.includes(String(v)))
-        throw new AgentError(400, `Invalid ${n.kind}.${c.key}`)
-      if (
-        c.type === "number" &&
-        (typeof v !== "number" ||
-          !Number.isFinite(v) ||
-          (c.min !== undefined && v < c.min) ||
-          (c.max !== undefined && v > c.max))
-      )
-        throw new AgentError(400, `Invalid ${n.kind}.${c.key}`)
-      if (c.type === "toggle" && typeof v !== "boolean")
-        throw new AgentError(400, `Invalid ${n.kind}.${c.key}`)
-      if ((c.type === "text" || c.type === "icon") && typeof v !== "string")
-        throw new AgentError(400, `Invalid ${n.kind}.${c.key}`)
-    }
-  }
-  return n
 }
 export function validateDocument(doc: CanvasDocument): CanvasDocument {
   lookSchema.parse(doc.look)
@@ -145,7 +127,12 @@ export function applyOperations(
   original: CanvasDocument,
   operations: Operation[],
 ): { document: CanvasDocument; createdIds: string[] } {
-  const d = structuredClone(original)
+  // lib/doc hands back a new document every time, but align, distribute and
+  // flip still write through the node objects, so the batch owns a copy and a
+  // refused operation leaves the caller's document where it was.
+  let d = structuredClone(original)
+  // the real faces, so a note wraps here exactly where the render breaks it
+  const measure = textMeasurer(original.look.font)
   const createdIds: string[] = []
   const members = (ids: string[], allowLocked = false) =>
     [...new Set(ids)].map((id) => {
@@ -156,32 +143,34 @@ export function applyOperations(
         throw new AgentError(409, `Node is locked: ${id}; unlock it explicitly`)
       return n
     })
-  const add = (raw: Record<string, unknown>) => {
-    const n = cleanNode(raw)
-    if (Object.hasOwn(d.nodes, n.id))
-      throw new AgentError(409, `Duplicate node ID: ${n.id}`)
-    d.nodes[n.id] = n
-    d.order.push(n.id)
-    createdIds.push(n.id)
+  // one call per batch of new nodes: a group only survives the trip if all of
+  // its members arrive together, since a group of one is not a group
+  const place = (nodes: readonly SquigNode[]) => {
+    d = withDoc(() => addNodes(d, nodes)) as CanvasDocument
+    for (const n of nodes) createdIds.push(n.id)
   }
   for (const op of operations) {
     switch (op.op) {
       case "add":
-        op.nodes.forEach(add)
+        place(op.nodes.map((n) => cleanNode(n as Record<string, unknown>)))
         break
       case "note":
-        add({
-          type: "text",
-          x: op.x,
-          y: op.y,
-          w: op.w,
-          h: Math.max(100, Math.ceil(op.text.length / 25) * 26),
-          text: op.text,
-          fontSize: 18,
-          boxed: true,
-          boxFill: "light",
-          fixedW: true,
-        })
+        place([
+          withDoc(() =>
+            textNode(
+              op.text,
+              {
+                x: op.x,
+                y: op.y,
+                w: op.w,
+                fontSize: 18,
+                boxed: true,
+                boxFill: "light",
+              },
+              measure,
+            ),
+          ),
+        ])
         break
       case "rename":
         d.fileName = op.name
@@ -210,23 +199,21 @@ export function applyOperations(
       }
       case "update":
         for (const { id, patch, unset } of op.patches) {
-          const n = members(
+          members(
             [id],
             patch.locked === false &&
               Object.keys(patch).length === 1 &&
               !unset?.length,
-          )[0]
+          )
           if (patch.id !== undefined || patch.type !== undefined)
             throw new AgentError(400, "Node id and type are immutable")
-          const next: Record<string, unknown> = {
-            ...n,
+          const changes = {
             ...patch,
-            ...(n.type === "component" && patch.props
-              ? { props: { ...n.props, ...(patch.props as object) } }
-              : {}),
-          }
-          for (const field of unset ?? []) delete next[field]
-          d.nodes[id] = cleanNode(next)
+            ...Object.fromEntries((unset ?? []).map((f) => [f, undefined])),
+          } as Partial<SquigNode>
+          d = withDoc(() =>
+            updateNode(d, id, changes, measure),
+          ) as CanvasDocument
         }
         break
       case "remove_variation":
@@ -234,12 +221,11 @@ export function applyOperations(
           throw new AgentError(404, "Variation not found")
         d.variations = d.variations.filter((v) => v.id !== op.id)
         break
-      case "delete":
-        members(op.ids).forEach((n) => {
-          delete d.nodes[n.id]
-        })
-        d.order = d.order.filter((id) => !op.ids.includes(id))
+      case "delete": {
+        const ids = members(op.ids).map((n) => n.id)
+        d = withDoc(() => removeNodes(d, ids)) as CanvasDocument
         break
+      }
       case "duplicate": {
         const originals = members(op.ids, true)
         const ids = new Map(originals.map((n) => [n.id, nanoid(12)]))
@@ -256,14 +242,20 @@ export function applyOperations(
           groupIds: n.groupIds?.map((g) => groups.get(g)!),
         }))
         remapBinds(clones, ids)
-        clones.forEach((n) => add(n as unknown as Record<string, unknown>))
+        place(
+          clones.map((n) => cleanNode(n as unknown as Record<string, unknown>)),
+        )
         break
       }
       case "group": {
-        const g = op.groupId ?? nanoid(12)
-        members(op.ids).forEach((n) => {
-          n.groupIds = [g, ...(n.groupIds ?? []).filter((id) => id !== g)]
-        })
+        members(op.ids, true)
+        const grouped = withDoc(() => groupNodes(d, op.ids, op.groupId))
+        if (!grouped)
+          throw new AgentError(
+            400,
+            "Nothing to group: needs two or more unlocked nodes that are not already one group",
+          )
+        d = grouped.doc as CanvasDocument
         break
       }
       case "ungroup":
@@ -274,16 +266,20 @@ export function applyOperations(
       case "detach":
         for (const n of members(op.ids)) {
           if (n.type !== "component") continue
-          const index = d.order.indexOf(n.id)
-          const parts = breakApart(n)
-          delete d.nodes[n.id]
-          d.order.splice(index, 1)
-          for (const p of parts) {
-            p.groupIds = n.groupIds
-            add(p as unknown as Record<string, unknown>)
-          }
-          if (parts.length) d.order.splice(-parts.length)
-          d.order.splice(index, 0, ...parts.map((p) => p.id))
+          const at = d.order.indexOf(n.id)
+          const parts = breakApart(n).map((p) =>
+            cleanNode({
+              ...p,
+              groupIds: n.groupIds,
+            } as unknown as Record<string, unknown>),
+          )
+          d = withDoc(() => removeNodes(d, [n.id])) as CanvasDocument
+          place(parts)
+          // the parts landed on top; they belong where the component stood
+          const ids = parts.map((p) => p.id)
+          const fresh = new Set(ids)
+          const rest = d.order.filter((id) => !fresh.has(id))
+          d = { ...d, order: [...rest.slice(0, at), ...ids, ...rest.slice(at)] }
         }
         break
       case "flip":
@@ -340,13 +336,13 @@ export function applyOperations(
         break
       }
       case "reorder": {
-        members(op.ids)
-        const ids = new Set(op.ids),
-          selected = d.order.filter((id) => ids.has(id)),
-          other = d.order.filter((id) => !ids.has(id))
-        if (op.position === "front") d.order = [...other, ...selected]
-        else if (op.position === "back") d.order = [...selected, ...other]
+        const picked = members(op.ids).map((n) => n.id)
+        if (op.position === "front")
+          d = bringToFront(d, picked) as CanvasDocument
+        else if (op.position === "back")
+          d = sendToBack(d, picked) as CanvasDocument
         else {
+          const ids = new Set(picked)
           const forward = op.position === "forward"
           const order = forward ? [...d.order].reverse() : [...d.order]
           for (let i = 1; i < order.length; i++)

--- a/lib/canvas/text-metrics.ts
+++ b/lib/canvas/text-metrics.ts
@@ -65,8 +65,8 @@ export function measureTextWidth(text: string, style: TypeStyle): number {
 }
 
 /** Widest of a run's lines. */
-export function measureLinesWidth(lines: string[], style: TypeStyle): number {
-  return lines.reduce((max, line) => Math.max(max, measureTextWidth(line, style)), 0)
+export function measureLinesWidth(lines: string[], style: TypeStyle, measure: TextMeasurer = measureTextWidth): number {
+  return lines.reduce((max, line) => Math.max(max, measure(line, style)), 0)
 }
 
 /**

--- a/lib/canvas/text-reflow.ts
+++ b/lib/canvas/text-reflow.ts
@@ -9,7 +9,7 @@ import {
   textContentWidth,
   verticalAnchorFactor,
 } from "@/lib/sketch/text-layout"
-import { measureLinesWidth, wrapText } from "./text-metrics"
+import { measureLinesWidth, wrapText, type TextMeasurer } from "./text-metrics"
 import type { TextNode } from "@/lib/types"
 
 /** Narrow enough to hug an "i", wide enough to still be worth clicking. */
@@ -54,16 +54,21 @@ function fitHeight(n: TextNode, natural: number): number {
  * A mirrored node pins the opposite edge: flipping swaps which end of the box
  * the run hangs off (see mirrorPrims), so the anchor has to swap with it.
  */
-export function fitTextBox(n: TextNode, text: string, fontSize = n.fontSize): Partial<TextNode> {
+export function fitTextBox(
+  n: TextNode,
+  text: string,
+  fontSize = n.fontSize,
+  measureText?: TextMeasurer
+): Partial<TextNode> {
   const style = { size: fontSize, bold: n.bold, italic: n.italic }
   const boxed = !!n.boxed
   if (n.fixedW) {
     const measure = textContentWidth(n.w, fontSize, boxed)
-    const natural = textBlockHeight(wrapText(text, measure, style).length, fontSize, boxed)
+    const natural = textBlockHeight(wrapText(text, measure, style, measureText).length, fontSize, boxed)
     return { text, fontSize, h: fitHeight(n, natural) }
   }
   const lines = (text || " ").split("\n")
-  const measured = measureLinesWidth(lines, style)
+  const measured = measureLinesWidth(lines, style, measureText)
   const contentW = Math.max(MIN_WIDTH, measured + SLACK)
   const oldPad = textBoxPadding(n.fontSize, boxed)
   const nextPad = textBoxPadding(fontSize, boxed)

--- a/lib/doc.ts
+++ b/lib/doc.ts
@@ -34,7 +34,8 @@ import { bindPair, settleBinds } from "./canvas/arrow-binding"
 import { nodeVisualBounds } from "./canvas/line-routing"
 import { planGroupPaths, pruneDegenerateGroups } from "./canvas/groups"
 import { fitTextBox } from "./canvas/text-reflow"
-import { ALL_DEFS, getDef, matches, type Category, type ControlDef, type Props } from "./library/registry"
+import type { TextMeasurer } from "./canvas/text-metrics"
+import { ALL_DEFS, getDef, matches, type Category, type ComponentDef, type ControlDef, type Props } from "./library/registry"
 import { DEFAULT_LOOK, knownLook, type Look } from "./theme"
 
 export const DOC_VERSION = 1
@@ -51,6 +52,11 @@ export class DocError extends Error {}
 
 /** Short and URL-safe, like the ids the app mints; a caller may bring its own. */
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+/** Names a plain object already answers to — as a key they'd reach the prototype. */
+const RESERVED_IDS = new Set(["__proto__", "constructor", "prototype"])
+/** A picture is raster: an SVG data URL can carry script, and nothing here needs one. */
+const RASTER_SRC = /^data:image\/(png|jpeg|webp|gif);base64,/i
+const MAX_FONT_SIZE = 1000
 /** Keeps a typo'd coordinate from putting a node a light-year off the sheet. */
 const MAX_COORD = 1_000_000
 
@@ -214,6 +220,7 @@ export interface TextAt extends NodeAt {
   underline?: boolean
   ink?: InkTone
   boxed?: boolean
+  boxFill?: FillTone
   link?: string
 }
 
@@ -222,9 +229,11 @@ export interface TextAt extends NodeAt {
  *
  * `x` is where the anchor edge lands — the left edge for left-aligned text,
  * the middle for centred, the right edge for right-aligned — and `y` is the
- * top of the box. Give it a `w` and the words wrap to it instead.
+ * top of the box. Give it a `w` and the words wrap to it instead. Off the
+ * browser, `measureText` (see lib/canvas/text-metrics) is what makes the
+ * box the size the real face needs rather than an em-ratio guess.
  */
-export function textNode(text: string, at: TextAt): TextNode {
+export function textNode(text: string, at: TextAt, measureText?: TextMeasurer): TextNode {
   const fontSize = at.fontSize ?? DEFAULT_FONT_SIZE
   if (!(fontSize > 0)) throw new DocError("fontSize has to be a positive number")
   const base: TextNode = {
@@ -244,10 +253,11 @@ export function textNode(text: string, at: TextAt): TextNode {
     ...(at.underline ? { underline: true } : {}),
     ...(at.ink && at.ink !== "ink" ? { ink: at.ink } : {}),
     ...(at.boxed ? { boxed: true } : {}),
+    ...(at.boxed && at.boxFill ? { boxFill: at.boxFill } : {}),
     ...(at.link ? { link: at.link } : {}),
     ...(at.locked ? { locked: true } : {}),
   }
-  return { ...base, ...fitTextBox(base, text, fontSize) }
+  return { ...base, ...fitTextBox(base, text, fontSize, measureText) }
 }
 
 export interface ShapeAt extends NodeAt {
@@ -336,16 +346,79 @@ export function arrowNode(opts: ArrowOpts, nodes: Record<string, SquigNode>): Ar
 
 // -- changing a document -----------------------------------------------------
 
-/** The one gate: the node as the canvas would accept it, or a reason it won't. */
-function vouch(raw: unknown): SquigNode {
+/**
+ * The one gate: the node as the canvas would accept it, or a reason it won't.
+ *
+ * validNode is the shape check every door already shares; what's added here
+ * is what a stranger's node can get wrong that a paste can't — a name that
+ * reaches the prototype, a component with a prop its controls don't allow, a
+ * picture that isn't a raster. The store, the CLI, window.squig and the
+ * workspace engine all come through this, so a refusal reads the same at
+ * every door.
+ */
+export function vouchNode(raw: unknown): SquigNode {
   const n = validNode({ ...(raw as object) })
   if (!n) throw new DocError(`not a node squig can draw: ${describe(raw)}`)
-  if (!ID_PATTERN.test(n.id)) throw new DocError(`"${n.id}" isn't a usable id (letters, digits, - and _, up to 64)`)
+  if (!ID_PATTERN.test(n.id) || RESERVED_IDS.has(n.id)) {
+    throw new DocError(`"${n.id}" isn't a usable id (letters, digits, - and _, up to 64)`)
+  }
   if ([n.x, n.y, n.w, n.h].some((v) => Math.abs(v) > MAX_COORD)) {
     throw new DocError(`node "${n.id}" is off the sheet — keep coordinates within ±${MAX_COORD}`)
   }
-  if (n.type === "component" && !getDef(n.kind)) throw new DocError(`no component called "${n.kind}"`)
+  switch (n.type) {
+    case "component": {
+      const def = getDef(n.kind)
+      if (!def) throw new DocError(`no component called "${n.kind}"`)
+      checkProps(def, n.props)
+      break
+    }
+    case "text":
+      if (!(n.fontSize > 0 && n.fontSize <= MAX_FONT_SIZE)) {
+        throw new DocError(`fontSize has to be between 1 and ${MAX_FONT_SIZE}, not ${n.fontSize}`)
+      }
+      break
+    case "image":
+      if (!RASTER_SRC.test(n.src)) throw new DocError(`a picture is a png, jpeg, webp or gif data URL, not "${n.src.slice(0, 24)}…"`)
+      if (!(n.naturalW > 0 && n.naturalH > 0 && Number.isFinite(n.naturalW) && Number.isFinite(n.naturalH))) {
+        throw new DocError(`picture "${n.id}" needs its own size — positive naturalW and naturalH`)
+      }
+      break
+  }
   return n
+}
+
+/** Every prop a control governs holds a value that control could have set. */
+function checkProps(def: ComponentDef, props: Props): void {
+  for (const c of def.controls) {
+    const v = props[c.key]
+    if (v === undefined) continue
+    const bad = (why: string) => new DocError(`${def.kind}.${c.key} can't be ${JSON.stringify(v)}: ${why}`)
+    switch (c.type) {
+      case "select":
+        if (c.options && !c.options.includes(String(v))) throw bad(`it's one of ${c.options.join(", ")}`)
+        break
+      case "number":
+        if (typeof v !== "number" || !Number.isFinite(v)) throw bad("it wants a number")
+        if ((c.min !== undefined && v < c.min) || (c.max !== undefined && v > c.max)) {
+          throw bad(`it stays between ${c.min ?? "-∞"} and ${c.max ?? "∞"}`)
+        }
+        break
+      case "toggle":
+        if (typeof v !== "boolean") throw bad("it's on or off")
+        break
+      case "text":
+      case "icon":
+        if (typeof v !== "string") throw bad("it wants a string")
+        break
+    }
+  }
+  // a def that throws on its own props is the last check — it's what the
+  // canvas would do on the first paint, and the paint is the wrong place
+  try {
+    def.render({ ...def.defaults, ...props }, def.size.w, def.size.h)
+  } catch {
+    throw new DocError(`${def.kind} can't draw with those props`)
+  }
 }
 
 function describe(raw: unknown): string {
@@ -365,7 +438,7 @@ export function addNodes(doc: SquigDocument, nodes: readonly SquigNode[]): Squig
   const map = { ...doc.nodes }
   const order = [...doc.order]
   for (const raw of nodes) {
-    const n = vouch(raw)
+    const n = vouchNode(raw)
     if (map[n.id]) throw new DocError(`there is already a node called "${n.id}"`)
     map[n.id] = n
     order.push(n.id)
@@ -381,7 +454,12 @@ export function addNodes(doc: SquigDocument, nodes: readonly SquigNode[]): Squig
  * with one member dissolves, and bound arrows follow a moved box — so read
  * the whole node map, not just the node you named.
  */
-export function updateNode(doc: SquigDocument, id: string, patch: Partial<SquigNode>): SquigDocument {
+export function updateNode(
+  doc: SquigDocument,
+  id: string,
+  patch: Partial<SquigNode>,
+  measureText?: TextMeasurer
+): SquigDocument {
   const node = doc.nodes[id]
   if (!node) throw new DocError(`no node called "${id}"`)
   if ("type" in patch && patch.type !== node.type) throw new DocError(`a ${node.type} can't become a ${patch.type}`)
@@ -389,14 +467,14 @@ export function updateNode(doc: SquigDocument, id: string, patch: Partial<SquigN
   if (node.type === "text") {
     const { text, fontSize, ...rest } = patch as Partial<TextNode>
     const base: TextNode = { ...node, ...rest, ...(rest.w !== undefined ? { fixedW: true } : {}) }
-    merged = { ...base, ...fitTextBox(base, text ?? node.text, fontSize ?? node.fontSize) }
+    merged = { ...base, ...fitTextBox(base, text ?? node.text, fontSize ?? node.fontSize, measureText) }
   } else if (node.type === "component") {
     const { props, ...rest } = patch as Partial<ComponentNode>
     merged = { ...node, ...rest, ...(props ? { props: { ...node.props, ...props } } : {}) }
   } else {
     merged = { ...node, ...patch } as SquigNode
   }
-  const next = vouch({ ...merged, id })
+  const next = vouchNode({ ...merged, id })
   return { ...doc, nodes: settleBinds(pruneDegenerateGroups({ ...doc.nodes, [id]: next })) }
 }
 
@@ -418,12 +496,15 @@ export function removeNodes(doc: SquigDocument, ids: readonly string[]): SquigDo
  * it belongs. Locked layers are left out. Null when there is nothing to group
  * — fewer than two things, or one group that is already whole.
  */
-export function groupNodes(doc: SquigDocument, ids: readonly string[]): { doc: SquigDocument; groupId: string } | null {
+export function groupNodes(
+  doc: SquigDocument,
+  ids: readonly string[],
+  groupId: string = newId()
+): { doc: SquigDocument; groupId: string } | null {
   // a locked layer is never in a selection, so ⌘G never sees one; here the
   // ids come straight from a caller, and the plan below would leave it out
   // while the stamping would still reach it
   const members = doc.order.filter((id) => ids.includes(id) && doc.nodes[id] && !doc.nodes[id].locked)
-  const groupId = newId()
   const paths = planGroupPaths(members, doc.nodes, doc.order, groupId)
   if (!paths) return null
   const map = { ...doc.nodes }

--- a/lib/doc.ts
+++ b/lib/doc.ts
@@ -447,7 +447,7 @@ export function addNodes(doc: SquigDocument, nodes: readonly SquigNode[]): Squig
 }
 
 /** The keys whose change means a text layer's box has to be measured again. */
-const TEXT_LAYOUT_KEYS: ReadonlySet<string> = new Set(["text", "fontSize", "bold", "italic", "boxed", "w", "fixedW", "fixedH"])
+const TEXT_LAYOUT_KEYS: ReadonlySet<string> = new Set(["text", "fontSize", "bold", "italic", "boxed", "w", "h", "fixedW", "fixedH"])
 
 /**
  * One node with a patch on it, vouched. A text layer keeps its box honest
@@ -463,7 +463,15 @@ export function patchNode(node: SquigNode, patch: Partial<SquigNode>, measureTex
   let merged: SquigNode
   if (node.type === "text") {
     const { text, fontSize, ...rest } = patch as Partial<TextNode>
-    const base: TextNode = { ...node, ...rest, ...(rest.w !== undefined ? { fixedW: true } : {}) }
+    // a width or height handed in is a chosen one, the way a dragged handle
+    // is: the words wrap to the width, and the height is a floor they may
+    // still push past — see setTextWidth and setTextHeight in text-reflow
+    const base: TextNode = {
+      ...node,
+      ...rest,
+      ...(rest.w !== undefined ? { fixedW: true } : {}),
+      ...(rest.h !== undefined ? { fixedH: true } : {}),
+    }
     const relaid = Object.keys(patch).some((k) => TEXT_LAYOUT_KEYS.has(k))
     merged = relaid
       ? { ...base, ...fitTextBox(base, text ?? node.text, fontSize ?? node.fontSize, measureText) }
@@ -518,6 +526,17 @@ export function groupNodes(
   ids: readonly string[],
   groupId: string = newId()
 ): { doc: SquigDocument; groupId: string } | null {
+  const stamped = stampGroup(doc, ids, groupId)
+  return stamped && { doc: { ...stamped, nodes: pruneDegenerateGroups(stamped.nodes) }, groupId }
+}
+
+/**
+ * The stamping half of groupNodes, with the document's other groups left
+ * exactly as they are. A caller applying a batch of its own uses this and
+ * prunes once at the end, so grouping two things can't dissolve a group it
+ * is still in the middle of rebuilding.
+ */
+export function stampGroup(doc: SquigDocument, ids: readonly string[], groupId: string): SquigDocument | null {
   // a locked layer is never in a selection, so ⌘G never sees one; here the
   // ids come straight from a caller, and the plan below would leave it out
   // while the stamping would still reach it
@@ -529,7 +548,7 @@ export function groupNodes(
   const top = doc.order.lastIndexOf(members[members.length - 1])
   const before = doc.order.slice(0, top + 1).filter((id) => !members.includes(id))
   const after = doc.order.slice(top + 1).filter((id) => !members.includes(id))
-  return { doc: { ...doc, nodes: pruneDegenerateGroups(map), order: [...before, ...members, ...after] }, groupId }
+  return { ...doc, nodes: map, order: [...before, ...members, ...after] }
 }
 
 export function bringToFront(doc: SquigDocument, ids: readonly string[]): SquigDocument {

--- a/lib/doc.ts
+++ b/lib/doc.ts
@@ -465,12 +465,14 @@ export function patchNode(node: SquigNode, patch: Partial<SquigNode>, measureTex
     const { text, fontSize, ...rest } = patch as Partial<TextNode>
     // a width or height handed in is a chosen one, the way a dragged handle
     // is: the words wrap to the width, and the height is a floor they may
-    // still push past — see setTextWidth and setTextHeight in text-reflow
+    // still push past — see setTextWidth and setTextHeight in text-reflow.
+    // Unless the patch says otherwise about the flag itself: a caller
+    // handing back a size together with fixedW: false is letting go.
     const base: TextNode = {
       ...node,
       ...rest,
-      ...(rest.w !== undefined ? { fixedW: true } : {}),
-      ...(rest.h !== undefined ? { fixedH: true } : {}),
+      ...(rest.w !== undefined && !("fixedW" in rest) ? { fixedW: true } : {}),
+      ...(rest.h !== undefined && !("fixedH" in rest) ? { fixedH: true } : {}),
     }
     const relaid = Object.keys(patch).some((k) => TEXT_LAYOUT_KEYS.has(k))
     merged = relaid

--- a/lib/doc.ts
+++ b/lib/doc.ts
@@ -51,7 +51,7 @@ export interface SquigDocument extends SquigDoc {
 export class DocError extends Error {}
 
 /** Short and URL-safe, like the ids the app mints; a caller may bring its own. */
-const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,80}$/
 /** Names a plain object already answers to — as a key they'd reach the prototype. */
 const RESERVED_IDS = new Set(["__proto__", "constructor", "prototype"])
 /** A picture is raster: an SVG data URL can carry script, and nothing here needs one. */
@@ -360,7 +360,7 @@ export function vouchNode(raw: unknown): SquigNode {
   const n = validNode({ ...(raw as object) })
   if (!n) throw new DocError(`not a node squig can draw: ${describe(raw)}`)
   if (!ID_PATTERN.test(n.id) || RESERVED_IDS.has(n.id)) {
-    throw new DocError(`"${n.id}" isn't a usable id (letters, digits, - and _, up to 64)`)
+    throw new DocError(`"${n.id}" isn't a usable id (letters, digits, - and _, up to 80)`)
   }
   if ([n.x, n.y, n.w, n.h].some((v) => Math.abs(v) > MAX_COORD)) {
     throw new DocError(`node "${n.id}" is off the sheet — keep coordinates within ±${MAX_COORD}`)
@@ -446,13 +446,42 @@ export function addNodes(doc: SquigDocument, nodes: readonly SquigNode[]): Squig
   return { ...doc, nodes: settleBinds(pruneDegenerateGroups(map)), order }
 }
 
+/** The keys whose change means a text layer's box has to be measured again. */
+const TEXT_LAYOUT_KEYS: ReadonlySet<string> = new Set(["text", "fontSize", "bold", "italic", "boxed", "w", "fixedW", "fixedH"])
+
 /**
- * Change one node. A text layer keeps its box honest: new words, a new size
- * or a new measure re-fit the box the way the inline editor would. A
- * component's props merge, so setting the label keeps the variant. The
- * document that comes back may have changed neighbours too — a group left
- * with one member dissolves, and bound arrows follow a moved box — so read
- * the whole node map, not just the node you named.
+ * One node with a patch on it, vouched. A text layer keeps its box honest
+ * when the patch touches its words or its measure — new words, a new size,
+ * a new width re-fit the box the way the inline editor would — and keeps
+ * its box as it was for anything else, so locking or moving a label never
+ * re-lays it out. A component's props merge, so setting the label keeps the
+ * variant. This is the node half of updateNode; a caller building a batch
+ * of its own applies it per node and settles the document once at the end.
+ */
+export function patchNode(node: SquigNode, patch: Partial<SquigNode>, measureText?: TextMeasurer): SquigNode {
+  if ("type" in patch && patch.type !== node.type) throw new DocError(`a ${node.type} can't become a ${patch.type}`)
+  let merged: SquigNode
+  if (node.type === "text") {
+    const { text, fontSize, ...rest } = patch as Partial<TextNode>
+    const base: TextNode = { ...node, ...rest, ...(rest.w !== undefined ? { fixedW: true } : {}) }
+    const relaid = Object.keys(patch).some((k) => TEXT_LAYOUT_KEYS.has(k))
+    merged = relaid
+      ? { ...base, ...fitTextBox(base, text ?? node.text, fontSize ?? node.fontSize, measureText) }
+      : { ...base, text: text ?? node.text, fontSize: fontSize ?? node.fontSize }
+  } else if (node.type === "component") {
+    const { props, ...rest } = patch as Partial<ComponentNode>
+    merged = { ...node, ...rest, ...(props ? { props: { ...node.props, ...props } } : {}) }
+  } else {
+    merged = { ...node, ...patch } as SquigNode
+  }
+  return vouchNode({ ...merged, id: node.id })
+}
+
+/**
+ * Change one node in a document. The document that comes back may have
+ * changed neighbours too — a group left with one member dissolves, and bound
+ * arrows follow a moved box — so read the whole node map, not just the node
+ * you named.
  */
 export function updateNode(
   doc: SquigDocument,
@@ -462,19 +491,7 @@ export function updateNode(
 ): SquigDocument {
   const node = doc.nodes[id]
   if (!node) throw new DocError(`no node called "${id}"`)
-  if ("type" in patch && patch.type !== node.type) throw new DocError(`a ${node.type} can't become a ${patch.type}`)
-  let merged: SquigNode
-  if (node.type === "text") {
-    const { text, fontSize, ...rest } = patch as Partial<TextNode>
-    const base: TextNode = { ...node, ...rest, ...(rest.w !== undefined ? { fixedW: true } : {}) }
-    merged = { ...base, ...fitTextBox(base, text ?? node.text, fontSize ?? node.fontSize, measureText) }
-  } else if (node.type === "component") {
-    const { props, ...rest } = patch as Partial<ComponentNode>
-    merged = { ...node, ...rest, ...(props ? { props: { ...node.props, ...props } } : {}) }
-  } else {
-    merged = { ...node, ...patch } as SquigNode
-  }
-  const next = vouchNode({ ...merged, id })
+  const next = patchNode(node, patch, measureText)
   return { ...doc, nodes: settleBinds(pruneDegenerateGroups({ ...doc.nodes, [id]: next })) }
 }
 

--- a/scripts/test-agent.ts
+++ b/scripts/test-agent.ts
@@ -11,13 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import { isDeepStrictEqual } from "node:util"
-import {
-  applyOperations,
-  cleanNode,
-  diffNodes,
-  emptyDocument,
-  validateDocument,
-} from "../lib/agent/engine.ts"
+import { applyOperations, cleanNode, diffNodes, emptyDocument, validateDocument, AgentError, type CanvasDocument } from "../lib/agent/engine.ts"
 import { renderPng, renderSvg, pngDocument } from "../lib/agent/render.ts"
 import { operation } from "../lib/agent/schema.ts"
 import { ALL_DEFS } from "../lib/library/registry.ts"
@@ -774,5 +768,71 @@ check(
 )
 
 // ---------------------------------------------------------------------------
+
+// -- a batch is one edit: invariants hold at the end, not between steps ----
+
+{
+  const ops = (list: unknown[]) => operation.array().parse(list)
+  const status = (fn: () => unknown) => {
+    try {
+      fn()
+      return null
+    } catch (e) {
+      return e instanceof AgentError ? e.status : "threw"
+    }
+  }
+  const two = applyOperations(
+    emptyDocument("batch"),
+    ops([
+      { op: "add", nodes: [{ id: "p", type: "shape", x: 0, y: 0, w: 40, h: 40 }] },
+      {
+        op: "add",
+        nodes: [
+          { id: "link", type: "arrow", x: 0, y: 0, w: 10, h: 10, points: [[0, 0], [10, 10]], head: true, bind: ["p", "q"] },
+        ],
+      },
+      { op: "add", nodes: [{ id: "q", type: "shape", x: 200, y: 0, w: 40, h: 40 }] },
+    ]),
+  ).document
+  check("an arrow may name a box a later add brings", same(two.nodes.link.type === "arrow" && two.nodes.link.bind, ["p", "q"]))
+
+  const paired = applyOperations(
+    two,
+    ops([{ op: "update", patches: [{ id: "p", patch: { groupIds: ["g9"] } }, { id: "q", patch: { groupIds: ["g9"] } }] }]),
+  ).document
+  check("two patches can found a group between them", same(paired.nodes.p.groupIds, ["g9"]) && same(paired.nodes.q.groupIds, ["g9"]))
+
+  const labelled = applyOperations(
+    two,
+    ops([{ op: "add", nodes: [{ id: "t", type: "text", x: 0, y: 100, w: 160, h: 80, text: "Hi", fontSize: 20, align: "center" }] }]),
+  ).document
+  const lockedLabel = applyOperations(labelled, ops([{ op: "update", patches: [{ id: "t", patch: { locked: true } }] }])).document
+  check("locking a label leaves its box alone", lockedLabel.nodes.t.w === 160 && lockedLabel.nodes.t.x === 0)
+
+  const words = "Wide words wrap here and keep going for a while yet"
+  const hand = applyOperations(emptyDocument("faces"), ops([{ op: "note", x: 0, y: 0, w: 200, text: words }])).document
+  const sans = applyOperations(
+    emptyDocument("faces"),
+    ops([{ op: "look", font: "sans" }, { op: "note", x: 0, y: 0, w: 200, text: words }]),
+  ).document
+  const height = (doc: CanvasDocument) => doc.nodes[doc.order[0]].h
+  check("a note after a look change measures with the new face", height(hand) !== height(sans))
+
+  check("words that aren't a string are a 400, not a crash", status(() => applyOperations(two, ops([{ op: "update", patches: [{ id: "p", patch: { text: 123 } }] }]))) === 400)
+  check("a negative width in a patch is a 400", status(() => applyOperations(two, ops([{ op: "update", patches: [{ id: "p", patch: { w: -5 } }] }]))) === 400)
+
+  const long = "x".repeat(80)
+  check("an eighty-character id is still welcome", status(() => applyOperations(two, ops([{ op: "add", nodes: [{ id: long, type: "shape", x: 0, y: 0, w: 1, h: 1 }] }]))) === null)
+
+  const withButton = applyOperations(
+    two,
+    ops([
+      { op: "add", nodes: [{ id: "btn", type: "component", kind: "button", x: 0, y: 300 }] },
+      { op: "group", ids: ["btn", "q"], groupId: "pair" },
+    ]),
+  ).document
+  const detached = applyOperations(withButton, ops([{ op: "detach", ids: ["btn"] }])).document
+  check("detaching a grouped component keeps its sibling in the group", same(detached.nodes.q.groupIds, ["pair"]))
+}
 
 report(`agent engine checks passed (${ALL_DEFS.length} library definitions)`)

--- a/scripts/test-agent.ts
+++ b/scripts/test-agent.ts
@@ -833,6 +833,25 @@ check(
   ).document
   const detached = applyOperations(withButton, ops([{ op: "detach", ids: ["btn"] }])).document
   check("detaching a grouped component keeps its sibling in the group", same(detached.nodes.q.groupIds, ["pair"]))
+
+  const rebuilt = applyOperations(
+    withButton,
+    ops([
+      { op: "delete", ids: ["q"] },
+      { op: "add", nodes: [{ id: "c", type: "shape", x: 0, y: 500, w: 1, h: 1 }, { id: "d", type: "shape", x: 0, y: 600, w: 1, h: 1 }] },
+      { op: "group", ids: ["c", "d"] },
+      { op: "add", nodes: [{ id: "q", type: "shape", x: 200, y: 0, w: 40, h: 40, groupIds: ["pair"] }] },
+    ]),
+  ).document
+  check("grouping elsewhere doesn't dissolve a group the batch is rebuilding", same(rebuilt.nodes.btn.groupIds, ["pair"]) && same(rebuilt.nodes.q.groupIds, ["pair"]))
+
+  const tall = applyOperations(
+    two,
+    ops([{ op: "add", nodes: [{ id: "para", type: "text", x: 0, y: 0, w: 80, fixedW: true, text: "two lines of words here", fontSize: 18 }] }]),
+  ).document
+  const squashed = applyOperations(tall, ops([{ op: "update", patches: [{ id: "para", patch: { h: 1 } }] }])).document
+  const needed = textNode("two lines of words here", { x: 0, y: 0, w: 80, fontSize: 18 }, textMeasurer("hand")).h
+  check("a height patch can't push the words out of the box", squashed.nodes.para.h === needed && needed > 1)
 }
 
 report(`agent engine checks passed (${ALL_DEFS.length} library definitions)`)

--- a/scripts/test-agent.ts
+++ b/scripts/test-agent.ts
@@ -251,6 +251,34 @@ check("the copied arrow binds to the copies", (() => {
   return n.type === "arrow" && same(n.bind, cloned.createdIds.slice(0, 2))
 })())
 
+// -- grouping is whatever ⌘G does -------------------------------------------
+
+const grouped = applyOperations(
+  d,
+  operation.array().parse([{ op: "group", ids: ["a", "b"] }]),
+).document
+check("both members carry the one new group", (() => {
+  const path = grouped.nodes.a.groupIds
+  return !!path && path.length === 1 && same(path, grouped.nodes.b.groupIds)
+})())
+check("and nobody else joined it", grouped.nodes.c.groupIds === undefined)
+check(
+  "grouping the same pair again has nothing to do",
+  refused(() =>
+    applyOperations(
+      grouped,
+      operation.array().parse([{ op: "group", ids: ["a", "b"] }]),
+    ),
+  ),
+)
+check(
+  "deleting one of two leaves the other ungrouped",
+  applyOperations(
+    grouped,
+    operation.array().parse([{ op: "delete", ids: ["a"] }]),
+  ).document.nodes.b.groupIds === undefined,
+)
+
 // -- arranging --------------------------------------------------------------
 
 const arranged = applyOperations(
@@ -629,6 +657,62 @@ check(
   measuredCharacters < 300000,
   `${measuredCharacters} characters measured`,
 )
+const { textNode } = await import("../lib/doc.ts")
+const noteText = "Wide words wrap here and keep going for a while yet"
+const noteAt = {
+  x: 0,
+  y: 0,
+  w: 200,
+  fontSize: 18,
+  boxed: true,
+  boxFill: "light",
+} as const
+const noteDoc = emptyDocument("Notes")
+const noted = applyOperations(
+  noteDoc,
+  operation.array().parse([{ op: "note", x: 0, y: 0, w: 200, text: noteText }]),
+)
+check(
+  "a note is wrapped by the faces the render uses",
+  noted.document.nodes[noted.createdIds[0]].h ===
+    textNode(noteText, noteAt, textMeasurer(noteDoc.look.font)).h,
+)
+check(
+  "…which is not the em-ratio guess a browserless caller gets",
+  textNode(noteText, noteAt).h !==
+    textNode(noteText, noteAt, textMeasurer(noteDoc.look.font)).h,
+)
+const fixedWidth = applyOperations(
+  emptyDocument("Hug"),
+  operation.array().parse([
+    {
+      op: "add",
+      nodes: [
+        {
+          id: "t",
+          type: "text",
+          x: 0,
+          y: 0,
+          w: 60,
+          h: 40,
+          fixedW: true,
+          text: "Hug these words",
+          fontSize: 20,
+        },
+      ],
+    },
+  ]),
+).document
+const hugging = applyOperations(
+  fixedWidth,
+  operation
+    .array()
+    .parse([{ op: "update", patches: [{ id: "t", unset: ["fixedW"] }] }]),
+).document
+check("unsetting fixedW puts the box back around the words", (() => {
+  const n = hugging.nodes.t
+  return n.type === "text" && !n.fixedW && n.w > fixedWidth.nodes.t.w
+})())
 
 // -- WebP is accepted by the canvas and must survive agent PNG previews -----
 

--- a/scripts/test-doc.ts
+++ b/scripts/test-doc.ts
@@ -38,6 +38,7 @@ import {
   type SquigDocument,
 } from "../lib/doc.ts"
 import type { ArrowNode, ComponentNode, ShapeNode, SquigNode, TextNode } from "../lib/types.ts"
+import type { TextMeasurer } from "../lib/canvas/text-metrics.ts"
 import type { Look } from "../lib/theme.ts"
 import { check, report } from "./harness.ts"
 
@@ -383,6 +384,48 @@ const button = (id: string, x = 0, y = 0) => componentNode("button", { id, seed:
   const grouped = groupNodes(doc, ["p", "q"])!
   const alone = updateNode(grouped.doc, "p", { groupIds: undefined })
   check("leaving a group of two dissolves it for the other member too", alone.nodes.q.groupIds === undefined)
+}
+
+// -- the gate refuses what a paste never sends -------------------------------
+
+{
+  const at = { x: 0, y: 0, seed: 1 }
+  const refused = (fn: () => unknown) => {
+    try {
+      fn()
+      return false
+    } catch (e) {
+      return e instanceof DocError
+    }
+  }
+  const empty = emptyDoc("gate")
+  check("an id that reaches the prototype is refused", refused(() => addNodes(empty, [shapeNode("rect", { ...at, w: 1, h: 1, id: "__proto__" })])))
+  check("a kind named after an Object property is refused", refused(() => componentNode("constructor", at)))
+  check("a select prop off its list is refused", refused(() => addNodes(empty, [componentNode("button", { ...at, props: { variant: "neon" } })])))
+  check("a number prop past its range is refused", refused(() => addNodes(empty, [componentNode("table", { ...at, props: { rows: 999 } })])))
+  check("a toggle prop that isn't a boolean is refused", refused(() => addNodes(empty, [componentNode("switch", { ...at, props: { on: "yes" } })])))
+  check("a legal prop passes", !refused(() => addNodes(empty, [componentNode("button", { ...at, props: { variant: "outline" } })])))
+  const picture = (src: string): SquigNode =>
+    ({ id: "pic", seed: 1, type: "image", x: 0, y: 0, w: 10, h: 10, src, naturalW: 10, naturalH: 10 }) as SquigNode
+  check("an SVG data URL is refused, since it carries script", refused(() => addNodes(empty, [picture("data:image/svg+xml;base64,xxx")])))
+  check("a png is a picture", !refused(() => addNodes(empty, [picture("data:image/png;base64,AA==")])))
+  check("a zero font size is refused", refused(() => addNodes(empty, [{ ...textNode("hi", at), fontSize: 0 }])))
+}
+
+// -- a caller's own group id, and a caller's own ruler ----------------------
+
+{
+  const doc = addNodes(emptyDoc("mine"), [
+    shapeNode("rect", { x: 0, y: 0, w: 10, h: 10, id: "a", seed: 1 }),
+    shapeNode("rect", { x: 20, y: 0, w: 10, h: 10, id: "b", seed: 1 }),
+  ])
+  const g = groupNodes(doc, ["a", "b"], "chosen")
+  check("a group can be named by the caller", g?.groupId === "chosen" && g.doc.nodes.a.groupIds?.[0] === "chosen")
+
+  const wide: TextMeasurer = (text) => text.length * 40
+  const guessed = textNode("one two three four", { x: 0, y: 0, w: 120, seed: 1 })
+  const measured = textNode("one two three four", { x: 0, y: 0, w: 120, seed: 1 }, wide)
+  check("a measurer that knows the face wraps the words differently", measured.h > guessed.h)
 }
 
 report("document checks passed")

--- a/scripts/test-doc.ts
+++ b/scripts/test-doc.ts
@@ -33,6 +33,7 @@ import {
   shapeNode,
   textNode,
   updateNode,
+  patchNode,
   groupNodes,
   DocError,
   type SquigDocument,
@@ -438,6 +439,11 @@ const button = (id: string, x = 0, y = 0) => componentNode("button", { id, seed:
   check("locking a label leaves its box alone", locked.nodes.t.w === 160 && locked.nodes.t.h === 80)
   const reworded = updateNode(doc, "t", { text: "Hello there" } as Partial<SquigNode>)
   check("…while new words re-fit it", reworded.nodes.t.w !== 160)
+  const wrapped = textNode("two lines of words here", { x: 0, y: 0, w: 80, fontSize: 18, seed: 1, id: "p" })
+  const squashed = patchNode(wrapped, { h: 1 } as Partial<SquigNode>) as TextNode
+  check("a height patch is a floor the words may push past", squashed.h >= wrapped.h && squashed.fixedH === true)
+  const roomy = patchNode(wrapped, { h: 300 } as Partial<SquigNode>) as TextNode
+  check("…and a roomy one is kept", roomy.h === 300)
   const long = "y".repeat(80)
   check("an eighty-character id is welcome", addNodes(emptyDoc("ids"), [shapeNode("rect", { x: 0, y: 0, w: 1, h: 1, id: long, seed: 1 })]).order[0] === long)
 }

--- a/scripts/test-doc.ts
+++ b/scripts/test-doc.ts
@@ -428,4 +428,18 @@ const button = (id: string, x = 0, y = 0) => componentNode("button", { id, seed:
   check("a measurer that knows the face wraps the words differently", measured.h > guessed.h)
 }
 
+// -- a patch reaches only as far as it says -----------------------------------
+
+{
+  const doc = addNodes(emptyDoc("still"), [
+    { ...textNode("Hi", { x: 0, y: 0, align: "center", fontSize: 20, seed: 1, id: "t" }), x: 0, w: 160, h: 80 } as SquigNode,
+  ])
+  const locked = updateNode(doc, "t", { locked: true })
+  check("locking a label leaves its box alone", locked.nodes.t.w === 160 && locked.nodes.t.h === 80)
+  const reworded = updateNode(doc, "t", { text: "Hello there" } as Partial<SquigNode>)
+  check("…while new words re-fit it", reworded.nodes.t.w !== 160)
+  const long = "y".repeat(80)
+  check("an eighty-character id is welcome", addNodes(emptyDoc("ids"), [shapeNode("rect", { x: 0, y: 0, w: 1, h: 1, id: long, seed: 1 })]).order[0] === long)
+}
+
 report("document checks passed")

--- a/scripts/test-doc.ts
+++ b/scripts/test-doc.ts
@@ -444,6 +444,10 @@ const button = (id: string, x = 0, y = 0) => componentNode("button", { id, seed:
   check("a height patch is a floor the words may push past", squashed.h >= wrapped.h && squashed.fixedH === true)
   const roomy = patchNode(wrapped, { h: 300 } as Partial<SquigNode>) as TextNode
   check("…and a roomy one is kept", roomy.h === 300)
+  const letGo = patchNode(roomy, { h: 300, fixedH: undefined } as Partial<SquigNode>) as TextNode
+  check("a size handed back with the flag let go is not a chosen size", letGo.fixedH === undefined && letGo.h === wrapped.h)
+  const loose = patchNode(wrapped, { w: 200, fixedW: false } as Partial<SquigNode>) as TextNode
+  check("…and the same for width", !loose.fixedW)
   const long = "y".repeat(80)
   check("an eighty-character id is welcome", addNodes(emptyDoc("ids"), [shapeNode("rect", { x: 0, y: 0, w: 1, h: 1, id: long, seed: 1 })]).order[0] === long)
 }


### PR DESCRIPTION
The follow-up named in #82: the workspace engine now stands on `lib/doc.ts` instead of re-implementing its rules.

## What moved

- **One node gate.** `vouchNode` in `lib/doc.ts` now carries every rule `lib/agent/engine.ts`'s `cleanNode` enforced by hand: ids that reach the prototype, unknown kinds, a select prop off its list, a number prop past its range, a toggle that is not a boolean, a def that throws on its props, a picture that is not a raster data URL, font sizes outside 1..1000. The CLI, `window.squig` and the store's imports get those refusals too; they used to accept, say, `variant: "neon"` and let the canvas find out.
- **The engine calls lib/doc for node rules and keeps its batch contract.** `cleanNode` is zod at the boundary plus prefill, then `vouchNode`. `note` is `textNode` with the workspace's fontkit measurer, read off the document as it stands (a `look` op earlier in the batch changes the face), so a note wraps where the render breaks it; the hand-rolled height guess is gone. `update` is zod on the merged fields, then `patchNode` (props merge; a text box is re-fit only when the patch touches its words or measure, so locking a label leaves it put). `group` is `groupNodes`, which is what ⌘G does. `reorder` front/back are `bringToFront`/`sendToBack`. A batch is still applied whole, with bind settling and group pruning once at the end in `validateDocument`, so an arrow in one `add` may name a box a later `add` brings, and two patches can found a group between them. `DocError` becomes a 400.
- **Text fitting takes a measurer** (`fitTextBox`, `textNode`, `updateNode`), the same `TextMeasurer` the renderer already accepted.

## Behaviour changes in the workspace API

- `group` now nests a new group under the members' shared parent (⌘G semantics) instead of prepending a group id; a locked member is left out; nothing to group is a 400. `lib/agent/docs.ts` says so.
- `delete` prunes a group left with one member and releases arrows bound to the deleted node, as the app does.
- The duplicate-id message reads `there is already a node called "x"`; the status is still 409.

## Verified

- `pnpm verify` (lint, both typechecks, 25 suites; the agent suite grew from 225 to 240 checks, the document suite from 81 to 95) and `make build-xdc`.
- Four Codex passes. The second found seven regressions that shared one cause (per-step settling where the API promised batch-level invariants); the third and fourth found four more edge cases in text sizing and mid-batch grouping. All are fixed with a check each (agent suite 225 → 242, document suite 81 → 99).

## Known and unchanged

- A `look` op that switches the font after a note was fitted leaves the note's box sized for the old face. The browser behaves the same way today (a font change does not re-fit existing text), so this PR keeps that rather than inventing a rule the canvas does not have.
- `eslint` also ignores `.claude/**` now, so a local lint no longer walks stale worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JpEu2BWtDAPLJrFeeCH6y
