### PR TITLE
Harden workspace and canvas invitation credentials

### DIFF
--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -3,7 +3,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { authenticate } from "@/lib/agent/db"
 import { tools, type ToolName } from "@/lib/agent/schema"
 import { execute } from "@/lib/agent/service"
-import { checkOrigin, failure, body } from "@/lib/agent/http"
+import { checkOrigin, failure, body, headers } from "@/lib/agent/http"
 import { workflow } from "@/lib/agent/workflow"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -129,7 +129,10 @@ export async function POST(request: Request) {
     })
     await server.connect(transport)
     try {
-      return await transport.handleRequest(request, { parsedBody })
+      const response = await transport.handleRequest(request, { parsedBody })
+      for (const [name, value] of Object.entries(headers))
+        response.headers.set(name, value)
+      return response
     } finally {
       await server.close()
     }
@@ -138,6 +141,6 @@ export async function POST(request: Request) {
   }
 }
 export async function GET() {
-  return new Response(null, { status: 405, headers: { Allow: "POST" } })
+  return new Response(null, { status: 405, headers: { ...headers, Allow: "POST" } })
 }
 export const DELETE = GET

--- a/components/agent/bridge.tsx
+++ b/components/agent/bridge.tsx
@@ -3,6 +3,11 @@ import { useEffect, useState, useRef } from "react"
 import { useCanvasSyncIssue } from "@/lib/agent/sync-status"
 import { useSquig } from "@/lib/store"
 import { agentRequest, KEY_STORAGE } from "@/lib/agent/client"
+import {
+  canvasConnection,
+  canvasStorage,
+  workspaceKey,
+} from "@/lib/agent/credentials"
 import { agentInvite, mcpConfig } from "@/lib/agent/invite"
 import { prepareCanvas, applyPreparedImages } from "@/lib/agent/prepare-canvas"
 import { unionBox } from "@/lib/types"
@@ -36,10 +41,10 @@ const editable = (doc: Snapshot): Snapshot => ({
   look: doc.look,
 })
 const equal = canvasEqual
-const canvasStorage = (id: string) => `squig:canvas-key:${id}`
 
 export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
   const attaching = useRef<string | null>(null)
+  const invitation = useRef<{ id: string; fragment: string } | null>(null)
   const [status, setStatus] = useState("")
   function reportIssue(message: string) {
     setStatus(message)
@@ -63,25 +68,14 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
   const [connectBusy, setConnectBusy] = useState(false)
   useEffect(() => {
     const id = new URLSearchParams(location.search).get("agent")
-    if (!id) return
     const fragment = location.hash.slice(1)
-    if (fragment.startsWith("sq_canvas_")) {
-      localStorage.setItem(canvasStorage(id), fragment)
+    // Scrub before validation or storage access, which can throw. Keep the
+    // candidate in memory until the server confirms it belongs to this canvas.
+    if (location.hash && (id !== null || fragment.startsWith("sq_"))) {
       history.replaceState(null, "", location.pathname + location.search)
+      if (id !== null) invitation.current = { id, fragment }
     }
-    const canvasKey = localStorage.getItem(canvasStorage(id))
-    const key = canvasKey || localStorage.getItem(KEY_STORAGE)
-    if (!key) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- browser-only connection hydration
-      reportIssue("Open the full canvas invitation link to connect.")
-      return
-    }
-    if (canvasKey)
-      setCredentials({
-        key: canvasKey,
-        url: `${location.origin}/?agent=${id}#${canvasKey}`,
-        id,
-      })
+    if (id === null) return
     let active = true,
       busy = false,
       initialized = false,
@@ -93,6 +87,7 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
     function detach() {
       active = false
       stopped = true
+      invitation.current = null
       setConnected(false)
       setConflict(false)
       setCredentials({ key: "", url: "", id: "" })
@@ -100,6 +95,34 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
       clearIssue()
       history.replaceState(null, "", "/")
       setStatus("")
+    }
+    function watchDocument() {
+      return useSquig.subscribe((s) => {
+        if (
+          active &&
+          (initialized || stopped) &&
+          s.docId !== (initialized ? localId : openingId)
+        ) detach()
+      })
+    }
+    let connection: ReturnType<typeof canvasConnection>
+    try {
+      connection = canvasConnection(
+        id,
+        invitation.current?.id === id ? invitation.current.fragment : undefined,
+        localStorage,
+      )
+    } catch (e) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- report invalid browser-only invitations after SSR
+      reportIssue((e as Error).message)
+      stopped = true
+      return watchDocument()
+    }
+    const { key, canvasKey } = connection
+    if (!key) {
+      reportIssue("Open the full canvas invitation link to connect.")
+      stopped = true
+      return watchDocument()
     }
     function apply(doc: Snapshot) {
       const s = useSquig.getState()
@@ -146,6 +169,18 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
           if (useSquig.getState().docId !== openingId) {
             detach()
             return
+          }
+          if (canvasKey) {
+            try {
+              localStorage.setItem(canvasStorage(id!), canvasKey)
+            } catch {
+              // A private or full browser can still use this tab's invitation.
+            }
+            setCredentials({
+              key: canvasKey,
+              url: `${location.origin}/?agent=${id}#${canvasKey}`,
+              id: id!,
+            })
           }
           const keepCurrent = attaching.current === id
           if (!keepCurrent)
@@ -253,6 +288,11 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
           return
         }
         const error = e as Error & { status?: number }
+        if (error.status === 401 || error.status === 403 || error.status === 404) {
+          stopped = true
+          setConnected(false)
+          setCredentials({ key: "", url: "", id: "" })
+        }
         // A racing commit is retried against the fresh revision next tick.
         if (error.status !== 409) reportIssue(error.message)
       } finally {
@@ -263,9 +303,7 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
     const timer = setInterval(tick, 1000)
     // Release the old invitation immediately, including while a save is in
     // flight or a conflict has stopped polling.
-    const unsubscribe = useSquig.subscribe((s) => {
-      if (active && initialized && s.docId !== localId) detach()
-    })
+    const unsubscribe = watchDocument()
     const prevent = (e: BeforeUnloadEvent) => {
       if (active && initialized && !equal(snapshot(), baseline)) {
         e.preventDefault()
@@ -284,6 +322,11 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
   const connecting = useRef(false)
   async function connect() {
     if (credentials.key || connecting.current) return
+    // An unopened or revoked invitation must never publish the local draft.
+    if (new URLSearchParams(location.search).has("agent") && !connected) {
+      if (!status) reportIssue("Open a valid canvas invitation before sharing.")
+      return
+    }
     connecting.current = true
     setConnectBusy(true)
     setConnectError("")
@@ -294,7 +337,7 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
       const original = JSON.parse(useSquig.getState().serialize())
       const doc = await prepareCanvas(original)
       if (useSquig.getState().docId !== sourceId) return
-      let key = localStorage.getItem(KEY_STORAGE)
+      let key = workspaceKey(localStorage)
       if (!key) {
         const workspace = await agentRequest("workspaces", "", {
           name: "My Squig canvases",

--- a/components/agent/connect.tsx
+++ b/components/agent/connect.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { AgentShell } from "./shell"
 import { agentRequest, KEY_STORAGE } from "@/lib/agent/client"
+import { keyKind, workspaceKey } from "@/lib/agent/credentials"
 export function Connect() {
   const [key, setKey] = useState(""),
     [input, setInput] = useState(""),
@@ -18,7 +19,7 @@ export function Connect() {
   // The workspace key exists only in this browser, never in server-rendered HTML.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate the private browser credential after SSR
-    setKey(localStorage.getItem(KEY_STORAGE) ?? "")
+    setKey(workspaceKey(localStorage) ?? "")
     setEndpoint(`${location.origin}/mcp`)
   }, [])
   useEffect(() => {
@@ -32,8 +33,13 @@ export function Connect() {
     setError("")
     try {
       let next = existing
-      if (next) await agentRequest("documents", next)
-      else {
+      if (next) {
+        if (keyKind(next) !== "workspace")
+          throw new Error(
+            "Use a workspace key here. Open canvas invitations in the editor.",
+          )
+        await agentRequest("documents", next)
+      } else {
         const r = await fetch("/api/v1/workspaces", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -191,7 +197,7 @@ export function Connect() {
                   <summary>Manage this connection</summary>
                   <p className="agent-muted">
                     Rotating the key disconnects agents using the old one.
-                    Review links keep working.
+                    Editable canvas links keep working.
                   </p>
                   <button
                     className="agent-button secondary"

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -22,8 +22,13 @@ validated, atomic command engine.
 Canvas keys can inspect and edit only their document. They cannot create or
 delete canvases, rotate keys, or access siblings in the workspace. Workspace
 keys can manage those actions. Keys are random and stored as SHA-256 hashes.
-The invitation secret is in the URL fragment; the editor stores it locally
-and removes it from the address bar. The server receives it as a bearer header.
+The invitation secret is in the URL fragment. The editor removes it from the
+address bar before reading storage, and saves or shares it only after the server
+confirms access to that document. A supplied invitation never falls back to the
+browser's workspace key. Rejected or revoked invitations stop synchronization
+and clear the displayed sharing credential, preserving the local draft.
+Workspace and canvas keys have separate formats and storage slots; the workspace
+connection form accepts only workspace keys. The server receives keys as bearer headers.
 `rotate_canvas_link` revokes the previous canvas key without rotating the
 workspace key. Treat invitations as editing credentials.
 
@@ -103,6 +108,10 @@ local document unchanged. Newly pasted SVGs are also stored as raster images.
 ## Verification
 
 Run `pnpm test`, `pnpm test:agent`, `pnpm lint`, `pnpm build` and `make build-xdc`.
+With the app running, `pnpm test:agent:security-browser` checks invitation
+validation, credential storage, revocation, framing headers and the local canvas
+with an intercepted API, requiring no database. Set `SQUIG_TEST_URL` to override
+the default `http://localhost:3000`.
 With the app running and DATABASE_URL loaded, run the real REST/MCP integration
 suite and `pnpm test:agent:browser`. These create isolated fixtures and clean
 them up. Browser coverage includes direct invitations, existing local files,

--- a/lib/agent/client.ts
+++ b/lib/agent/client.ts
@@ -1,4 +1,4 @@
-export const KEY_STORAGE = "squig:agent-key"
+export { KEY_STORAGE } from "./credentials"
 export async function agentRequest(path: string, key: string, data?: unknown) {
   const response = await fetch(`/api/v1/${path}`, {
     method: data === undefined ? "GET" : "POST",
@@ -8,6 +8,8 @@ export async function agentRequest(path: string, key: string, data?: unknown) {
     },
     ...(data === undefined ? {} : { body: JSON.stringify(data) }),
     cache: "no-store",
+    // A credential-bearing request must never follow a redirect to another route.
+    redirect: "error",
   })
   const result = await response.json()
   if (!response.ok)

--- a/lib/agent/credentials.ts
+++ b/lib/agent/credentials.ts
@@ -1,0 +1,39 @@
+export const KEY_STORAGE = "squig:agent-key"
+export const canvasStorage = (id: string) => `squig:canvas-key:${id}`
+
+export function keyKind(key: string): "workspace" | "canvas" | null {
+  if (key.length === 53 && /^sq_canvas_[A-Za-z0-9_-]{43}$/.test(key))
+    return "canvas"
+  if (key.length === 46 && /^sq_[A-Za-z0-9_-]{43}$/.test(key))
+    return "workspace"
+  return null
+}
+
+type KeyStorage = Pick<Storage, "getItem">
+
+export function workspaceKey(storage: KeyStorage): string | null {
+  const key = storage.getItem(KEY_STORAGE)
+  return key && keyKind(key) === "workspace" ? key : null
+}
+
+/** A supplied invitation must succeed on its own, even in an owner's browser. */
+export function canvasConnection(
+  id: string,
+  fragment: string | undefined,
+  storage: KeyStorage,
+) {
+  if (!id || id.length > 80 || /[^A-Za-z0-9_-]/.test(id))
+    throw new Error("Invalid canvas invitation.")
+  if (fragment !== undefined) {
+    if (keyKind(fragment) !== "canvas")
+      throw new Error("Invalid canvas invitation. Open the full editable link.")
+    return { key: fragment, canvasKey: fragment }
+  }
+  const saved = storage.getItem(canvasStorage(id))
+  if (saved) {
+    if (keyKind(saved) !== "canvas")
+      throw new Error("Invalid saved canvas key. Open a new invitation link.")
+    return { key: saved, canvasKey: saved }
+  }
+  return { key: workspaceKey(storage), canvasKey: null }
+}

--- a/lib/agent/db.ts
+++ b/lib/agent/db.ts
@@ -2,6 +2,7 @@ import { neon } from "@neondatabase/serverless"
 import { createHash, randomBytes } from "node:crypto"
 import { AgentError, type CanvasDocument } from "./engine"
 import { StorageError } from "./storage"
+import { keyKind } from "./credentials"
 
 export const token = () => randomBytes(32).toString("base64url")
 export const hash = (value: string) =>
@@ -39,7 +40,9 @@ export async function authenticate(
       401,
       "Supply Authorization: Bearer <key>. Get a canvas key from Connect agent in the editor, or a workspace key at /connect.",
     )
-  if (bearer.startsWith("sq_canvas_")) {
+  const kind = keyKind(bearer)
+  if (!kind) throw new AgentError(401, "Invalid key format")
+  if (kind === "canvas") {
     const rows =
       await db()`SELECT id, workspace_id FROM agent_documents WHERE canvas_hash = ${hash(bearer)}`
     if (!rows.length)

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,22 @@ const webxdc = process.env.WEBXDC === "1";
 const nextConfig: NextConfig = {
   env: { NEXT_PUBLIC_SQUIG_OFFLINE: webxdc ? "1" : "0" },
   ...(webxdc ? { pageExtensions: ["tsx"] } : {}),
+  ...(webxdc
+    ? {}
+    : {
+        async headers() {
+          return [{
+            source: "/:path*",
+            headers: [
+              // Sharing grants editing access; don't let another site overlay its controls.
+              { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+              { key: "X-Frame-Options", value: "DENY" },
+              { key: "Referrer-Policy", value: "no-referrer" },
+              { key: "X-Content-Type-Options", value: "nosniff" },
+            ],
+          }];
+        },
+      }),
   // resvg is a native Node addon: bundling it fails ("non-ecmascript placeable
   // asset"), so it stays a plain require at runtime.
   serverExternalPackages: ["@resvg/resvg-js"],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "pnpm typecheck && node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test.ts",
     "test:agent": "node --experimental-strip-types --import ./scripts/register-loader.mjs scripts/test.ts agent",
     "test:agent:integration": "node scripts/agent/smoke.mjs",
+    "test:agent:security-browser": "node scripts/agent/security-browser.mjs",
     "test:agent:browser": "node --env-file=.env.local scripts/agent/browser.mjs",
     "test:agent:rollout": "node scripts/agent/rollout-browser.mjs",
     "db:migrate": "node --env-file-if-exists=.env.local scripts/agent/migrate.mjs",

--- a/scripts/agent/browser.mjs
+++ b/scripts/agent/browser.mjs
@@ -5,7 +5,7 @@ import { mkdir, readFile } from "node:fs/promises"
 const base = process.env.SQUIG_TEST_URL ?? "http://localhost:3001"
 const sql = neon(process.env.DATABASE_URL)
 const workspace = `browser_${randomBytes(10).toString("hex")}`,
-  key = randomBytes(32).toString("hex")
+  key = `sq_${randomBytes(32).toString("base64url")}`
 const browser = await chromium.launch()
 const context = await browser.newContext({
   viewport: { width: 1440, height: 1000 },

--- a/scripts/agent/demo.mjs
+++ b/scripts/agent/demo.mjs
@@ -6,7 +6,7 @@ import { neon } from "@neondatabase/serverless"
 const base = process.env.SQUIG_TEST_URL ?? "http://localhost:3001"
 const output = process.env.SQUIG_DEMO_FILE ?? "/tmp/squig-agent-demo.json"
 const sql = neon(process.env.DATABASE_URL)
-const key = randomBytes(32).toString("base64url"),
+const key = `sq_${randomBytes(32).toString("base64url")}`,
   workspace = `demo_${randomBytes(8).toString("hex")}`
 await sql`INSERT INTO agent_workspaces (id,name,key_hash) VALUES (${workspace},'Book club exploration',${createHash("sha256").update(key).digest("hex")})`
 async function call(path, data) {

--- a/scripts/agent/rollout-browser.mjs
+++ b/scripts/agent/rollout-browser.mjs
@@ -1,5 +1,6 @@
 import { chromium, expect } from "@playwright/test"
 import { mkdir } from "node:fs/promises"
+import { randomBytes } from "node:crypto"
 
 // Run against a dev server with DATABASE_URL unset. Recovery uses an isolated
 // HTTP fixture so this check never needs, or writes to, a hosted database.
@@ -60,13 +61,13 @@ try {
   await page.unroute("**/api/v1/**")
   let uploaded
   let revision = 1
-  const canvasKey = "sq_canvas_rollout_fixture"
+  const canvasKey = `sq_canvas_${randomBytes(32).toString("base64url")}`
   const id = "rollout_fixture"
   await page.route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname.replace("/api/v1/", "")
     const body = route.request().postDataJSON()
     let result
-    if (path === "workspaces") result = { key: "sq_workspace_fixture" }
+    if (path === "workspaces") result = { key: `sq_${randomBytes(32).toString("base64url")}` }
     else if (path === "documents") result = { id, revision, canvasKey }
     else if (path === "tools/replace_document") {
       uploaded = body.document

--- a/scripts/agent/security-browser.mjs
+++ b/scripts/agent/security-browser.mjs
@@ -1,0 +1,155 @@
+// Browser credential regressions with an intercepted API; no database or account.
+// Start pnpm dev, then run pnpm test:agent:security-browser.
+import { chromium, expect } from "@playwright/test"
+import { randomBytes } from "node:crypto"
+const base = process.env.SQUIG_TEST_URL ?? "http://localhost:3000"
+const owner = `sq_${randomBytes(32).toString("base64url")}`
+const saved = `sq_canvas_${randomBytes(32).toString("base64url")}`
+const candidate = `sq_canvas_${randomBytes(32).toString("base64url")}`
+const slot = "squig:canvas-key:one"
+const browser = await chromium.launch()
+const errors = []
+async function fixture(seed = {}, handler = (route) => route.fulfill({ status: 401, json: { error: "Invalid or revoked canvas key" } })) {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } })
+  // Seed once, without silently restoring poisoned credentials after navigation.
+  await context.addInitScript((seed) => {
+    if (!sessionStorage.getItem("security-seeded")) {
+      for (const [key, value] of Object.entries(seed)) localStorage.setItem(key, value)
+      sessionStorage.setItem("security-seeded", "1")
+    }
+  }, seed)
+  const calls = []
+  await context.route("**/api/v1/**", async (route) => {
+    calls.push({ method: route.request().method(), url: route.request().url(), key: route.request().headers().authorization })
+    await handler(route)
+  })
+  const page = await context.newPage()
+  page.on("pageerror", (error) => errors.push(error.message))
+  return { page, context, calls }
+}
+try {
+  const local = await fixture()
+  const response = await local.page.goto(base)
+  expect(response.headers()["content-security-policy"]).toContain("frame-ancestors 'none'")
+  expect(response.headers()["x-frame-options"]).toBe("DENY")
+  expect(response.headers()["referrer-policy"]).toBe("no-referrer")
+  await local.page.waitForFunction(() => !!window.squig)
+  await local.page.evaluate(() => window.squig.addText("Private local draft", { x: 10, y: 10 }))
+  await expect.poll(() => local.page.evaluate(() => window.squig.doc().order.length)).toBe(1)
+  await local.page.waitForTimeout(1200)
+  await local.page.reload()
+  await local.page.waitForFunction(() => !!window.squig)
+  await expect.poll(() => local.page.evaluate(() => Object.values(window.squig.doc().nodes).some((n) => n.text === "Private local draft"))).toBe(true)
+  expect(local.calls).toEqual([])
+  expect(await local.page.evaluate(() => localStorage.getItem("squig:agent-key"))).toBeNull()
+  const document = await local.page.evaluate(() => ({ ...window.squig.doc(), variations: [] }))
+  await local.context.close()
+
+  for (const fragment of [owner, "sq_canvas_bad", candidate]) {
+    const invalid = await fixture({ "squig:agent-key": owner, [slot]: saved })
+    await invalid.page.goto(`${base}/?agent=one#${fragment}`)
+    await expect.poll(() => new URL(invalid.page.url()).hash).toBe("")
+    await expect(invalid.page.locator(".agent-sync")).toHaveAttribute("data-connected", "false")
+    await invalid.page.getByRole("button", { name: "Share", exact: true }).click()
+    await expect(invalid.page.getByLabel("Editable canvas link", { exact: true })).toHaveCount(0)
+    await invalid.page.waitForTimeout(1200)
+    expect(await invalid.page.evaluate((slot) => localStorage.getItem(slot), slot)).toBe(saved)
+    expect(invalid.calls.every((c) => c.method === "GET" && c.key === `Bearer ${candidate}`)).toBe(true)
+    if (fragment !== candidate) expect(invalid.calls).toEqual([])
+    const stoppedAt = invalid.calls.length
+    await invalid.page.waitForTimeout(1200)
+    expect(invalid.calls.length).toBe(stoppedAt)
+    await invalid.page.evaluate(() => {
+      const doc = JSON.parse(window.squig.serialize())
+      doc.fileName = "Another local drawing"
+      window.squig.load(JSON.stringify(doc))
+    })
+    await expect.poll(() => new URL(invalid.page.url()).search).toBe("")
+    expect(invalid.calls.length).toBe(stoppedAt)
+    await invalid.context.close()
+  }
+
+  let release
+  const pending = new Promise((resolve) => { release = resolve })
+  let revoked = false
+  const valid = await fixture({ "squig:agent-key": owner, [slot]: saved }, async (route) => {
+    await pending
+    await route.fulfill(revoked
+      ? { status: 401, json: { error: "Invalid or revoked canvas key" } }
+      : { json: { id: "one", revision: 1, document } })
+  })
+  await valid.page.goto(`${base}/?agent=one#${candidate}`)
+  await expect.poll(() => valid.calls.length).toBeGreaterThan(0)
+  expect(await valid.page.evaluate((slot) => localStorage.getItem(slot), slot)).toBe(saved)
+  expect(new URL(valid.page.url()).hash).toBe("")
+  await valid.page.getByRole("button", { name: "Share", exact: true }).click()
+  await expect(valid.page.getByLabel("Editable canvas link", { exact: true })).toHaveCount(0)
+  expect(valid.calls.every((c) => c.method === "GET" && c.key === `Bearer ${candidate}`)).toBe(true)
+  release()
+  await expect(valid.page.locator(".agent-sync")).toHaveAttribute("data-connected", "true")
+  await expect(valid.page.getByLabel("Editable canvas link", { exact: true })).toHaveValue(`${base}/?agent=one#${candidate}`)
+  expect(await valid.page.evaluate((slot) => localStorage.getItem(slot), slot)).toBe(candidate)
+  revoked = true
+  await expect(valid.page.locator(".agent-sync")).toHaveAttribute("data-connected", "false")
+  await expect(valid.page.getByLabel("Editable canvas link", { exact: true })).toHaveCount(0)
+  expect(valid.calls.every((c) => c.method === "GET" && c.key === `Bearer ${candidate}`)).toBe(true)
+  await valid.context.close()
+
+  const poisoned = await fixture({ "squig:agent-key": owner, [slot]: owner })
+  await poisoned.page.goto(`${base}/?agent=one`)
+  await poisoned.page.getByRole("button", { name: "Share", exact: true }).click()
+  await expect(poisoned.page.getByLabel("Editable canvas link", { exact: true })).toHaveCount(0)
+  expect(poisoned.calls).toEqual([])
+  for (const id of ["../../catalog", ""]) {
+    await poisoned.page.goto(`${base}/?agent=${encodeURIComponent(id)}#${candidate}`)
+    await expect.poll(() => new URL(poisoned.page.url()).hash).toBe("")
+    expect(poisoned.calls).toEqual([])
+    await poisoned.page.evaluate(() => window.squig.load(window.squig.serialize()))
+    await expect.poll(() => new URL(poisoned.page.url()).search).toBe("")
+  }
+  await poisoned.context.close()
+
+  const redirected = await fixture({}, (route) => route.fulfill({
+    status: 302, headers: { Location: `${base}/credential-sink` },
+  }))
+  let forwarded = false
+  await redirected.context.route("**/credential-sink", (route) => {
+    forwarded = true
+    return route.fulfill({ json: {} })
+  })
+  await redirected.page.goto(`${base}/?agent=one#${candidate}`)
+  await expect.poll(() => redirected.calls.length).toBeGreaterThan(0)
+  await redirected.page.waitForTimeout(1200)
+  expect(forwarded).toBe(false)
+  expect(await redirected.page.evaluate((slot) => localStorage.getItem(slot), slot)).toBeNull()
+  await redirected.context.close()
+
+  const full = await fixture({}, (route) => route.fulfill({ json: { id: "one", revision: 1, document } }))
+  await full.context.addInitScript(() => {
+    const set = Storage.prototype.setItem
+    Storage.prototype.setItem = function (key, value) {
+      if (key.startsWith("squig:canvas-key:")) throw new DOMException("Full", "QuotaExceededError")
+      return set.call(this, key, value)
+    }
+  })
+  await full.page.goto(`${base}/?agent=one#${candidate}`)
+  await expect(full.page.locator(".agent-sync")).toHaveAttribute("data-connected", "true")
+  expect(new URL(full.page.url()).hash).toBe("")
+  expect(await full.page.evaluate((slot) => localStorage.getItem(slot), slot)).toBeNull()
+  await full.page.getByRole("button", { name: "Share", exact: true }).click()
+  await expect(full.page.getByLabel("Editable canvas link", { exact: true })).toHaveValue(`${base}/?agent=one#${candidate}`)
+  await full.context.close()
+
+  const connect = await fixture()
+  await connect.page.goto(`${base}/connect`)
+  await connect.page.getByLabel("Workspace key", { exact: true }).fill(candidate)
+  await connect.page.getByRole("button", { name: "Connect this browser", exact: true }).click()
+  await expect(connect.page.locator(".agent-error")).toContainText("Use a workspace key here")
+  expect(connect.calls).toEqual([])
+  expect(await connect.page.evaluate(() => localStorage.getItem("squig:agent-key"))).toBeNull()
+  await connect.context.close()
+  expect(errors).toEqual([])
+  console.log("✓ Browser security regressions passed: local persistence without API calls, framing, unvalidated invitations, pending/revoked keys, workspace separation")
+} finally {
+  await browser.close()
+}

--- a/scripts/agent/smoke.mjs
+++ b/scripts/agent/smoke.mjs
@@ -11,8 +11,8 @@ if (!process.env.DATABASE_URL)
 const sql = neon(process.env.DATABASE_URL)
 const hash = (v) => createHash("sha256").update(v).digest("hex")
 const workspaces = []
-const key = randomBytes(32).toString("hex"),
-  other = randomBytes(32).toString("hex")
+const key = `sq_${randomBytes(32).toString("base64url")}`,
+  other = `sq_${randomBytes(32).toString("base64url")}`
 async function fixture(key) {
   const id = `test_${randomBytes(10).toString("hex")}`
   await sql`INSERT INTO agent_workspaces (id,name,key_hash) VALUES (${id},'Integration test',${hash(key)})`

--- a/scripts/test-agent-storage.ts
+++ b/scripts/test-agent-storage.ts
@@ -17,7 +17,7 @@ const savedLog = console.error
 const logs: string[] = []
 console.error = (...args) => { logs.push(args.join(" ")) }
 const context = (path: string) => ({ params: Promise.resolve({ path: path.split("/") }) })
-const request = (path: string, data?: unknown, key = "sq_test") => new Request(`http://localhost/api/v1/${path}`, {
+const request = (path: string, data?: unknown, key = `sq_${"t".repeat(43)}`) => new Request(`http://localhost/api/v1/${path}`, {
   method: data === undefined ? "GET" : "POST",
   headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
   ...(data === undefined ? {} : { body: JSON.stringify(data) }),

--- a/scripts/test-agent.ts
+++ b/scripts/test-agent.ts
@@ -854,4 +854,95 @@ check(
   check("a height patch can't push the words out of the box", squashed.nodes.para.h === needed && needed > 1)
 }
 
+// -- credentials fail closed before storage or database access --------------
+
+const { keyKind, canvasConnection, workspaceKey, canvasStorage, KEY_STORAGE } =
+  await import("../lib/agent/credentials.ts")
+const { authenticate, hash, token } = await import("../lib/agent/db.ts")
+const { neonConfig } = await import("@neondatabase/serverless")
+const workspaceSecret = `sq_${token()}`
+const canvasSecret = `sq_canvas_${token()}`
+check("issued keys have distinct capabilities", keyKind(workspaceSecret) === "workspace" && keyKind(canvasSecret) === "canvas")
+for (const bad of ["", "sq_canvas_fake", workspaceSecret + "\n", canvasSecret + " extra", "sq_" + "a".repeat(10000)])
+  check("malformed keys are rejected", keyKind(bad) === null)
+const stored = new Map([[KEY_STORAGE, workspaceSecret], [canvasStorage("one"), canvasSecret]])
+const storage = { getItem: (name: string) => stored.get(name) ?? null }
+check("owners can still open a plain canvas URL", canvasConnection("two", undefined, storage).key === workspaceSecret)
+check("saved canvas keys take precedence over owner credentials", canvasConnection("one", undefined, storage).key === canvasSecret)
+check("a new invitation is only a candidate; it does not overwrite storage", canvasConnection("one", `sq_canvas_${token()}`, storage).canvasKey !== stored.get(canvasStorage("one")))
+for (const fragment of [workspaceSecret, "sq_canvas_fake", "", canvasSecret + "\n"])
+  check("an invalid invitation never falls back to a saved owner key", refused(() => canvasConnection("one", fragment, storage)))
+for (const badId of ["../catalog", "one/../../catalog", "one?x=1", "one#x", "one\n", "", "a".repeat(81)])
+  check("untrusted canvas IDs cannot become request paths", refused(() => canvasConnection(badId, canvasSecret, storage)))
+stored.set(KEY_STORAGE, canvasSecret)
+check("canvas keys cannot occupy the workspace credential slot", workspaceKey(storage) === null)
+stored.set(canvasStorage("one"), workspaceSecret)
+check("workspace credentials cannot be shared from a canvas slot", refused(() => canvasConnection("one", undefined, storage)))
+
+async function statusOf(run: () => Promise<unknown>) {
+  try { await run(); return 200 } catch (e) { return e instanceof AgentError ? e.status : 500 }
+}
+const scopedPrincipal = { workspaceId: "w", documentId: "one" }
+for (const [name, args] of [
+  ["create_document", { name: "No" }],
+  ["delete_document", { documentId: "one", revision: 1 }],
+  ["rotate_canvas_link", { documentId: "one" }],
+] as const)
+  check(`canvas keys cannot ${name}`, await statusOf(() => execute(name, args, scopedPrincipal)) === 403)
+for (const [name, args] of [
+  ["get_document", {}], ["edit_document", { revision: 1, operations: [{ op: "rename", name: "No" }] }],
+  ["replace_document", { revision: 1, document: emptyDocument("No") }],
+  ["history", {}], ["restore", { revision: 1, targetRevision: 1 }],
+  ["comment", { text: "No" }], ["resolve_comment", { commentId: "c", resolved: true }],
+  ["export_document", {}], ["measure_text", {}], ["render_document", { format: "svg" }],
+] as const)
+  check(`canvas keys cannot ${name} on siblings`, await statusOf(() => execute(name, { ...args, documentId: "two" }, scopedPrincipal)) === 404)
+
+// Mock only Neon's HTTP boundary: the real authentication and REST/MCP handlers run.
+const previousDb = process.env.DATABASE_URL
+const previousFetch = neonConfig.fetchFunction
+let queries = 0
+neonConfig.fetchFunction = async (_url: string, init: RequestInit) => {
+  queries++
+  const { query, params } = JSON.parse(String(init.body))
+  let rows: Record<string, string>[] = []
+  if (query.includes("FROM agent_workspaces")) {
+    check("only the workspace hash reaches its lookup", params[0] === hash(workspaceSecret))
+    rows = [{ id: "w" }]
+  } else if (query.includes("FROM agent_documents")) {
+    check("only the canvas hash reaches its lookup", params[0] === hash(canvasSecret))
+    rows = [{ id: "one", workspace_id: "w" }]
+  } else if (query.includes("INSERT INTO agent_limits")) {
+    rows = [{ count: "1" }]
+  } else throw new Error("Unexpected security test query")
+  const names = Object.keys(rows[0] ?? {})
+  return Response.json({ fields: names.map((name) => ({ name, dataTypeID: 25 })), rows: rows.map((row) => names.map((name) => row[name])) })
+}
+process.env.DATABASE_URL = "postgresql://test:test@security.invalid/test"
+try {
+  const req = (secret?: string) => new Request("https://squig.sh/api/v1/documents", { headers: secret ? { Authorization: `Bearer ${secret}` } : {} })
+  for (const bad of [undefined, "bad", "sq_canvas_invalid", "sq_" + "x".repeat(5000)])
+    check("malformed bearer is rejected without a database call", await statusOf(() => authenticate(req(bad))) === 401 && queries === 0)
+  check("workspace authentication has no document scope", same(await authenticate(req(workspaceSecret)), { workspaceId: "w" }))
+  check("canvas authentication retains its document scope", same(await authenticate(req(canvasSecret)), scopedPrincipal))
+  const rest = await import("../app/api/v1/[...path]/route.ts")
+  const rotate = await rest.POST(new Request("https://squig.sh/api/v1/workspace/rotate-key", {
+    method: "POST", headers: { Authorization: `Bearer ${canvasSecret}`, "Content-Type": "application/json" }, body: "{}",
+  }), { params: Promise.resolve({ path: ["workspace", "rotate-key"] }) })
+  check("REST workspace rotation refuses canvas keys", rotate.status === 403)
+  const mcp = await import("../app/mcp/route.ts")
+  const request = new Request("https://squig.sh/mcp", {
+    method: "POST", headers: { Authorization: `Bearer ${canvasSecret}`, "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "squig_get_document", arguments: { documentId: "two" } } }),
+  })
+  const response = await mcp.POST(request)
+  const rpc = await response.json()
+  check("MCP enforces the same document boundary", rpc.result?.isError === true && JSON.parse(rpc.result.content[0].text).status === 404)
+  check("MCP responses carrying private data cannot be cached", response.headers.get("cache-control") === "no-store" && response.headers.get("referrer-policy") === "no-referrer")
+} finally {
+  neonConfig.fetchFunction = previousFetch
+  if (previousDb === undefined) delete process.env.DATABASE_URL
+  else process.env.DATABASE_URL = previousDb
+}
+
 report(`agent engine checks passed (${ALL_DEFS.length} library definitions)`)


### PR DESCRIPTION
Unverified canvas invitations could overwrite saved credentials and appear in sharing controls before the server checked document access. Validate key types and document IDs, scrub invitation fragments before storage access, and persist or share canvas keys only after a successful read. Rejected or revoked invitations stop syncing without falling back to workspace authority or publishing the local draft; opening another local file releases the failed connection.

Also reject malformed bearer keys before database access, prevent credential-bearing fetches from following redirects, give MCP responses the REST API's no-store headers, and block framing of the hosted editor. The local no-account canvas and offline Webxdc build remain intact, including PR #84's storage diagnostics and legacy-image support.

Validation:
- `pnpm verify`: lint, typechecks, all 26 suites, and production build.
- Real REST/MCP integration: 51 checks in a temporary, isolated Neon test database, including scope isolation, rotation, and concurrency.
- Full database-backed browser workflow: invitations, live editing, conflicts, and legacy SVG sharing.
- Targeted security browser regressions and storage-rollout recovery checks against the production build.
- `make build-xdc`.
