### PR TITLE
Improve typography and readability across Squig's UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@ subject.
   and it is Postgres-backed; see
   [docs/agent-architecture.md](docs/agent-architecture.md).
 - **No emoji in UI copy.**
+- **Use the shared UI type scale.** Sizes, line heights and spacing live in
+  `app/globals.css`; [docs/ui-typography.md](docs/ui-typography.md) explains the
+  roles. Make room for labels instead of shrinking them.
 
 ## The big files
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -81,7 +81,7 @@ export default function CanvasError({
         <h1 className="text-2xl" style={{ color: "var(--sq-ink)", fontFamily: "var(--sq-font)" }}>
           squig lost its place
         </h1>
-        <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--sq-muted)", fontFamily: "var(--sq-font)" }}>
+        <p className="mt-3 text-row leading-relaxed text-muted-foreground">
           something on this page stopped it drawing. nothing has been thrown away — every drawing is still saved in
           this browser, this one included. try it again, or go and sit with another one for a bit.
         </p>
@@ -124,7 +124,7 @@ export default function CanvasError({
         )}
 
         {/* the one line worth quoting if this ever gets reported */}
-        <p className="mt-6 font-mono text-label break-words text-muted-foreground/70">
+        <p className="mt-6 font-mono text-label break-words text-muted-foreground">
           {error.message || "no message"}
           {error.digest ? ` · ${error.digest}` : ""}
         </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
   --font-heading: var(--font-sans);
   --font-sketch: var(--font-sketch), "Patrick Hand", "Comic Sans MS", cursive;
   --font-serif: var(--font-serif), "Source Serif 4", ui-serif, Georgia, serif;
@@ -69,29 +69,28 @@
   --radius-chrome-lg: 10px; /* floating panels and menus */
 
   /* Control height. `sm` is only for controls nested inside another control. */
-  --spacing-ctl-sm: 26px;
-  --spacing-ctl: 32px;
-  --spacing-ctl-lg: 36px;
+  --spacing-ctl-sm: 28px;
+  --spacing-ctl: 36px;
+  --spacing-ctl-lg: 40px;
 
-  /* Chrome type. Four sizes and that is the whole scale: a hint, a
-     label-or-value, a row of running text, a dialog heading. Canvas text is a
-     separate world — it uses --sq-font and is not governed here. The wordmark
-     is deliberately outside it too; it is brand, not a control.
-
-     These read a step larger than the numbers suggest, because Geist has a
-     tall x-height — 11px here sits where 12px would in most faces. Judge the
-     panel by eye rather than by the number, and if you retune one of these,
-     retune it against the others rather than nudging a component. */
-  --text-micro: 10px; /* kbd chips, counts, the axis letter in a field */
-  --text-label: 11px; /* panel labels, values, panel copy */
-  --text-row: 13px; /* menu rows, palette rows, a panel's own title */
-  --text-title: 15px; /* dialog headings and the ⌘K hero input */
+  /* Every UI role includes its line height so inherited leading cannot make
+     labels cramped in one panel and loose in another. 12px is the floor;
+     weight, spacing and contrast carry the hierarchy instead of tiny text.
+     Document lettering and the wordmark have their own scales. */
+  --text-micro: 12px; /* shortcuts, counts, field prefixes, supporting metadata */
+  --text-micro--line-height: 16px;
+  --text-label: 13px; /* panel labels, values, controls and explanatory copy */
+  --text-label--line-height: 20px;
+  --text-row: 14px; /* menu rows, search results and panel titles */
+  --text-row--line-height: 20px;
+  --text-title: 16px; /* dialog headings and the command palette input */
+  --text-title--line-height: 24px;
 
   /* Layout rhythm. The panel gutter, the gap between rows, and the seam every
      label stops at so controls line up down one edge. */
-  --spacing-gutter: 14px;
-  --spacing-row: 10px;
-  --spacing-label: 60px;
+  --spacing-gutter: 16px;
+  --spacing-row: 12px;
+  --spacing-label: 72px;
 
   /* Depth. Two elevations only: a panel resting on the canvas, and a popup
      floating over a panel. */
@@ -129,7 +128,7 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.49 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -164,7 +163,7 @@
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
+  --muted-foreground: oklch(0.75 0 0);
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
@@ -191,7 +190,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-label text-foreground;
   }
   html {
     @apply font-sans;

--- a/app/kitchen-sink/page.tsx
+++ b/app/kitchen-sink/page.tsx
@@ -39,13 +39,13 @@ function Cell({ def, scale }: { def: ComponentDef; scale: number }) {
         </svg>
       </div>
       <div className="flex items-baseline gap-2">
-        <span className="text-xs font-medium">{def.name}</span>
-        <span className="font-mono text-[10px] text-neutral-400">{def.kind}</span>
-        <span className="ml-auto font-mono text-[10px] text-neutral-400">
+        <span className="text-label font-medium">{def.name}</span>
+        <span className="font-mono text-micro text-muted-foreground">{def.kind}</span>
+        <span className="ml-auto font-mono text-micro text-muted-foreground">
           {w}×{h}
         </span>
       </div>
-      {failed && <p className="font-mono text-[10px] text-red-600">{(prims as { error: string }).error}</p>}
+      {failed && <p className="font-mono text-micro text-red-600">{(prims as { error: string }).error}</p>}
     </div>
   )
 }
@@ -87,13 +87,13 @@ export default function KitchenSink() {
     <div className="min-h-screen bg-white p-8 font-sans">
       <div className="sticky top-0 z-10 -mx-8 mb-6 flex items-center gap-4 border-b bg-white/90 px-8 py-3 backdrop-blur">
         <h1 className="text-lg font-bold tracking-tight">squig kitchen sink</h1>
-        <span className="text-sm text-neutral-500">{total} defs</span>
+        <span className="text-row text-muted-foreground">{total} defs</span>
         <div className="ml-4 flex gap-1">
           {(["components", "blocks"] as Category[]).map((c) => (
             <button
               key={c}
               onClick={() => setCategory(c)}
-              className={`rounded-lg px-3 py-1 text-sm capitalize ${
+              className={`rounded-lg px-3 py-1 text-row capitalize ${
                 category === c ? "bg-neutral-900 text-white" : "hover:bg-neutral-100"
               }`}
             >
@@ -101,7 +101,7 @@ export default function KitchenSink() {
             </button>
           ))}
         </div>
-        <label className="ml-auto flex items-center gap-2 text-sm text-neutral-500">
+        <label className="ml-auto flex items-center gap-2 text-row text-muted-foreground">
           scale {Math.round(scale * 100)}%
           <input
             type="range"
@@ -117,7 +117,7 @@ export default function KitchenSink() {
       {drawn &&
         sections.map((section) => (
           <section key={section.group} className="mb-10">
-            <h2 className="mb-3 text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <h2 className="mb-3 text-label font-semibold text-foreground">
               {section.group} · {section.defs.length}
             </h2>
             <div className="flex flex-wrap items-start gap-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,7 +68,7 @@ export default function Home() {
         </>
       )}
       {uiHidden && (
-        <p className="pointer-events-none absolute right-4 bottom-4 z-30 font-mono text-[10px] text-muted-foreground/60">
+        <p className="pointer-events-none absolute right-4 bottom-4 z-30 font-sans text-micro text-muted-foreground">
           {kbd("mod+\\")}
         </p>
       )}

--- a/components/agent/agent.css
+++ b/components/agent/agent.css
@@ -4,6 +4,8 @@
   background: #fafbff;
   color: #172b66;
   font-family: var(--font-sans), sans-serif;
+  font-size: var(--text-title);
+  line-height: 1.65;
 }
 .agent-nav {
   display: flex;
@@ -24,7 +26,7 @@
   display: flex;
   gap: 24px;
   align-items: center;
-  font-size: 14px;
+  font-size: var(--text-row);
 }
 .agent-content {
   max-width: 1120px;
@@ -75,7 +77,7 @@
   padding: 11px 18px;
   border: 1px solid #214be0;
   border-radius: var(--radius-chrome-sm);
-  font-size: 14px;
+  font-size: var(--text-row);
   cursor: pointer;
   text-decoration: none;
   font-weight: 500;
@@ -110,7 +112,7 @@
   min-height: 100px;
 }
 .agent-page label {
-  font-size: 14px;
+  font-size: var(--text-row);
   font-weight: 500;
 }
 .agent-split {
@@ -132,7 +134,8 @@
   color: #233b80;
   border-radius: var(--radius-chrome-md);
   padding: 20px;
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
   line-height: 1.7;
   overflow: auto;
   margin: 16px 0;
@@ -145,7 +148,7 @@
 }
 .agent-muted {
   color: #64708c;
-  font-size: 14px;
+  font-size: var(--text-row);
 }
 .agent-row {
   display: flex;
@@ -177,11 +180,13 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  padding: 7px 9px;
+  min-height: var(--spacing-ctl);
+  padding: 8px 10px;
   border-radius: var(--radius-chrome-sm);
-  font:
-    12px var(--font-sans),
-    sans-serif;
+  font-family: var(--font-sans), sans-serif;
+  font-size: var(--text-label);
+  line-height: var(--text-label--line-height);
+  font-weight: 500;
   cursor: pointer;
 }
 .canvas-action:hover {
@@ -201,7 +206,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  font-size: 14px;
+  font-size: var(--text-row);
 }
 .docs-article {
   max-width: 760px;
@@ -247,6 +252,8 @@
 
 .agent-connect-panel {
   width: min(360px, calc(100vw - 32px));
+  max-height: var(--available-height);
+  overflow-y: auto;
   padding: 20px;
   background: var(--popover);
   color: var(--popover-foreground);
@@ -254,9 +261,9 @@
   border-radius: var(--radius-chrome-md);
   box-shadow: 0 8px 30px #0002;
   text-align: left;
-  font:
-    13px/1.5 var(--font-sans),
-    sans-serif;
+  font-family: var(--font-sans), sans-serif;
+  font-size: var(--text-label);
+  line-height: var(--text-label--line-height);
   transform-origin: var(--transform-origin);
   transition:
     opacity 120ms,
@@ -284,7 +291,8 @@
 .agent-copy-field label > span {
   display: block;
   margin-bottom: 6px;
-  font-size: 12px;
+  font-size: var(--text-label);
+  font-weight: 500;
 }
 .agent-copy-field input {
   display: block;
@@ -294,7 +302,9 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-chrome-sm);
   background: var(--background);
-  font: 12px monospace;
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+  line-height: var(--text-label--line-height);
 }
 .agent-copy-button {
   position: absolute;
@@ -339,7 +349,7 @@
 }
 .agent-invite textarea {
   display: block;
-  height: 132px;
+  height: 160px;
   width: 100%;
   box-sizing: border-box;
   padding: 9px 10px;
@@ -347,7 +357,9 @@
   border-radius: var(--radius-chrome-sm);
   background: var(--background);
   color: inherit;
-  font: 11px/1.5 monospace;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: var(--text-label--line-height);
   resize: none;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -390,7 +402,7 @@
 .agent-invite-more summary {
   cursor: pointer;
   color: var(--muted-foreground);
-  font-size: 12px;
+  font-size: var(--text-label);
 }
 .agent-invite-more summary:hover {
   color: inherit;
@@ -401,5 +413,5 @@
 .agent-invite-more a {
   display: inline-block;
   margin-top: 8px;
-  font-size: 12px;
+  font-size: var(--text-label);
 }

--- a/components/agent/bridge.tsx
+++ b/components/agent/bridge.tsx
@@ -412,7 +412,7 @@ export function AgentBridge({ hidden = false }: { hidden?: boolean }) {
               className="z-50"
             >
               <Popover.Popup className="agent-connect-panel">
-                <Popover.Title className="font-medium">
+                <Popover.Title className="text-row font-semibold">
                   {kind === "share" ? "Share canvas" : "Connect an agent"}
                 </Popover.Title>
                 <Popover.Description>

--- a/components/canvas/empty-canvas.tsx
+++ b/components/canvas/empty-canvas.tsx
@@ -77,7 +77,7 @@ export function EmptyCanvas() {
           <path key={i} d={d} />
         ))}
       </svg>
-      <p className="text-center text-sm" style={{ color: "var(--sq-muted)", fontFamily: "var(--sq-font)" }}>
+      <p className="text-center text-title text-muted-foreground">
         {line}
       </p>
     </div>

--- a/components/canvas/selection-overlay.tsx
+++ b/components/canvas/selection-overlay.tsx
@@ -457,8 +457,8 @@ export function SmartGuides({ guides, distances }: { guides: GuideLine[]; distan
       )}
       {distances.map((d, i) => {
         const label = String(d.distance)
-        const labelW = Math.max(18, label.length * 6 + 8)
-        const labelH = 16
+        const labelW = Math.max(24, label.length * 8 + 12)
+        const labelH = 20
         return (
           <g key={`distance-${d.axis}-${i}`}>
             <line x1={d.x1} y1={d.y1} x2={d.x2} y2={d.y2} stroke="var(--sq-measure)" strokeWidth={1} />
@@ -487,9 +487,7 @@ export function SmartGuides({ guides, distances }: { guides: GuideLine[]; distan
               dy="0.34em"
               fill="white"
               fontFamily="var(--font-sans), ui-sans-serif, sans-serif"
-              fontSize={10}
-              fontWeight={650}
-              style={{ fontVariantNumeric: "tabular-nums" }}
+              className="text-micro font-medium tabular-nums"
               textAnchor="middle"
             >
               {label}

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -349,7 +349,7 @@ function Palette() {
             )}
             {sections.map((section) => (
               <div key={section.title} className="mb-2">
-                <div className="px-2.5 pt-3 pb-1.5 text-label font-medium text-foreground">
+                <div className="px-2.5 pt-3 pb-1.5 text-label font-semibold text-foreground">
                   {section.title}
                 </div>
                 {section.rows.map(({ row, index }) => (
@@ -373,11 +373,11 @@ function Palette() {
             ))}
           </div>
 
-          <div className="flex shrink-0 items-center gap-4 border-t border-border/70 px-4 py-2.5 text-label text-muted-foreground">
+          <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-t border-border/70 px-4 py-3 text-micro text-muted-foreground">
             <span><Kbd>↑</Kbd><Kbd>↓</Kbd> move</span>
             <span><Kbd>↵</Kbd> pick</span>
             <span><Kbd>esc</Kbd> close</span>
-            <span className="ml-auto">components drop in the middle of your view</span>
+            <span className="w-full sm:ml-auto sm:w-auto">components drop in the middle of your view</span>
           </div>
         </div>
       </div>
@@ -387,7 +387,7 @@ function Palette() {
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="mr-1 inline-flex h-4 min-w-4 items-center justify-center rounded-chrome-xs border bg-muted px-1 font-mono text-micro">
+    <kbd className="mr-1 inline-flex h-5 min-w-5 items-center justify-center rounded-chrome-xs border bg-muted px-1 font-sans text-micro">
       {children}
     </kbd>
   )
@@ -418,7 +418,7 @@ function PaletteRow({
         <>
           <row.action.icon className="size-4 shrink-0 text-muted-foreground" weight="regular" />
           <span className="flex-1 truncate">{row.action.label}</span>
-          {row.action.hint && <span className="pl-6 font-mono text-label text-muted-foreground">{row.action.hint}</span>}
+          {row.action.hint && <span className="pl-6 text-micro text-muted-foreground">{row.action.hint}</span>}
         </>
       ) : row.kind === "node" ? (
         <>

--- a/components/chrome/context-menu.tsx
+++ b/components/chrome/context-menu.tsx
@@ -235,7 +235,7 @@ export function CanvasContextMenu() {
   return (
     <div
       ref={ref}
-      className="fixed z-50 min-w-52 rounded-chrome-lg border border-border/80 bg-background p-1.5 shadow-popup"
+      className="fixed z-50 max-h-[calc(100dvh-1rem)] min-w-52 overflow-y-auto overscroll-contain rounded-chrome-lg border border-border/80 bg-background p-1.5 shadow-popup"
       style={{ left: pos.x, top: pos.y }}
       onPointerDown={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.preventDefault()}
@@ -260,7 +260,7 @@ export function CanvasContextMenu() {
               weight="fill"
             />
             <span className="flex-1 truncate">{entry.label}</span>
-            {entry.hint && <span className="pl-6 font-mono text-label text-muted-foreground">{entry.hint}</span>}
+            {entry.hint && <span className="pl-6 text-micro text-muted-foreground">{entry.hint}</span>}
           </button>
         )
       )}

--- a/components/chrome/file-name.tsx
+++ b/components/chrome/file-name.tsx
@@ -120,7 +120,7 @@ export function FileName() {
       )}
       <span
         aria-live="polite"
-        className={`absolute top-full left-1/2 mt-1 -translate-x-1/2 text-[11px] whitespace-nowrap transition-opacity duration-200 ${
+        className={`absolute top-full left-1/2 mt-1 -translate-x-1/2 text-micro whitespace-nowrap transition-opacity duration-200 ${
           stuck ? "text-destructive" : "text-muted-foreground"
         }`}
         style={{ opacity: note ? 1 : 0 }}

--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -111,11 +111,10 @@ const FONT_OPTIONS: readonly SegmentOption<FontMode>[] = [
   { value: "serif", label: "Serif", content: <FontSample family="var(--font-serif)" /> },
 ]
 
-/** "Aa" set in one face — a little large for the row, because two letters at
-    11px don't carry enough of a face to tell it from its neighbour. */
+/** A larger sample makes the three canvas faces easy to tell apart. */
 function FontSample({ family }: { family: string }) {
   return (
-    <span className="text-[13px] leading-none" style={{ fontFamily: family }}>
+    <span className="text-title" style={{ fontFamily: family }}>
       Aa
     </span>
   )
@@ -142,7 +141,7 @@ const TEXT_BOX_BORDER_OPTIONS: readonly SegmentOption<TextBoxBorder>[] = [
 /** "A" set in one tone — the ink previewed on the thing it will colour. */
 function InkLetter({ color }: { color: string }) {
   return (
-    <span className="text-[13px] leading-none font-semibold" style={{ color }}>
+    <span className="text-title font-semibold" style={{ color }}>
       A
     </span>
   )
@@ -191,7 +190,7 @@ export function Inspector() {
   const subtitle = selected.length > 1 ? selectionSummary(selected) : undefined
 
   return (
-    <Panel className="absolute top-16 right-4 z-30 max-h-[calc(100vh-5rem)] w-[272px]">
+    <Panel className="absolute top-16 right-4 z-30 max-h-[calc(100vh-5rem)] w-[296px] max-w-[calc(100vw-88px)]">
       <PanelHeader title={heading} subtitle={subtitle} />
 
       <ScrollArea className="min-h-0">

--- a/components/chrome/left-rail.tsx
+++ b/components/chrome/left-rail.tsx
@@ -50,7 +50,7 @@ function RailButton({
       </TooltipTrigger>
       <TooltipContent side="right" className="flex items-center gap-2">
         {label}
-        <kbd className="rounded-chrome-xs bg-muted px-1 font-mono text-micro text-muted-foreground">{hotkey}</kbd>
+        <kbd className="rounded-chrome-xs bg-muted px-1 font-sans text-micro text-muted-foreground">{hotkey}</kbd>
       </TooltipContent>
     </Tooltip>
   )

--- a/components/chrome/library-panel.tsx
+++ b/components/chrome/library-panel.tsx
@@ -90,17 +90,17 @@ function Preview({
       }}
       title={def.name}
       className={cn(
-        "group flex flex-col items-center gap-1 rounded-chrome-sm border border-border/70 p-1 transition-colors outline-none hover:border-border hover:bg-accent",
+        "group flex min-w-0 flex-col items-center gap-1 rounded-chrome-sm border border-border/70 p-2 transition-colors outline-none hover:border-border hover:bg-accent",
         active && "border-[var(--sq-ink)] bg-[var(--sq-ink)]/8 ring-1 ring-inset ring-[var(--sq-ink)]/25"
       )}
     >
-      <svg width={BOX_W} height={BOX_H} className="shrink-0">
+      <svg width={BOX_W} height={BOX_H} viewBox={`0 0 ${BOX_W} ${BOX_H}`} className="h-auto max-w-full shrink-0">
         <g transform={`translate(${ox} ${oy}) scale(${scale})`}>
           <SketchPrims prims={prims} seed={13} />
         </g>
       </svg>
       {/* a component's name, not a hint — it stays at label size */}
-      <span className="w-full truncate pb-0.5 text-center text-label leading-none text-muted-foreground group-hover:text-foreground">
+      <span className="flex min-h-10 w-full items-center justify-center text-center text-label text-pretty text-foreground">
         {def.name}
       </span>
     </button>
@@ -134,9 +134,9 @@ function Library({ panel }: { panel: Exclude<PanelKind, null> }) {
   const first = sections[0]?.defs[0]
 
   return (
-    <Panel className="absolute top-1/2 left-16 z-30 max-h-[82vh] w-[316px] -translate-y-1/2">
-      <div className="relative shrink-0 border-b border-border/70 p-3">
-        <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-[22px] size-4 -translate-y-1/2 text-muted-foreground" />
+    <Panel className="absolute top-1/2 left-[72px] z-30 max-h-[82vh] w-[336px] max-w-[calc(100vw-88px)] -translate-y-1/2">
+      <div className="relative shrink-0 border-b border-border/70 p-gutter">
+        <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-[26px] size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           ref={inputRef}
           value={query}
@@ -155,10 +155,10 @@ function Library({ panel }: { panel: Exclude<PanelKind, null> }) {
           The scrollbar fades in while scrolling or hovering, so a list this
           long doesn't look like it ends at the fold. */}
       <ScrollArea className="min-h-0 flex-1 overscroll-contain">
-        <div className="p-3 pt-1.5">
+        <div className="p-gutter pt-1.5">
           {sections.map((section) => (
             <div key={section.group} className="mb-3">
-              <div className="px-0.5 pt-2 pb-2 text-label font-medium text-foreground">
+              <div className="px-0.5 pt-2 pb-2 text-label font-semibold text-foreground">
                 {section.group}
               </div>
               <div className="grid grid-cols-2 gap-1.5">
@@ -182,7 +182,7 @@ function Library({ panel }: { panel: Exclude<PanelKind, null> }) {
         </div>
       </ScrollArea>
 
-      <PanelFooter className="px-gutter py-2.5 text-label text-muted-foreground">
+      <PanelFooter className="text-micro text-muted-foreground">
         {placingDrag
           ? "let go where you want it"
           : placing

--- a/components/chrome/mixed-fields.tsx
+++ b/components/chrome/mixed-fields.tsx
@@ -158,7 +158,7 @@ const FIELD_INPUT =
   "h-full w-full min-w-0 bg-transparent text-label tabular-nums outline-none placeholder:text-muted-foreground [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
 
 const FIELD_HANDLE =
-  "flex shrink-0 cursor-ew-resize items-center rounded-chrome-xs px-1 py-1 text-micro leading-none text-muted-foreground/80 select-none hover:bg-accent hover:text-foreground"
+  "flex shrink-0 cursor-ew-resize items-center rounded-chrome-xs px-1 py-1 text-micro text-muted-foreground select-none hover:bg-accent hover:text-foreground"
 
 /**
  * The drag target when a field has no axis letter to put there — font size,
@@ -457,7 +457,7 @@ export function MixedSwitch({
       )}
     >
       <span className="pointer-events-none block size-4 translate-x-[calc(50%-2px)] rounded-full bg-background dark:bg-foreground" />
-      <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[9px] leading-none font-semibold text-muted-foreground">
+      <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-micro font-semibold text-muted-foreground">
         {MIXED_LABEL}
       </span>
     </button>

--- a/components/chrome/notice.tsx
+++ b/components/chrome/notice.tsx
@@ -41,7 +41,7 @@ export function Notice() {
   return (
     <div
       aria-live="polite"
-      className="pointer-events-none absolute bottom-16 left-1/2 z-40 -translate-x-1/2 rounded-chrome-lg border border-border/80 bg-background px-3 py-1.5 text-label whitespace-nowrap text-muted-foreground shadow-popup transition-opacity duration-200"
+      className="pointer-events-none absolute bottom-16 left-1/2 z-40 -translate-x-1/2 rounded-chrome-lg border border-border/80 bg-background max-w-[calc(100vw-2rem)] w-max px-gutter py-2.5 text-center text-label text-muted-foreground shadow-popup transition-opacity duration-200"
       style={{ opacity: shown ? 1 : 0 }}
     >
       {text}

--- a/components/chrome/recent-files.tsx
+++ b/components/chrome/recent-files.tsx
@@ -40,7 +40,7 @@ export function RecentFiles() {
             because this is the list you're looking at when you go to make
             room — and the trash to do it with is on the row above. */}
         {full && (
-          <p className="mt-1 border-t px-2.5 pt-2 pb-1 text-label leading-relaxed text-muted-foreground">
+          <p className="mt-1 border-t px-2.5 pt-2 pb-1 text-label text-muted-foreground">
             this browser is out of room, so nothing new is being saved. pictures fill it fastest, and a cropped one
             still carries the parts it hides. export what you want to keep, then let a drawing go here.
           </p>

--- a/components/chrome/shortcuts-sheet.tsx
+++ b/components/chrome/shortcuts-sheet.tsx
@@ -23,9 +23,9 @@ export function ShortcutsSheet() {
         className="animate-in fade-in zoom-in-95 relative flex max-h-full w-full max-w-3xl flex-col overflow-hidden rounded-chrome-lg border border-border/80 bg-background shadow-popup duration-150"
         onPointerDown={(e) => e.stopPropagation()}
       >
-        <div className="flex shrink-0 items-baseline gap-3 border-b border-border/70 px-5 py-4">
-          <h2 className="text-title font-medium">Keyboard</h2>
-          <p className="text-label text-muted-foreground">mostly Figma&apos;s, so your hands already know it</p>
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border/70 px-5 py-4">
+          <h2 className="text-title font-semibold">Keyboard</h2>
+          <p className="order-3 w-full text-label text-muted-foreground sm:order-none sm:w-auto">mostly Figma&apos;s, so your hands already know it</p>
           <button
             type="button"
             className="ml-auto h-ctl rounded-chrome-sm px-2.5 text-label text-muted-foreground hover:bg-accent"
@@ -35,21 +35,21 @@ export function ShortcutsSheet() {
           </button>
         </div>
 
-        <div className="columns-1 gap-x-8 overflow-y-auto overscroll-contain p-5 sm:columns-2 lg:columns-3">
+        <div className="columns-1 gap-x-8 overflow-y-auto overscroll-contain p-5 sm:columns-2">
           {SHORTCUT_GROUPS.map((group) => (
             <section key={group.title} className="mb-5 break-inside-avoid">
-              <h3 className="mb-2 text-label font-medium text-foreground">
+              <h3 className="mb-2 text-label font-semibold text-foreground">
                 {group.title}
               </h3>
               <dl className="flex flex-col gap-1.5">
                 {group.rows.map((row) => (
                   <div key={row.label} className="flex items-baseline justify-between gap-3">
-                    <dt className="truncate text-row text-muted-foreground">{row.label}</dt>
+                    <dt className="min-w-0 text-label text-foreground">{row.label}</dt>
                     <dd className="flex shrink-0 items-center gap-1">
                       {row.keys.map((k, i) => (
                         <span key={k} className="flex items-center gap-1">
                           {i > 0 && <span className="text-micro text-muted-foreground">or</span>}
-                          <kbd className="inline-flex h-5 items-center rounded-chrome-xs border bg-muted px-1.5 font-mono text-micro whitespace-nowrap text-muted-foreground">
+                          <kbd className="inline-flex h-5 items-center rounded-chrome-xs border bg-muted px-1.5 font-sans text-micro whitespace-nowrap text-muted-foreground">
                             {kbd(k)}
                           </kbd>
                         </span>

--- a/components/chrome/small-screen-note.tsx
+++ b/components/chrome/small-screen-note.tsx
@@ -5,7 +5,7 @@
 //
 // A phone can draw on squig now — one finger inks, two fingers pan and zoom.
 // What a phone can't do is get out of the way of its own chrome: the inspector
-// is a fixed 272px pinned to the right and the tool rail sits on the left, so
+// is pinned to the right and the tool rail sits on the left, so
 // under about 700px the panels are lying on most of the paper.
 //
 // This is a note, not a redesign and not a wall. It says the honest thing once,

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -52,7 +52,7 @@ export function TopCorner() {
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className="w-56"
+          className="w-64"
           // Rename hands focus to the floating name field; returning focus to
           // the wordmark here would snatch it straight back.
           finalFocus={() => {
@@ -189,7 +189,7 @@ export function CommandHint() {
       className="absolute bottom-4 left-1/2 z-30 flex h-ctl -translate-x-1/2 items-center gap-2 rounded-full border border-border/80 bg-background px-gutter text-label text-muted-foreground shadow-panel hover:text-foreground"
     >
       search everything
-      <kbd className="inline-flex h-4 items-center rounded-chrome-xs border bg-muted px-1 font-mono text-micro">⌘K</kbd>
+      <kbd className="inline-flex h-5 items-center rounded-chrome-xs border bg-muted px-1 font-sans text-micro">⌘K</kbd>
     </button>
   )
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { useRender } from "@base-ui/react/use-render"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-chrome-sm border border-transparent bg-clip-padding text-row font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/25 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-chrome-sm border border-transparent bg-clip-padding text-label font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/25 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 import { CaretRightIcon } from "@phosphor-icons/react"
 
 const POPUP =
-  "min-w-52 origin-(--transform-origin) rounded-chrome-lg bg-popover p-1.5 text-popover-foreground shadow-popup ring-1 ring-foreground/10 outline-none transition-[transform,opacity] duration-100 data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0"
+  "max-h-(--available-height) min-w-52 origin-(--transform-origin) overflow-y-auto overscroll-contain rounded-chrome-lg bg-popover p-1.5 text-popover-foreground shadow-popup ring-1 ring-foreground/10 outline-none transition-[transform,opacity] duration-100 data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0"
 
 /**
  * A menu row is a place to land, not a line of text — it gets a real height and
@@ -75,7 +75,7 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn("ml-auto pl-6 text-label text-muted-foreground", className)}
+      className={cn("ml-auto pl-6 text-micro text-muted-foreground", className)}
       {...props}
     />
   )

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-ctl w-full min-w-0 rounded-chrome-sm border border-input bg-transparent px-2.5 py-1 text-row transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-label file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/15 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-ctl w-full min-w-0 rounded-chrome-sm border border-input bg-transparent px-2.5 py-1 text-label transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-label file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-[var(--sq-ink)] focus-visible:ring-2 focus-visible:ring-[var(--sq-ink)]/15 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/components/ui/panel.tsx
+++ b/components/ui/panel.tsx
@@ -69,8 +69,8 @@ export function PanelHeader({
       )}
     >
       <div className="min-w-0">
-        <h2 className="truncate text-row leading-tight font-medium">{title}</h2>
-        {subtitle && <p className="mt-1 truncate text-label leading-tight text-muted-foreground">{subtitle}</p>}
+        <h2 className="truncate text-row font-semibold">{title}</h2>
+        {subtitle && <p className="mt-1 text-micro text-muted-foreground">{subtitle}</p>}
       </div>
       {right && <div className="flex shrink-0 items-center gap-0.5">{right}</div>}
     </div>
@@ -79,7 +79,7 @@ export function PanelHeader({
 
 export function PanelFooter({ className, children }: { className?: string; children: React.ReactNode }) {
   return (
-    <div className={cn("flex shrink-0 items-center gap-2 border-t border-border/70 p-3", className)}>{children}</div>
+    <div className={cn("flex shrink-0 items-center gap-2 border-t border-border/70 px-gutter py-3", className)}>{children}</div>
   )
 }
 
@@ -157,11 +157,11 @@ export function PanelSection({
             headings are as quiet as the labels has no hierarchy at all — it
             just has rows. */}
         <Collapsible.Trigger className="group flex min-w-0 flex-1 items-center gap-1.5 px-gutter pt-gutter pb-2 text-left outline-none">
-          <span className="truncate text-label font-medium text-foreground">{title}</span>
+          <span className="truncate text-label font-semibold text-foreground">{title}</span>
           {count !== undefined && <span className="text-micro text-muted-foreground tabular-nums">({count})</span>}
           <CaretRightIcon
             weight="bold"
-            className="ml-auto size-2.5 shrink-0 text-muted-foreground/60 transition-transform duration-150 group-data-[panel-open]:rotate-90"
+            className="ml-auto size-3 shrink-0 text-muted-foreground transition-transform duration-150 group-data-[panel-open]:rotate-90"
           />
         </Collapsible.Trigger>
         {right}
@@ -213,7 +213,7 @@ export function Row({
         <label
           htmlFor={htmlFor}
           className={cn(
-            "shrink-0 truncate text-label text-muted-foreground select-none",
+            "shrink-0 text-label text-pretty wrap-anywhere text-muted-foreground select-none",
             spread ? "flex-1" : "w-label",
             align === "start" && "pt-2"
           )}
@@ -246,5 +246,5 @@ export function StackRow({
 
 /** Explanatory aside — grouping hints, empty states, "these don't share knobs". */
 export function PanelNote({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <p className={cn("text-label leading-relaxed text-muted-foreground", className)}>{children}</p>
+  return <p className={cn("text-label text-pretty text-muted-foreground", className)}>{children}</p>
 }

--- a/docs/ui-typography.md
+++ b/docs/ui-typography.md
@@ -1,0 +1,38 @@
+# UI typography
+
+Squig's interface uses Geist. The shared tokens in `app/globals.css` set both
+size and line height; use the role that fits the content rather than a local
+pixel size. The same tokens work inside portals and in `components/agent/agent.css`.
+
+| Role | Size / line height | Use |
+| --- | --- | --- |
+| `text-micro` | 12 / 16px | Shortcuts, counts, field prefixes, timestamps, supporting metadata |
+| `text-label` | 13 / 20px | Labels, values, buttons, panel copy, tooltips, library names |
+| `text-row` | 14 / 20px | Menu items, search results, panel titles |
+| `text-title` | 16 / 24px | Dialog headings, command search |
+
+12px is the minimum for interface text. Keep ordinary labels and values at
+normal weight, actions at medium, and section/panel/dialog headings at
+semibold. Use sentence case and normal tracking. Shortcuts use the same sans
+face; code, configurations and technical identifiers use `font-mono`. Numeric
+fields and counters use tabular numerals.
+
+Use `text-foreground` for primary content and `text-muted-foreground` for
+secondary content. Do not fade secondary text again with opacity. Disabled
+controls can retain their disabled treatment. Canvas ink swatches preview
+document colors and are separate from UI text contrast.
+
+Controls use `h-ctl` (36px), nested segments `h-ctl-sm` (28px), and menu/search
+rows `h-ctl-lg` (40px). Panel gutters are 16px, row gaps 12px, and the label
+column 72px. Let longer names wrap and give menus a scrollable viewport;
+do not shrink text to fit a fixed box.
+
+Document text, sketch previews, and the wordmark have their own typography.
+The documentation pages use 16px body copy and larger editorial headings.
+Changing interface tokens must not resize the wireframes people have drawn.
+
+For a typography change, review the page and selection inspectors, library,
+file/context menus, command palette, keyboard sheet, tooltips, agent popovers,
+and documentation. Check a laptop viewport and a short/narrow viewport, including
+scrolling to the final menu item. `/kitchen-sink` shows the library's document
+rendering alongside UI labels, so both can be checked together.


### PR DESCRIPTION
Squig's inspector and supporting UI used 9–11px text, inconsistent line heights, and faint secondary labels. This pass makes the interface easier to read using shared typography roles and more room around controls, informed by [Beautiful UI](https://github.com/slev12397/beautiful-ui).

- Standardize on 12px supporting text, 13px labels/values/buttons, 14px menu rows/panel titles, and 16px dialog headings, each with an explicit line height. Strengthen secondary contrast and heading weights, and use the same sans face for shortcuts.
- Increase control heights and panel spacing; widen the inspector and library; wrap long names and field labels; let menus scroll on short screens. Carry the scale through agent dialogs, save feedback, measurements, tooltips, empty/error states, and the kitchen sink.
- Document the roles in `docs/ui-typography.md` and point to them from `AGENTS.md`. Wireframes keep their document-defined text sizes.

Validation:

- `pnpm verify` (lint, typechecks, all test suites, production build)
- `pnpm test:agent`
- `make build-xdc`
- Browser audit of all 155 component/block inspectors: no horizontal clipping after fixing 11 labels.
- Visual and interaction checks across the library, file/context menus, text/mixed inspectors, selectors, context toolbar, command palette, keyboard sheet, tooltips, documentation, and kitchen sink. Checked desktop, 1024×600, and 390px viewports, including reaching the last menu item on a short screen.
- Agent invitation/config and Share popovers exercised with mocked local API responses; browser checks reported no page errors.
