### PR TITLE
Give the keyboard shortcuts panel more breathing room

### DIFF
--- a/components/chrome/shortcuts-sheet.tsx
+++ b/components/chrome/shortcuts-sheet.tsx
@@ -6,6 +6,7 @@
 // ---------------------------------------------------------------------------
 
 import { useEffect, useRef } from "react"
+import { XIcon } from "@phosphor-icons/react"
 import { useSquig } from "@/lib/store"
 import { SHORTCUT_GROUPS, kbd } from "@/lib/shortcuts"
 import { trapFocus } from "@/components/ui/focus-trap"
@@ -58,10 +59,10 @@ function Sheet() {
             ref={closeRef}
             type="button"
             aria-label="Close keyboard shortcuts"
-            className="ml-auto h-ctl rounded-chrome-sm px-2.5 text-label text-muted-foreground hover:bg-accent"
+            className="ml-auto flex h-ctl w-ctl items-center justify-center rounded-chrome-sm text-muted-foreground hover:bg-accent"
             onClick={() => st().setShortcutsOpen(false)}
           >
-            Close
+            <XIcon aria-hidden="true" className="size-4" />
           </button>
         </div>
 

--- a/components/chrome/shortcuts-sheet.tsx
+++ b/components/chrome/shortcuts-sheet.tsx
@@ -32,7 +32,7 @@ function Sheet() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-6"
+      className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-6"
       onPointerDown={() => st().setShortcutsOpen(false)}
     >
       <div className="absolute inset-0 bg-foreground/10 backdrop-blur-[2px]" />
@@ -40,7 +40,7 @@ function Sheet() {
         role="dialog"
         aria-modal="true"
         aria-labelledby="keyboard-shortcuts-title"
-        className="relative flex max-h-full w-full max-w-3xl flex-col overflow-hidden rounded-chrome-lg border border-border/80 bg-background shadow-popup"
+        className="relative flex max-h-full w-full max-w-4xl flex-col overflow-hidden rounded-chrome-lg border border-border/80 bg-background shadow-popup"
         onPointerDown={(e) => e.stopPropagation()}
         onKeyDownCapture={(e) => {
           if (e.key === "Escape") {
@@ -52,7 +52,7 @@ function Sheet() {
           trapFocus(e)
         }}
       >
-        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border/70 px-5 py-4">
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border/70 px-5 py-4 sm:px-8 sm:py-5">
           <h2 id="keyboard-shortcuts-title" className="text-title font-semibold">Keyboard</h2>
           <button
             ref={closeRef}
@@ -69,22 +69,22 @@ function Sheet() {
           role="region"
           tabIndex={0}
           aria-label="Keyboard shortcuts"
-          className="columns-1 gap-x-8 overflow-y-auto overscroll-contain p-5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--sq-ink)]/40 sm:columns-2"
+          className="columns-1 gap-x-12 overflow-y-auto overscroll-contain p-5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--sq-ink)]/40 sm:p-8 md:columns-2"
         >
           {SHORTCUT_GROUPS.map((group) => (
-            <section key={group.title} className="mb-5 break-inside-avoid">
-              <h3 className="mb-2 text-label font-semibold text-foreground">
+            <section key={group.title} className="mb-8 break-inside-avoid last:mb-0">
+              <h3 className="mb-4 border-b border-border/60 pb-3 text-label font-semibold text-foreground">
                 {group.title}
               </h3>
-              <dl className="flex flex-col gap-1.5">
+              <dl className="flex flex-col gap-3">
                 {group.rows.map((row) => (
-                  <div key={row.label} className="flex items-baseline justify-between gap-3">
+                  <div key={row.label} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4">
                     <dt className="min-w-0 text-label text-foreground">{row.label}</dt>
-                    <dd className="flex shrink-0 items-center gap-1">
+                    <dd className="flex flex-wrap items-center justify-end gap-1.5">
                       {row.keys.map((k, i) => (
                         <span key={k} className="flex items-center gap-1">
                           {i > 0 && <span className="text-micro text-muted-foreground">or</span>}
-                          <kbd className="inline-flex h-5 items-center rounded-chrome-xs border bg-muted px-1.5 font-sans text-micro whitespace-nowrap text-foreground">
+                          <kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded-chrome-xs border bg-muted px-2 font-sans text-micro whitespace-nowrap text-foreground">
                             {kbd(k)}
                           </kbd>
                         </span>


### PR DESCRIPTION
The keyboard shortcuts panel felt cramped, especially between rows and around longer labels. This widens the panel, doubles the row gap, adds space and subtle dividers between sections, and gives keycaps more padding. An X icon button closes the dialog while retaining its accessible name and keyboard focus. The layout stays in one column until the medium breakpoint so narrow screens have room for labels.

Validation: `pnpm verify` (lint, typecheck, all test suites, production build) and `make build-xdc` passed. Visually checked desktop and 375px mobile layouts, scrolling to the final shortcut, no horizontal overflow, and Escape dismissal.
