### PR TITLE
Move Fit to zoom controls and remove panel actions

### DIFF
--- a/components/chrome/inspector.tsx
+++ b/components/chrome/inspector.tsx
@@ -42,7 +42,6 @@ import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   ArrowCounterClockwiseIcon,
-  ArrowsOutIcon,
   CropIcon,
   FlipHorizontalIcon,
   FlipVerticalIcon,
@@ -50,7 +49,6 @@ import {
   LinkBreakIcon,
   LockSimpleIcon,
   LockSimpleOpenIcon,
-  SelectionAllIcon,
   TrashIcon,
 } from "@phosphor-icons/react"
 import { kbd } from "@/lib/shortcuts"
@@ -204,7 +202,7 @@ export function Inspector() {
         </div>
       </ScrollArea>
 
-      {empty ? <PageFooter /> : <Footer selected={selected} />}
+      {!empty && <Footer selected={selected} />}
     </Panel>
   )
 }
@@ -309,35 +307,6 @@ function PageSettings() {
         </Row>
       </PanelSection>
     </>
-  )
-}
-
-/** Footer for the page panel — whole-canvas moves, not selection ones. */
-function PageFooter() {
-  const count = useSquig((s) => s.order.length)
-  const st = useSquig.getState
-
-  return (
-    <PanelFooter>
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={count === 0}
-        className="h-ctl flex-1 rounded-chrome-sm text-label"
-        onClick={() => st().zoomToFit()}
-      >
-        <ArrowsOutIcon className="size-3" /> Fit
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={count === 0}
-        className="h-ctl flex-1 rounded-chrome-sm text-label"
-        onClick={() => st().selectAll()}
-      >
-        <SelectionAllIcon className="size-3" /> Select all
-      </Button>
-    </PanelFooter>
   )
 }
 

--- a/components/chrome/top-corner.tsx
+++ b/components/chrome/top-corner.tsx
@@ -14,7 +14,7 @@ import { useRef } from "react"
 import { useSquig } from "@/lib/store"
 import { exportDoc, importDoc } from "@/lib/file-io"
 import { saveImageWithNotice } from "@/lib/export-image"
-import { ArrowUpRightIcon, CaretDownIcon } from "@phosphor-icons/react"
+import { ArrowsOutIcon, ArrowUpRightIcon, CaretDownIcon } from "@phosphor-icons/react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -138,6 +138,7 @@ export function TopCorner() {
 
 export function ZoomPill() {
   const zoom = useSquig((s) => s.viewport.zoom)
+  const empty = useSquig((s) => s.order.length === 0)
   const st = useSquig.getState
 
   const zoomBy = (factor: number) => {
@@ -175,6 +176,16 @@ export function ZoomPill() {
         aria-label="Zoom in"
       >
         +
+      </button>
+      <button
+        type="button"
+        className="flex size-ctl items-center justify-center rounded-chrome-sm text-muted-foreground hover:bg-accent focus-visible:outline-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
+        onClick={() => st().zoomToFit()}
+        disabled={empty}
+        title={`Zoom to fit (${kbd("shift+1")})`}
+        aria-label="Zoom to fit"
+      >
+        <ArrowsOutIcon className="size-3.5" />
       </button>
     </Panel>
   )


### PR DESCRIPTION
Moves Fit from the page inspector to an icon button immediately right of the bottom-left zoom controls, and removes the Select all button from the inspector. Fit keeps its accessible name, shortcut hint, and disabled state on an empty canvas.

Verified placement and Fit behavior in the browser. Passed `pnpm verify`, `pnpm test:agent`, and `make build-xdc`.
