### PR TITLE
Connect agents to SVG canvases and prepare storage before deployment

### DIFF
--- a/components/agent/bridge.tsx
+++ b/components/agent/bridge.tsx
@@ -4,6 +4,7 @@ import { useCanvasSyncIssue } from "@/lib/agent/sync-status"
 import { useSquig } from "@/lib/store"
 import { agentRequest, KEY_STORAGE } from "@/lib/agent/client"
 import { agentInvite, mcpConfig } from "@/lib/agent/invite"
+import { prepareCanvas, applyPreparedImages } from "@/lib/agent/prepare-canvas"
 import { unionBox } from "@/lib/types"
 import { nodeVisualBounds } from "@/lib/canvas/line-routing"
 import { fitViewport } from "@/lib/canvas/navigate"
@@ -58,6 +59,8 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
     id: "",
   })
   const [reload, setReload] = useState(0)
+  const [connectError, setConnectError] = useState("")
+  const [connectBusy, setConnectBusy] = useState(false)
   useEffect(() => {
     const id = new URLSearchParams(location.search).get("agent")
     if (!id) return
@@ -282,9 +285,15 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
   async function connect() {
     if (credentials.key || connecting.current) return
     connecting.current = true
+    setConnectBusy(true)
+    setConnectError("")
+    clearIssue()
+    setStatus("Connecting this canvas…")
     const sourceId = useSquig.getState().docId
-    const doc = JSON.parse(useSquig.getState().serialize())
     try {
+      const original = JSON.parse(useSquig.getState().serialize())
+      const doc = await prepareCanvas(original)
+      if (useSquig.getState().docId !== sourceId) return
       let key = localStorage.getItem(KEY_STORAGE)
       if (!key) {
         const workspace = await agentRequest("workspaces", "", {
@@ -323,6 +332,13 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
       })
       localStorage.setItem(canvasStorage(created.id), created.canvasKey)
       if (useSquig.getState().docId !== sourceId) return
+      // Undo must not reintroduce a legacy SVG into the connected document.
+      const state = useSquig.getState()
+      useSquig.setState({
+        nodes: applyPreparedImages(state.nodes, original, doc),
+        past: state.past.map((frame) => ({ ...frame, nodes: applyPreparedImages(frame.nodes, original, doc) })),
+        future: state.future.map((frame) => ({ ...frame, nodes: applyPreparedImages(frame.nodes, original, doc) })),
+      })
       attaching.current = created.id
       history.pushState(null, "", `/?agent=${created.id}`)
       setCredentials({
@@ -332,10 +348,14 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
       })
       setReload((v) => v + 1)
     } catch (e) {
-      if (useSquig.getState().docId === sourceId)
-        reportIssue((e as Error).message)
+      if (useSquig.getState().docId === sourceId) {
+        const message = (e as Error).message
+        setConnectError(message)
+        reportIssue("Could not connect this canvas. Open Connect agent to try again.")
+      }
     } finally {
       connecting.current = false
+      setConnectBusy(false)
       if (useSquig.getState().docId !== sourceId) {
         setPanel(null)
         setStatus("")
@@ -420,7 +440,18 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
                     />
                   )
                 ) : (
-                  <p role="status">{status || "Preparing canvas…"}</p>
+                  <>
+                    <p role={connectError ? "alert" : "status"}>{connectError || status || "Preparing canvas…"}</p>
+                    {connectError && (
+                      <>
+                        <p>Your local canvas is still available to edit and save.</p>
+                        <button type="button" className="agent-invite-copy" disabled={connectBusy} onClick={() => void connect()}>
+                          {connectBusy ? "Connecting…" : "Try again"}
+                        </button>
+                        <a href="/docs/self-hosting" target="_blank" rel="noreferrer">Operator setup guide</a>
+                      </>
+                    )}
+                  </>
                 )}
               </Popover.Popup>
             </Popover.Positioner>

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -77,6 +77,29 @@ retained for migration compatibility; no review interface or endpoint is
 exposed. Database backups, retention and operating budgets belong to the host.
 The Webxdc package keeps the offline canvas and excludes hosted connections.
 
+Before promoting a deployment, run `pnpm db:check` with that deployment's
+`DATABASE_URL` and database role. It is a read-only preflight: required columns
+in all five tables, table privileges and the nullable `review_hash` upgrade.
+It emits JSON and exits nonzero when storage is not ready. Run `pnpm db:migrate`
+and repeat the check for a schema failure. Both commands accept environment
+variables directly and optionally load `.env.local`. They are intentionally
+separate from ordinary local builds: the editor and offline package need no database.
+The REST/MCP preview smoke suite remains the check for actual writes.
+
+Vercel's build command is `pnpm build:hosted`: migrate, check readiness, then
+build. Schema upgrades happen automatically before the new deployment can
+receive traffic. A missing database or failed migration stops the deployment;
+so that release cannot replace the working live site. Other
+hosts can use the same command. Keep migrations additive and compatible with
+the currently serving release. Runtime requests never run migrations.
+
+REST and MCP return sanitized 503 diagnostics with stable `AGENT_STORAGE_*`
+codes for missing configuration, migration, permissions and availability.
+Database error text, credentials and query details are never returned or logged.
+Failed connections retain the local canvas and show a retry action. Legacy SVG
+images are rasterized in the browser for sharing; failed uploads leave the
+local document unchanged. Newly pasted SVGs are also stored as raster images.
+
 ## Verification
 
 Run `pnpm test`, `pnpm test:agent`, `pnpm lint`, `pnpm build` and `make build-xdc`.
@@ -84,3 +107,9 @@ With the app running and DATABASE_URL loaded, run the real REST/MCP integration
 suite and `pnpm test:agent:browser`. These create isolated fixtures and clean
 them up. Browser coverage includes direct invitations, existing local files,
 two live editors, independent concurrent writes and conflicting draft recovery.
+
+For rollout regressions without a database, start `DATABASE_URL='' pnpm dev
+--port 3011`, then run `pnpm test:agent:rollout`. This checks the real missing
+configuration response, then uses isolated HTTP fixtures for an unmigrated
+database and recovery. It covers retry, preserved local editing, legacy SVG
+sharing and SVG paste. Screenshots are saved under `test-results/agent-rollout`.

--- a/lib/agent/db.ts
+++ b/lib/agent/db.ts
@@ -1,17 +1,21 @@
 import { neon } from "@neondatabase/serverless"
 import { createHash, randomBytes } from "node:crypto"
 import { AgentError, type CanvasDocument } from "./engine"
+import { StorageError } from "./storage"
 
 export const token = () => randomBytes(32).toString("base64url")
 export const hash = (value: string) =>
   createHash("sha256").update(value).digest("hex")
 export function db() {
-  if (!process.env.DATABASE_URL)
-    throw new AgentError(
-      503,
-      "Agent storage is not configured. See /docs/self-hosting.",
-    )
-  return neon(process.env.DATABASE_URL)
+  if (!process.env.DATABASE_URL?.trim())
+    throw new StorageError("AGENT_STORAGE_UNCONFIGURED")
+  try {
+    return neon(process.env.DATABASE_URL, {
+      fetchOptions: { signal: AbortSignal.timeout(10_000) },
+    })
+  } catch {
+    throw new StorageError("AGENT_STORAGE_UNAVAILABLE")
+  }
 }
 export interface StoredDocument {
   id: string

--- a/lib/agent/docs.ts
+++ b/lib/agent/docs.ts
@@ -210,11 +210,16 @@ export const pages: DocPage[] = [
       {
         title: "Install and migrate",
         text: "Create a Neon database through the Vercel Marketplace or your own Neon account. Set DATABASE_URL in .env.local. Set SQUIG_PUBLIC_URL to the public origin of your instance (http://localhost:3000 for local development). The app uses this value for returned canvas links. Keep secrets out of NEXT_PUBLIC_ variables.",
-        code: "pnpm install --frozen-lockfile\nnode --env-file=.env.local scripts/agent/migrate.mjs\npnpm dev",
+        code: "pnpm install --frozen-lockfile\npnpm db:migrate\npnpm db:check\npnpm dev",
       },
       {
         title: "Deployment",
-        text: "Run the additive, idempotent migration before serving traffic. On Vercel, connect the database integration to the deployment environments and configure SQUIG_PUBLIC_URL. Run pnpm test, pnpm test:agent, pnpm lint and pnpm build. Verify a preview with the MCP integration smoke test before promoting it. All API and MCP routes use the Node.js runtime. Back up the database and set retention/budget policies suitable for your instance.",
+        text: "Vercel runs pnpm build:hosted: the additive, idempotent migration, then the readiness check, then the app build. This prepares the schema before the deployment can receive traffic; missing storage or a failed migration stops that deployment. Connect the database integration to the deployment environments and configure SQUIG_PUBLIC_URL. Other hosts should also use pnpm build:hosted. Run pnpm test, pnpm test:agent and pnpm lint, then verify a preview with the MCP integration smoke test before promoting it. The ordinary pnpm build and Webxdc package remain database-free. All API and MCP routes use the Node.js runtime. Back up the database and set retention/budget policies suitable for your instance.",
+      },
+      {
+        title: "Readiness before promotion",
+        text: "Run pnpm db:check with the exact DATABASE_URL and database role used by the target deployment. It reads schema metadata without creating workspaces, consuming signup quotas or changing documents. It checks connectivity, required columns in all five agent tables, table permissions, and the nullable review_hash upgrade. It prints ready: true and exits zero on success; failures exit nonzero with a stable diagnostic code and an operator action. Both db commands accept an injected DATABASE_URL without .env.local; an existing environment variable takes precedence over that file. A passing ordinary build does not prove database readiness. Hosted builds include the check; ordinary local builds and Webxdc remain usable without hosted storage. After the check, run the REST/MCP smoke suite on a preview to verify actual writes before promoting it.",
+        code: "pnpm db:check\n# If AGENT_STORAGE_SCHEMA is reported:\npnpm db:migrate\npnpm db:check",
       },
       {
         title: "Storage and access",

--- a/lib/agent/http.ts
+++ b/lib/agent/http.ts
@@ -1,5 +1,6 @@
 import { ZodError } from "zod"
 import { AgentError } from "./engine"
+import { storageFailure } from "./storage"
 export const headers = {
   "Cache-Control": "no-store",
   "X-Content-Type-Options": "nosniff",
@@ -9,13 +10,18 @@ export function json(value: unknown, status = 200) {
   return Response.json(value, { status, headers })
 }
 export function failure(error: unknown) {
+  const storage = storageFailure(error)
+  if (storage) {
+    console.error("Agent storage unavailable", storage.code)
+    return json({ error: storage.message, code: storage.code }, storage.status)
+  }
   if (error instanceof ZodError)
     return json({ error: "Invalid input", details: error.issues }, 400)
   if (error instanceof AgentError)
     return json({ error: error.message }, error.status)
   console.error(
     "Agent request failed",
-    error instanceof Error ? error.message : "Unknown error",
+    "Unexpected internal error",
   )
   return json(
     {

--- a/lib/agent/prepare-canvas.ts
+++ b/lib/agent/prepare-canvas.ts
@@ -1,0 +1,27 @@
+import { rasterizeImageSource } from "../clipboard"
+import type { SquigDoc, SquigNode } from "../types"
+
+/** Only the shared copy changes; a failed connection leaves the local file intact. */
+export async function prepareCanvas<T extends SquigDoc>(doc: T, rasterize = rasterizeImageSource): Promise<T> {
+  const nodes = { ...doc.nodes }
+  for (const [id, node] of Object.entries(nodes)) {
+    if (node.type !== "image" || !/^data:image\/svg\+xml[;,]/i.test(node.src)) continue
+    try {
+      const src = await rasterize(node.src)
+      if (!/^data:image\/(png|jpeg|webp|gif);base64,/i.test(src)) throw new Error("Not a raster")
+      nodes[id] = { ...node, src }
+    } catch {
+      throw new Error(`Could not prepare the SVG image “${node.name || id}” for sharing. Replace it with a PNG, JPEG, WebP or GIF and try again. Your local canvas is unchanged.`)
+    }
+  }
+  return { ...doc, nodes }
+}
+
+/** Preserve edits made during upload, including replacing an image's source. */
+export function applyPreparedImages(nodes: Record<string, SquigNode>, original: SquigDoc, prepared: SquigDoc) {
+  return Object.fromEntries(Object.entries(nodes).map(([id, node]) => {
+    const before = original.nodes[id], after = prepared.nodes[id]
+    return [id, node.type === "image" && before?.type === "image" && after?.type === "image" &&
+      node.src === before.src && before.src !== after.src ? { ...node, src: after.src } : node]
+  }))
+}

--- a/lib/agent/readiness.ts
+++ b/lib/agent/readiness.ts
@@ -1,0 +1,31 @@
+import { db } from "./db"
+import { StorageError, storageFailure } from "./storage"
+
+export const requiredColumns = {
+  agent_workspaces: "id, name, key_hash, created_at",
+  agent_documents: "id, workspace_id, document, revision, review_hash, canvas_hash, approval, updated_at",
+  agent_revisions: "document_id, revision, document, created_at",
+  agent_comments: "id, document_id, text, author, node_id, variation_id, resolved, created_at",
+  agent_limits: "key, bucket, count",
+}
+type Query = (sql: string) => Promise<Record<string, unknown>[]>
+
+/** Read-only and deliberately uncached: run against the deployment's own role. */
+export async function checkReadiness(query: Query = (sql) => db().query(sql)) {
+  try {
+    for (const [table, columns] of Object.entries(requiredColumns)) {
+      await query(`SELECT ${columns} FROM ${table} LIMIT 0`)
+      const [access] = await query(`SELECT has_table_privilege(current_user, '${table}', 'SELECT')
+        AND has_table_privilege(current_user, '${table}', 'INSERT')
+        AND has_table_privilege(current_user, '${table}', 'UPDATE')
+        AND has_table_privilege(current_user, '${table}', 'DELETE') AS allowed`)
+      if (!access?.allowed) throw new StorageError("AGENT_STORAGE_PERMISSIONS")
+    }
+    const [review] = await query(`SELECT attnotnull FROM pg_attribute
+      WHERE attrelid = 'agent_documents'::regclass AND attname = 'review_hash' AND NOT attisdropped`)
+    if (!review || review.attnotnull !== false) throw new StorageError("AGENT_STORAGE_SCHEMA")
+    return { ready: true, checks: ["connection", "columns", "permissions", "nullable review_hash"] }
+  } catch (error) {
+    throw storageFailure(error) ?? error
+  }
+}

--- a/lib/agent/storage.ts
+++ b/lib/agent/storage.ts
@@ -1,0 +1,34 @@
+import { NeonDbError } from "@neondatabase/serverless"
+
+const diagnostics = {
+  AGENT_STORAGE_UNCONFIGURED: "Agent storage is not configured. Operator: set DATABASE_URL for this deployment, run pnpm db:migrate, then pnpm db:check. See /docs/self-hosting.",
+  AGENT_STORAGE_SCHEMA: "Agent storage needs a database migration. Operator: run pnpm db:migrate against this deployment’s DATABASE_URL, then pnpm db:check. See /docs/self-hosting.",
+  AGENT_STORAGE_UNAVAILABLE: "Agent storage is unavailable. Operator: check this deployment’s DATABASE_URL, database availability and network access, then run pnpm db:check. See /docs/self-hosting.",
+  AGENT_STORAGE_PERMISSIONS: "Agent storage permissions are incomplete. Operator: grant the database role access to the agent tables, then run pnpm db:check. See /docs/self-hosting.",
+}
+export type StorageCode = keyof typeof diagnostics
+export class StorageError extends Error {
+  readonly status = 503
+  code: StorageCode
+  constructor(code: StorageCode) {
+    super(diagnostics[code])
+    this.code = code
+  }
+}
+
+/** Use SQLSTATE, never a database message that may contain credentials or data. */
+export function storageFailure(error: unknown): StorageError | null {
+  if (error instanceof StorageError) return error
+  const code = error && typeof error === "object" && "code" in error ? error.code : undefined
+  if (code === "42P01" || code === "42703" || code === "42P10") return new StorageError("AGENT_STORAGE_SCHEMA")
+  if (code === "42501") return new StorageError("AGENT_STORAGE_PERMISSIONS")
+  // Older installations required review_hash before canvas invitations existed.
+  if (code === "23502" && "table" in (error as object) && "column" in (error as object) &&
+      (error as { table: string }).table === "agent_documents" &&
+      (error as { column: string }).column === "review_hash")
+    return new StorageError("AGENT_STORAGE_SCHEMA")
+  if ((error instanceof NeonDbError && !code) || (typeof code === "string" &&
+      (code.startsWith("08") || ["28P01", "28000", "3D000", "53300", "57P01", "57P02", "57P03", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND"].includes(code))))
+    return new StorageError("AGENT_STORAGE_UNAVAILABLE")
+  return null
+}

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -119,10 +119,24 @@ function supportsWebp(): boolean {
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error("image failed to load"))
+    const timer = setTimeout(() => {
+      img.src = ""
+      reject(new Error("image took too long to load"))
+    }, 10_000)
+    img.onload = () => { clearTimeout(timer); resolve(img) }
+    img.onerror = () => { clearTimeout(timer); reject(new Error("image failed to load")) }
     img.src = src
   })
+}
+
+/** SVGs stay in an image context; never insert their markup into the page. */
+export async function rasterizeImageSource(src: string): Promise<string> {
+  const img = await loadImage(src)
+  const nw = img.naturalWidth || img.width, nh = img.naturalHeight || img.height
+  if (!nw || !nh) throw new Error("image has no dimensions")
+  const raster = reencode(img, nw, nh, "image/svg+xml")
+  if (!raster) throw new Error("image could not be converted")
+  return raster
 }
 
 function blobToDataUrl(blob: Blob): Promise<string> {
@@ -186,7 +200,8 @@ export async function imageNodeFrom(blob: Blob, name?: string): Promise<ImageNod
     // small enough already: keep the original bytes rather than re-encoding
     // them. That's what keeps a crisp UI screenshot crisp — and an animated
     // GIF animated, since a redraw would flatten it to its first frame
-    const asIs = blob.size <= KEEP_ORIGINAL_BYTES && Math.max(nw, nh) <= MAX_EDGE
+    const asIs = /^image\/(png|jpeg|webp|gif)$/i.test(blob.type) &&
+      blob.size <= KEEP_ORIGINAL_BYTES && Math.max(nw, nh) <= MAX_EDGE
     const src = asIs ? await blobToDataUrl(blob) : reencode(img, nw, nh, blob.type)
     if (!src) return null
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:hosted": "pnpm db:migrate && pnpm db:check && pnpm build",
     "build:xdc": "make build-xdc",
     "start": "next start",
     "squig": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./scripts/register-loader.mjs scripts/squig.ts",
@@ -15,7 +16,9 @@
     "test:agent": "node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test.ts agent",
     "test:agent:integration": "node scripts/agent/smoke.mjs",
     "test:agent:browser": "node --env-file=.env.local scripts/agent/browser.mjs",
-    "db:migrate": "node --env-file=.env.local scripts/agent/migrate.mjs",
+    "test:agent:rollout": "node scripts/agent/rollout-browser.mjs",
+    "db:migrate": "node --env-file-if-exists=.env.local scripts/agent/migrate.mjs",
+    "db:check": "node --env-file-if-exists=.env.local --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./scripts/register-loader.mjs scripts/agent/check.ts",
     "verify": "pnpm lint && pnpm test && pnpm build",
     "bench:history": "node --expose-gc --experimental-strip-types --import ./scripts/register-loader.mjs scripts/bench-history.ts",
     "gen:icons": "node scripts/gen-icons.mjs",

--- a/scripts/agent/browser.mjs
+++ b/scripts/agent/browser.mjs
@@ -412,8 +412,13 @@ try {
             fontSize: 32,
             text: "Already on my canvas",
           },
+          logo: {
+            id: "logo", type: "image", x: 0, y: 140, w: 240, h: 120,
+            naturalW: 240, naturalH: 120, seed: 1, name: "Legacy SVG",
+            src: `data:image/svg+xml;base64,${Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120"><rect width="240" height="120" fill="#333"/></svg>').toString("base64")}`,
+          },
         },
-        order: ["existing"],
+        order: ["existing", "logo"],
       }),
     ),
   })
@@ -438,6 +443,15 @@ try {
     (await api(`documents/${attachedId}`)).document.nodes.existing.text,
   ).toBe("Already on my canvas")
   await expect(local.locator(".agent-sync")).toHaveAttribute("data-connected", "true")
+  const attached = await api(`documents/${attachedId}`)
+  expect(attached.document.nodes.logo.src).toMatch(/^data:image\/(png|webp);base64,/)
+  expect(attached.document.nodes.logo.w).toBe(240)
+  await api("tools/edit_document", {
+    documentId: attachedId,
+    revision: attached.revision,
+    operations: [{ op: "add", nodes: [{ id: "agent_reply", type: "text", x: 0, y: 300, text: "Agent joined this canvas", fontSize: 24 }] }],
+  })
+  await expect(local.getByText("Agent joined this canvas", { exact: true }).first()).toBeVisible({ timeout: 15000 })
   const idleRevision = (await api(`documents/${attachedId}`)).revision
   let idlePolls = 0
   const countIdlePoll = (request) => {
@@ -534,7 +548,7 @@ try {
   await mkdir("test-results", { recursive: true })
   await page.screenshot({ path: "test-results/agent-connect-mobile.png" })
   console.log(
-    "✓ Browser workflow passed: direct canvas invitation, scoped connection, visible editable wireframes, human edits, remote sync, genuine conflict, draft recovery, SEO and mobile layouts; no page errors.",
+    "✓ Browser workflow passed: direct canvas invitation, legacy SVG sharing, agent joins and draws, scoped connection, visible editable wireframes, human edits, remote sync, genuine conflict, draft recovery, SEO and mobile layouts; no page errors.",
   )
 } finally {
   await browser.close()

--- a/scripts/agent/check.ts
+++ b/scripts/agent/check.ts
@@ -1,0 +1,14 @@
+import { checkReadiness } from "../../lib/agent/readiness.ts"
+import { storageFailure } from "../../lib/agent/storage.ts"
+
+try {
+  console.log(JSON.stringify(await checkReadiness()))
+} catch (error) {
+  const diagnostic = storageFailure(error)
+  console.error(JSON.stringify({
+    ready: false,
+    code: diagnostic?.code ?? "AGENT_PREFLIGHT_FAILED",
+    error: diagnostic?.message ?? "Agent preflight failed. Check the database configuration and run pnpm db:migrate, then pnpm db:check. See /docs/self-hosting.",
+  }))
+  process.exitCode = 1
+}

--- a/scripts/agent/rollout-browser.mjs
+++ b/scripts/agent/rollout-browser.mjs
@@ -1,0 +1,102 @@
+import { chromium, expect } from "@playwright/test"
+import { mkdir } from "node:fs/promises"
+
+// Run against a dev server with DATABASE_URL unset. Recovery uses an isolated
+// HTTP fixture so this check never needs, or writes to, a hosted database.
+const base = process.env.SQUIG_TEST_URL ?? "http://localhost:3011"
+const browser = await chromium.launch()
+const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } })
+const page = await context.newPage()
+const errors = []
+const requests = []
+page.on("pageerror", (error) => errors.push(error.message))
+page.on("request", (request) => { if (request.url().includes("/api/v1/")) requests.push(request.url()) })
+try {
+  await page.goto(base)
+  await page.waitForFunction(() => !!window.squig)
+  await page.evaluate(() => {
+    window.squig.addText("My local drawing", { x: 150, y: 180 })
+  })
+  const original = await page.evaluate(() => window.squig.serialize())
+  expect(requests).toHaveLength(0)
+  await page.getByRole("button", { name: "Connect agent", exact: true }).click()
+  await expect(page.getByRole("alert").filter({ hasText: "Agent storage is not configured" })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible()
+  expect(await page.evaluate(() => window.squig.serialize())).toBe(original)
+  expect(new URL(page.url()).search).toBe("")
+  await mkdir("test-results/agent-rollout", { recursive: true })
+  await page.screenshot({ path: "test-results/agent-rollout/missing-database.png" })
+
+  // A schema failure must be retryable without closing the popover.
+  await page.route("**/api/v1/**", (route) => route.fulfill({
+    status: 503, contentType: "application/json", body: JSON.stringify({
+      code: "AGENT_STORAGE_SCHEMA",
+      error: "Agent storage needs a database migration. Operator: run pnpm db:migrate, then pnpm db:check. See /docs/self-hosting.",
+    }),
+  }))
+  await page.getByRole("button", { name: "Try again" }).click()
+  await expect(page.getByRole("alert").filter({ hasText: "needs a database migration" })).toBeVisible()
+  expect(await page.evaluate(() => window.squig.serialize())).toBe(original)
+  await page.keyboard.press("Escape")
+  await page.evaluate(() => window.squig.addText("Still editable", { x: 150, y: 250 }))
+  expect(await page.evaluate(() => window.squig.serialize())).toContain("Still editable")
+
+  // Load an older local canvas containing an embedded SVG.
+  await page.evaluate(() => {
+    const doc = JSON.parse(window.squig.serialize())
+    doc.nodes.logo = {
+      id: "logo", type: "image", x: 150, y: 320, w: 240, h: 120,
+      naturalW: 240, naturalH: 120, seed: 1, name: "Legacy logo",
+      src: `data:image/svg+xml;base64,${btoa('<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120"><rect width="240" height="120" fill="#333"/><text x="25" y="65" fill="white" font-size="25">Legacy SVG</text></svg>')}`,
+    }
+    doc.order.push("logo")
+    window.squig.load(JSON.stringify(doc))
+  })
+  const legacy = await page.evaluate(() => window.squig.serialize())
+  await page.getByRole("button", { name: "Connect agent", exact: true }).click()
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible()
+  expect(await page.evaluate(() => window.squig.serialize())).toBe(legacy)
+
+  await page.unroute("**/api/v1/**")
+  let uploaded
+  let revision = 1
+  const canvasKey = "sq_canvas_rollout_fixture"
+  const id = "rollout_fixture"
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname.replace("/api/v1/", "")
+    const body = route.request().postDataJSON()
+    let result
+    if (path === "workspaces") result = { key: "sq_workspace_fixture" }
+    else if (path === "documents") result = { id, revision, canvasKey }
+    else if (path === "tools/replace_document") {
+      uploaded = body.document
+      revision++
+      result = { id, revision, document: uploaded }
+    } else if (path === `documents/${id}`) result = { id, revision, document: uploaded }
+    else throw new Error(`Unexpected route ${path}`)
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(result) })
+  })
+  await page.getByRole("button", { name: "Try again" }).click()
+  await expect(page.getByRole("button", { name: "Copy for your agent" })).toBeVisible()
+  await expect(page.locator(".agent-sync")).toHaveAttribute("data-connected", "true")
+  expect(uploaded.nodes.logo.src).toMatch(/^data:image\/(png|webp);base64,/)
+  expect(uploaded.nodes.logo.w).toBe(240)
+  expect(await page.evaluate(() => window.squig.doc().nodes.logo.src)).toBe(uploaded.nodes.logo.src)
+  await page.screenshot({ path: "test-results/agent-rollout/connected-svg.png" })
+
+  // Actual clipboard ingestion must rasterize even small SVGs.
+  await page.keyboard.press("Escape")
+  await expect(page.locator(".agent-connect-panel")).toHaveCount(0)
+  await page.evaluate(() => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30"><circle cx="15" cy="15" r="12"/></svg>'
+    const transfer = new DataTransfer()
+    transfer.items.add(new File([svg], "tiny.svg", { type: "image/svg+xml" }))
+    document.dispatchEvent(new ClipboardEvent("paste", { clipboardData: transfer, bubbles: true }))
+  })
+  await expect.poll(() => page.evaluate(() => Object.values(window.squig.doc().nodes).filter((n) => n.type === "image").length)).toBe(2)
+  expect(await page.evaluate(() => Object.values(window.squig.doc().nodes).filter((n) => n.type === "image").every((n) => /^data:image\/(png|webp|jpeg|gif);base64,/.test(n.src)))).toBe(true)
+  expect(errors).toEqual([])
+  console.log("Browser rollout checks passed: local editing, missing database, schema diagnostic, retry, legacy SVG sharing and SVG paste.")
+} finally {
+  await browser.close()
+}

--- a/scripts/test-agent-storage.ts
+++ b/scripts/test-agent-storage.ts
@@ -1,0 +1,137 @@
+import { isDeepStrictEqual } from "node:util"
+import { spawnSync } from "node:child_process"
+import { neonConfig } from "@neondatabase/serverless"
+import { check, report } from "./harness.ts"
+import { db } from "../lib/agent/db.ts"
+import { failure } from "../lib/agent/http.ts"
+import { StorageError, storageFailure } from "../lib/agent/storage.ts"
+import { checkReadiness, requiredColumns } from "../lib/agent/readiness.ts"
+import { prepareCanvas, applyPreparedImages } from "../lib/agent/prepare-canvas.ts"
+import { emptyDocument, validateDocument, AgentError } from "../lib/agent/engine.ts"
+import { POST as rest, GET as get } from "../app/api/v1/[...path]/route.ts"
+import { POST as mcp } from "../app/mcp/route.ts"
+
+const savedEnv = process.env.DATABASE_URL
+const savedFetch = neonConfig.fetchFunction
+const savedLog = console.error
+const logs: string[] = []
+console.error = (...args) => { logs.push(args.join(" ")) }
+const context = (path: string) => ({ params: Promise.resolve({ path: path.split("/") }) })
+const request = (path: string, data?: unknown, key = "sq_test") => new Request(`http://localhost/api/v1/${path}`, {
+  method: data === undefined ? "GET" : "POST",
+  headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+  ...(data === undefined ? {} : { body: JSON.stringify(data) }),
+})
+async function diagnostic(response: Response, code: string) {
+  const data = await response.json()
+  check(`${code} returns a no-store 503`, response.status === 503 && response.headers.get("Cache-Control") === "no-store")
+  check(`${code} has actionable operator guidance`, data.code === code && data.error.includes("Operator:") && data.error.includes("pnpm db:check"))
+  check(`${code} contains no database secrets`, !JSON.stringify(data).includes("private-secret"))
+}
+try {
+  delete process.env.DATABASE_URL
+  await diagnostic(await rest(request("workspaces", { name: "Test" }), context("workspaces")), "AGENT_STORAGE_UNCONFIGURED")
+  await diagnostic(await get(request("documents"), context("documents")), "AGENT_STORAGE_UNCONFIGURED")
+  await diagnostic(await mcp(request("mcp", {})), "AGENT_STORAGE_UNCONFIGURED")
+  const unauthorized = await get(new Request("http://localhost/api/v1/documents"), context("documents"))
+  check("missing credentials remain a 401", unauthorized.status === 401)
+  const invalid = await rest(request("workspaces", { name: "" }), context("workspaces"))
+  check("invalid input remains a 400", invalid.status === 400)
+  process.env.DATABASE_URL = "not-a-connection-string-private-secret"
+  try { db(); check("invalid connection refused", false) } catch (error) {
+    check("invalid connection has sanitized guidance", storageFailure(error)?.code === "AGENT_STORAGE_UNAVAILABLE")
+  }
+
+  process.env.DATABASE_URL = "postgresql://test:private-secret@db.example.invalid/test"
+  for (const [code, expected, extra] of [
+    ["42P01", "AGENT_STORAGE_SCHEMA", {}],
+    ["42703", "AGENT_STORAGE_SCHEMA", {}],
+    ["23502", "AGENT_STORAGE_SCHEMA", { table: "agent_documents", column: "review_hash" }],
+    ["42501", "AGENT_STORAGE_PERMISSIONS", {}],
+    ["28P01", "AGENT_STORAGE_UNAVAILABLE", {}],
+  ] as const) {
+    neonConfig.fetchFunction = async () => Response.json({ code, message: "private-secret SQL details", ...extra }, { status: 400 })
+    await diagnostic(await rest(request("workspaces", { name: "Test" }), context("workspaces")), expected)
+    await diagnostic(await mcp(request("mcp", {})), expected)
+  }
+  neonConfig.fetchFunction = async () => { throw new Error("network private-secret") }
+  await diagnostic(await get(request("documents"), context("documents")), "AGENT_STORAGE_UNAVAILABLE")
+  let calls = 0
+  neonConfig.fetchFunction = async (_url: string, options?: RequestInit) => {
+    calls++
+    check("database requests have a timeout", options?.signal instanceof AbortSignal)
+    const query = JSON.parse(String(options?.body)).query as string
+    return Response.json(query.includes("agent_limits")
+      ? { fields: [{ name: "count", dataTypeID: 23 }], rows: [["1"]] }
+      : { fields: [], rows: [] })
+  }
+  const healthy = await rest(request("workspaces", { name: "Test" }), context("workspaces"))
+  check("configured workspace creation still succeeds", healthy.status === 201 && (await healthy.json()).key.startsWith("sq_") && calls === 2)
+  check("conflicts remain 409", failure(new AgentError(409, "Revision conflict")).status === 409)
+  check("unrelated constraints are not mislabeled as rollout failures", storageFailure({ code: "23502", table: "elsewhere", column: "name" }) === null)
+  check("unexpected error details stay private", !(await failure(new Error("private-secret")).text()).includes("private-secret"))
+  check("server logs contain no driver secrets", logs.every((line) => !line.includes("private-secret")))
+
+  const queries: string[] = []
+  const readyQuery = async (sql: string) => {
+    queries.push(sql)
+    return sql.includes("has_table_privilege") ? [{ allowed: true }] : sql.includes("pg_attribute") ? [{ attnotnull: false }] : []
+  }
+  check("complete schema is ready", (await checkReadiness(readyQuery)).ready)
+  check("preflight executes only reads", queries.every((sql) => sql.startsWith("SELECT ")))
+  check("preflight checks all five tables", Object.keys(requiredColumns).every((table) => queries.some((sql) => sql.includes(`FROM ${table} LIMIT 0`))))
+  for (const table of Object.keys(requiredColumns)) {
+    try {
+      await checkReadiness(async (sql) => {
+        if (sql.includes(`FROM ${table} LIMIT 0`)) throw { code: "42P01" }
+        return readyQuery(sql)
+      })
+      check(`${table} required`, false)
+    } catch (error) { check(`${table} missing requires migration`, storageFailure(error)?.code === "AGENT_STORAGE_SCHEMA") }
+  }
+  for (const [needle, result, code] of [
+    ["has_table_privilege", [{ allowed: false }], "AGENT_STORAGE_PERMISSIONS"],
+    ["pg_attribute", [{ attnotnull: true }], "AGENT_STORAGE_SCHEMA"],
+  ] as const) {
+    try {
+      await checkReadiness(async (sql) => sql.includes(needle) ? [...result] : readyQuery(sql))
+      check(`${needle} failure refused`, false)
+    } catch (error) { check(`${needle} failure diagnosed`, storageFailure(error)?.code === code) }
+  }
+  const cli = spawnSync(process.execPath, ["--experimental-strip-types", "--import", "./scripts/register-loader.mjs", "scripts/agent/check.ts"], {
+    encoding: "utf8", env: { ...process.env, DATABASE_URL: "" },
+  })
+  check("preflight exits nonzero without configuration", cli.status === 1 && cli.stderr.includes("AGENT_STORAGE_UNCONFIGURED") && cli.stderr.includes('"ready":false'))
+  const hosted = spawnSync("pnpm", ["build:hosted"], {
+    encoding: "utf8", env: { ...process.env, DATABASE_URL: "" },
+  })
+  check("hosted build stops before compiling without storage", hosted.status !== 0 && !hosted.stdout.includes("> next build"))
+
+  const original = emptyDocument("Legacy SVG")
+  original.nodes.logo = { id: "logo", type: "image", x: 10, y: 20, w: 200, h: 100, seed: 1,
+    src: "data:image/svg+xml;base64,legacy", naturalW: 400, naturalH: 200, crop: { x: 0.1, y: 0.2, w: 0.8, h: 0.7 } }
+  original.order = ["logo"]
+  const before = structuredClone(original)
+  const raster = "data:image/png;base64,iVBORw0KGgo="
+  const prepared = await prepareCanvas(original, async () => raster)
+  check("sharing converts legacy SVG without changing local file", isDeepStrictEqual(original, before) && prepared.nodes.logo.type === "image" && prepared.nodes.logo.src === raster)
+  check("conversion preserves all image geometry and crop", isDeepStrictEqual(prepared.nodes.logo, { ...original.nodes.logo, src: raster }))
+  check("prepared canvas passes agent validation", !!validateDocument(prepared))
+  let rasterCalls = 0
+  await prepareCanvas(prepared, async () => { rasterCalls++; return raster })
+  check("raster images are not re-encoded", rasterCalls === 0)
+  try { await prepareCanvas(original, async () => { throw new Error("decode failed") }); check("broken SVG refused", false) }
+  catch (error) { check("broken SVG offers an actionable fix", (error as Error).message.includes("Replace it with a PNG")) }
+  check("failed conversion preserves original", isDeepStrictEqual(original, before))
+  const edited = { logo: { ...original.nodes.logo, x: 500 } }
+  check("successful conversion preserves in-flight moves", applyPreparedImages(edited, original, prepared).logo.x === 500)
+  const replacement = { logo: { ...original.nodes.logo, src: "data:image/png;base64,replacement" } }
+  check("successful conversion preserves in-flight replacement", isDeepStrictEqual(applyPreparedImages(replacement, original, prepared), replacement))
+  check("typed storage diagnostics retain 503", new StorageError("AGENT_STORAGE_SCHEMA").status === 503)
+} finally {
+  if (savedEnv === undefined) delete process.env.DATABASE_URL
+  else process.env.DATABASE_URL = savedEnv
+  neonConfig.fetchFunction = savedFetch
+  console.error = savedLog
+}
+report("agent rollout checks passed")

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build:hosted"
+}


### PR DESCRIPTION
Connecting a local canvas containing an SVG image used to stop at a validation error, leaving no invitation to copy. Squig now converts those images to raster data for the shared copy, preserves geometry and edits made during upload, and presents the working agent invitation. New SVG pastes are stored as raster images too. Failed connections preserve the local drawing and offer an explicit retry.

Hosted deployments now run the existing additive migration and a read-only readiness check before building. Missing configuration or a failed migration stops that deployment before it can replace the live site. REST and MCP retain sanitized, actionable 503 diagnostics for storage failures. Ordinary local builds and Webxdc remain independent of hosted storage.

Follow-up to #81, which is already merged.

Validation:

- `pnpm verify`, `pnpm test:agent`, and `make build-xdc` pass; 26 suites include 73 rollout checks.
- The database-free browser suite covers failure, retry, preserved editing, legacy SVG sharing, and actual SVG paste.
- The full browser suite passes against the real database, including an agent adding a visible object to a newly connected SVG-containing canvas, ongoing sync, file switching, and conflict recovery.
- Production's read-only database readiness check and all 51 REST/MCP smoke checks against squig.sh pass. No production schema repair was needed.
- The Vercel preview automatically completed migration, readiness and build, and all 51 real REST/MCP checks pass against that protected preview. GitHub CI is green.

The readiness command is `pnpm db:check`; the deployment command is `pnpm build:hosted`. Runtime requests never run migrations. Merged and deployed to squig.sh. Production migration and readiness checks, all 51 REST/MCP checks, and the full production browser workflow pass, including SVG sharing and an agent joining and drawing. Post-merge CI is green.

