### PR TITLE
Fix corner rotation cursors and tighten their hit areas

### DIFF
--- a/components/canvas/canvas.tsx
+++ b/components/canvas/canvas.tsx
@@ -71,7 +71,7 @@ import { AnchorZones, SelectionOverlay, SmartGuides } from "./selection-overlay"
 import { TextEditOverlay } from "./text-edit-overlay"
 import { nodeVisualBounds, type RouteHandle } from "@/lib/canvas/line-routing"
 import { normalizeRotation, orientResize, rotateNodes, rotatePoint, rotationDelta, unrotatePoint } from "@/lib/canvas/rotation"
-import { resizeCursor, ROTATE_CURSOR } from "@/lib/canvas/handles"
+import { resizeCursor, rotateCursor, type CornerHandle } from "@/lib/canvas/handles"
 import { SMALL_NUDGE } from "@/lib/nudge"
 import { constrainMoveTo45, constrainSnapToDirection, type DragDirection } from "@/lib/canvas/move"
 
@@ -250,6 +250,7 @@ export type Gesture =
     }
   | {
       kind: "rotate"
+      handle: CornerHandle
       sx: number
       sy: number
       pointerId: number
@@ -840,7 +841,9 @@ export function Canvas() {
         const current = Math.atan2(g.center[1] - wy, wx - g.center[0]) * 180 / Math.PI
         const delta = rotationDelta(g.startAngle, current, g.initialRotation, mods.shift)
         s.updateNodes(rotateNodes(g.origNodes, g.center, delta))
-        setRotationLabel(normalizeRotation(g.initialRotation + delta))
+        const rotation = normalizeRotation(g.initialRotation + delta)
+        setRotationLabel(rotation)
+        setGestureCursor(rotateCursor(g.handle, rotation))
         return
       }
 
@@ -1329,7 +1332,8 @@ export function Canvas() {
     (g: Gesture, e: React.PointerEvent) => {
       gestureRef.current = g
       setGestureKind(g.kind)
-      setGestureCursor(g.kind === "resize" ? resizeCursor(g.handle, g.origNodes.length === 1 ? g.origNodes[0].rotation : 0) : null)
+      setGestureCursor(g.kind === "rotate" ? rotateCursor(g.handle, g.initialRotation)
+        : g.kind === "resize" ? resizeCursor(g.handle, g.origNodes.length === 1 ? g.origNodes[0].rotation : 0) : null)
       setRotationFrame(g.kind === "rotate" && g.origNodes.length > 1 ? unionBounds(g.origNodes.map(nodeVisualBounds)) ?? undefined : undefined)
 
       // capture keeps events coming even when the pointer leaves the window
@@ -1486,7 +1490,7 @@ export function Canvas() {
     [st, beginGesture, toWorld, resetTextWidth, resetTextHeight]
   )
 
-  const startRotate = useCallback((e: React.PointerEvent) => {
+  const startRotate = useCallback((handle: CornerHandle, e: React.PointerEvent) => {
     if (e.button !== 0 || !e.isPrimary || gestureRef.current) return
     e.stopPropagation()
     e.preventDefault()
@@ -1496,7 +1500,7 @@ export function Canvas() {
     if (!b) return
     const center: [number, number] = [b.x + b.w / 2, b.y + b.h / 2]
     const [wx, wy] = toWorld(e)
-    beginGesture({ kind: "rotate", sx: e.clientX, sy: e.clientY, pointerId: e.pointerId, exceeded: false,
+    beginGesture({ kind: "rotate", handle, sx: e.clientX, sy: e.clientY, pointerId: e.pointerId, exceeded: false,
       center, startAngle: Math.atan2(center[1] - wy, wx - center[0]) * 180 / Math.PI,
       initialRotation: origNodes.length === 1 ? origNodes[0].rotation ?? 0 : 0,
       origNodes: structuredClone(origNodes), dirty: false }, e)
@@ -2489,8 +2493,6 @@ export function Canvas() {
       ? "crosshair"
       : gestureKind === "pan" || gestureKind === "pinch"
         ? "grabbing"
-        : gestureKind === "rotate"
-          ? ROTATE_CURSOR
         : gestureCursor
           ? gestureCursor
       : gestureKind === "move"

--- a/components/canvas/selection-overlay.tsx
+++ b/components/canvas/selection-overlay.tsx
@@ -14,7 +14,7 @@ import { anchorPoint, arrowEnds, bindOf } from "@/lib/canvas/arrow-binding"
 import { nodeVisualBounds, worldRouteHandle, type RouteHandle } from "@/lib/canvas/line-routing"
 import type { DistanceIndicator, GuideLine } from "@/lib/canvas/snap-engine"
 import { type Handle } from "@/lib/canvas/transform"
-import { resizeCursor, ROTATE_CURSOR, GRAB_OUT, grabPad, handleHitBox, edgeHitBox, visibleHandles, HANDLE_DOT, HANDLE_ROOM } from "@/lib/canvas/handles"
+import { resizeCursor, rotateCursor, type CornerHandle, GRAB_OUT, grabPad, handleHitBox, edgeHitBox, visibleHandles, HANDLE_DOT, HANDLE_ROOM } from "@/lib/canvas/handles"
 import type { Bounds } from "@/lib/selection"
 import { unionBounds } from "@/lib/selection"
 import { ARROW_ANCHORS, type ArrowAnchor, type ArrowNode, type SquigNode } from "@/lib/types"
@@ -244,7 +244,7 @@ export function SelectionOverlay({
   editing: boolean
   gestureKind: Gesture["kind"] | null
   interactive: boolean
-  onStartRotate: (e: React.PointerEvent) => void
+  onStartRotate: (h: CornerHandle, e: React.PointerEvent) => void
   rotationLabel: number | null
   rotationFrame?: Bounds
 }) {
@@ -335,8 +335,8 @@ export function SelectionOverlay({
           <div className="absolute inset-0 rounded-sm" style={{ border: "2px solid var(--sq-select)" }} />
           {showHandles && (["nw", "ne", "se", "sw"] as const).map((hd) => (
             <div key={`rotate-${hd}`} data-rotate-handle={hd} className="pointer-events-auto absolute"
-              style={{ left: hd.includes("w") ? -26 : w, top: hd.includes("n") ? -26 : h,
-                width: 26, height: 26, cursor: ROTATE_CURSOR }} onPointerDown={onStartRotate} />
+              style={{ left: hd.includes("w") ? -20 : w, top: hd.includes("n") ? -20 : h,
+                width: 20, height: 20, cursor: rotateCursor(hd, rotation) }} onPointerDown={(e) => onStartRotate(hd, e)} />
           ))}
           {showHandles && (["n", "e", "s", "w"] as const).map((hd) => {
             const box = edgeHitBox(hd, w, h)

--- a/lib/canvas/handles.ts
+++ b/lib/canvas/handles.ts
@@ -70,7 +70,16 @@ export function visibleHandles(w: number, h: number, text = false): Handle[] {
     ...(text || h >= HANDLE_ROOM ? ["e", "w"] : [])] as Handle[])
 }
 
-export const ROTATE_CURSOR = `url("data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M5 15a8 8 0 1 1 12 4M2 11l3 5 5-3" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 15a8 8 0 1 1 12 4M2 11l3 5 5-3" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>')}") 12 12, crosshair`
+export type CornerHandle = "nw" | "ne" | "se" | "sw"
+
+/** CSS cursors ignore the selection's transform, so mirror and turn the SVG itself. */
+export function rotateCursor(handle: CornerHandle, rotation = 0): string {
+  const flipX = handle.includes("w") ? -1 : 1
+  const flipY = handle.includes("s") ? -1 : 1
+  const path = "M5 15a8 8 0 1 1 12 4M2 11l3 5 5-3"
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="-2 -2 28 28"><g transform="translate(12 12) rotate(${-rotation}) scale(${flipX} ${flipY}) translate(-12 -12)" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="${path}" stroke="white" stroke-width="4"/><path d="${path}" stroke="black" stroke-width="2"/></g></svg>`
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 9 9, crosshair`
+}
 
 /** Native resize arrows follow the on-screen orientation of a rotated edge. */
 export function resizeCursor(handle: Handle, rotation = 0): string {


### PR DESCRIPTION
Rotation cursors now mirror horizontally and vertically for each selection corner and follow the selection angle while hovering and dragging. The cursor is smaller (18px instead of 24px), and each rotation target extends 20px outside its corner instead of 26px.

Validated with `pnpm verify`, `pnpm test:agent`, and `make build-xdc`. Browser checks covered all four cursor orientations, rotated selections, active dragging, undo, and hit targets at 16px versus 24px outside each corner.
